### PR TITLE
Add symlink support on Windows

### DIFF
--- a/common/util/__init__.py
+++ b/common/util/__init__.py
@@ -8,6 +8,7 @@ from . import log
 from . import actions
 from . import debug
 from . import diff_string
+from . import path
 from . import reload
 
 super_key = "SUPER" if sys.platform == "darwin" else "CTRL"

--- a/common/util/path.py
+++ b/common/util/path.py
@@ -18,25 +18,25 @@ try:
 
             Also note that _getfinalpathname in Python 3.3 throws
             `NotImplementedError` on Windows versions prior to Windows Vista,
-            hence we fallback to `os.path.abspath()` on these platforms.
+            hence we fallback to `os.path.realpath()` on these platforms.
 
         Arguments:
             path (string): The path to resolve.
 
         Returns:
             string: The resolved absolute path if exists or path as provided
-                otherwise.
+                otherwise. If `path` is '' or None the current directory is
+                returned.
         """
-        try:
-            if path:
+        if path:
+            try:
                 real_path = _getfinalpathname(path)
                 if real_path[5] == ':':
                     # Remove \\?\ from beginning of resolved path
                     return real_path[4:]
-                return os.path.abspath(path)
-        except FileNotFoundError:
-            pass
-        return path
+            except FileNotFoundError:
+                return path
+        return os.path.realpath(path)
 
 except (AttributeError, ImportError, AssertionError):
     def realpath(path):
@@ -48,7 +48,7 @@ except (AttributeError, ImportError, AssertionError):
         Returns:
             string: The resolved absolute path.
         """
-        return os.path.realpath(path) if path else None
+        return os.path.realpath(path)
 
 
 def is_work_tree(path):

--- a/common/util/path.py
+++ b/common/util/path.py
@@ -1,0 +1,93 @@
+import os.path
+
+try:
+    from nt import _getfinalpathname
+    from sys import getwindowsversion
+    assert getwindowsversion().major >= 6
+
+    def realpath(path):
+        """Resolve symlinks and return real path to file.
+
+        Note:
+            This is a fix for the issue of `os.path.realpath()` not to resolve
+            symlinks on Windows as it is an alias to `os.path.abspath()` only.
+            see: http://bugs.python.org/issue9949
+
+            This fix applies to local paths only as symlinks are not resolved
+            by _getfinalpathname on network drives anyway.
+
+            Also note that _getfinalpathname in Python 3.3 throws
+            `NotImplementedError` on Windows versions prior to Windows Vista,
+            hence we fallback to `os.path.abspath()` on these platforms.
+
+        Arguments:
+            path (string): The path to resolve.
+
+        Returns:
+            string: The resolved absolute path if exists or path as provided
+                otherwise.
+        """
+        try:
+            if path:
+                real_path = _getfinalpathname(path)
+                if real_path[5] == ':':
+                    # Remove \\?\ from beginning of resolved path
+                    return real_path[4:]
+                return os.path.abspath(path)
+        except FileNotFoundError:
+            pass
+        return path
+
+except (AttributeError, ImportError, AssertionError):
+    def realpath(path):
+        """Resolve symlinks and return real path to file.
+
+        Arguments:
+            path (string): The path to resolve.
+
+        Returns:
+            string: The resolved absolute path.
+        """
+        return os.path.realpath(path) if path else None
+
+
+def is_work_tree(path):
+    """Check if 'path' is a valid git working tree.
+
+    A working tree contains a `.git` directory or file.
+
+    Arguments:
+        path (string): The path to check.
+
+    Returns:
+        bool: True if path contains a '.git'
+    """
+    return path and os.path.exists(os.path.join(path, '.git'))
+
+
+def split_work_tree(file_path):
+    """Split the 'file_path' into working tree and relative path.
+
+    The file_path is converted to a absolute real path and split into
+    the working tree part and relative path part.
+
+    Note:
+        This is a local alternative to calling the git command:
+
+            git rev-parse --show-toplevel
+
+    Arguments:
+        file_path (string): Absolute path to a file.
+
+    Returns:
+        A tuple of two the elements (working tree, file path).
+    """
+    if file_path:
+        path, name = os.path.split(file_path)
+        # files within '.git' path are not part of a work tree
+        while path and name and name != '.git':
+            if is_work_tree(path):
+                return (path, os.path.relpath(
+                    file_path, path).replace('\\', '/'))
+            path, name = os.path.split(path)
+    return (None, None)

--- a/common/util/path.py
+++ b/common/util/path.py
@@ -35,7 +35,7 @@ try:
                     # Remove \\?\ from beginning of resolved path
                     return real_path[4:]
             except FileNotFoundError:
-                return path
+                pass
         return os.path.realpath(path)
 
 except (AttributeError, ImportError, AssertionError):

--- a/core/commands/init.py
+++ b/core/commands/init.py
@@ -105,7 +105,7 @@ class GsClone(WindowCommand, GitCommand):
             if not os.path.exists(os.path.join(folder, project, ".git")):
                 return os.path.join(folder, project)
             else:
-                parent = os.path.realpath(os.path.join(folder, ".."))
+                parent = util.path.realpath(os.path.join(folder, ".."))
                 return os.path.join(parent, project)
         return ""
 

--- a/core/commands/mv.py
+++ b/core/commands/mv.py
@@ -3,6 +3,7 @@ import os
 import sublime
 from sublime_plugin import WindowCommand
 
+from ...common import util
 from ..git_command import GitCommand
 from ..ui_mixins.input_panel import show_single_line_input_panel
 
@@ -35,4 +36,4 @@ class GsMvCurrentFileCommand(WindowCommand, GitCommand):
         v = self.window.find_open_file(file_path)
         if v:
             v.retarget(new_path)
-            v.settings().set("git_savvy.file_path", os.path.realpath(new_path))
+            v.settings().set("git_savvy.file_path", util.path.realpath(new_path))

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -408,7 +408,7 @@ class GitCommand(StatusMixin,
                 return repo_path
             if throw_on_stderr:
                 raise ValueError("Unable to determine Git repo path.")
-        except:
+        except Exception:
             if throw_on_stderr:
                 raise
         return None


### PR DESCRIPTION
The Issue
=========

Git for Windows does not enable support for symlinks by default as it
requires administrative privileges and causes a couple of edge cases.

Hence calling `git rev-parse --show-toplevel` is not able to resolve
junctions or symlinks and does not return the real repository path, if
the working directory is accessed via junction/symlink.

Another issue is caused by python itself, as its `os.path.realpath()`
function does not resolve junctions/symlinks on Windows as well.

The Motivation
==============

When working on `sublimehq/Packages` the only way to test changes of
single syntaxes is to create a junction of a Package (e.g. Python) in
ST's `Data/Packages` path. Otherwise syntax tests fail and changes of
the syntax-definition or any other module are not tracked by ST.

There may be other use cases for working with symlinks.

The Fix
=======

This commit enables GitSavvy to support this kind of workflow by
borrowing the `realpath patch` and the algorithm to find the repo's
toplevel path from GitGutter.

The fix consists of two parts:

1. A patched `realpath()` function, which is applied if Windows
   supports the underlying `_getfinalpathname()` function.

   On MacOS/Linux the default `os.path.realpath()` is called as it
   already supports symlinks.

2. A local alternative for the `git rev-parse --show-toplevel` command
   which resolves the repository path without calling any git command.

As a result any git command is now called with the real repository
path even if the working directory is accessed via a junction/symlink on all OS's.