### PR TITLE
Colorize word-diff

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -624,8 +624,7 @@
     },
     {
         "keys": ["w"],
-        "command": "gs_diff_toggle_setting",
-        "args": { "setting": "show_word_diff" },
+        "command": "gs_diff_cycle_word_diff",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.diff_view", "operator": "equal", "operand": true }

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -175,13 +175,8 @@ def augment_color_scheme(view):
 
 WORD_DIFF_PATTERNS = [
     None,
-    # "Default",
-    # "[^ ]+",
-    # r"[a-zA-Z_\-\x80-\xff]+|[\xc0-\xff][\x80-\xbf]+",
     r"[a-zA-Z_\-\x80-\xff]+|[^[:space:]]|[\xc0-\xff][\x80-\xbf]+",
-    # r"[a-zA-Z_\-]+|.",
     ".",
-    # "[a-zA-Z]+|[^ ]",
 ]
 WORD_DIFF_MARKERS_RE = re.compile(r"{\+(.*?)\+}|\[-(.*?)-\]")
 

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -295,7 +295,7 @@ class GsDiffRefreshCommand(TextCommand, GitCommand):
 class GsDiffToggleSetting(TextCommand):
 
     """
-    Toggle view settings: `ignore_whitespace` , or `show_word_diff`.
+    Toggle view settings: `ignore_whitespace`.
     """
 
     def run(self, edit, setting):
@@ -303,12 +303,26 @@ class GsDiffToggleSetting(TextCommand):
 
         setting_str = "git_savvy.diff_view.{}".format(setting)
         current_mode = settings.get(setting_str)
-        if setting == 'show_word_diff':
-            next_mode = (current_mode + 1) % len(WORD_DIFF_PATTERNS)
-        else:
-            next_mode = not current_mode
+        next_mode = not current_mode
         settings.set(setting_str, next_mode)
         self.view.window().status_message("{} is now {}".format(setting, next_mode))
+
+        self.view.run_command("gs_diff_refresh")
+
+
+class GsDiffCycleWordDiff(TextCommand):
+
+    """
+    Cycle through different word diff patterns.
+    """
+
+    def run(self, edit):
+        settings = self.view.settings()
+
+        setting_str = "git_savvy.diff_view.{}".format('show_word_diff')
+        current_mode = settings.get(setting_str)
+        next_mode = (current_mode + 1) % len(WORD_DIFF_PATTERNS)
+        settings.set(setting_str, next_mode)
 
         self.view.run_command("gs_diff_refresh")
 

--- a/popups/diff_view.html
+++ b/popups/diff_view.html
@@ -9,7 +9,7 @@
 <ul>
   <li><code><span class="shortcut-key">o&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>open file at hunk</code></li>
   <li><code><span class="shortcut-key">s&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>ignore white space</code></li>
-  <li><code><span class="shortcut-key">w&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>show word diff</code></li>
+  <li><code><span class="shortcut-key">w&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>show word diff. word, any charachter, standard</code></li>
   <li><code><span class="shortcut-key">.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>go to next hunk</code></li>
   <li><code><span class="shortcut-key">,&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>go to previous hunk</code></li>
 </ul>

--- a/tests/test_diff_view.py
+++ b/tests/test_diff_view.py
@@ -601,6 +601,7 @@ class TestZooming(DeferrableTestCase):
         view = self.window.new_file()
         self.addCleanup(view.close)
         view.set_scratch(True)
+        view.settings().set("git_savvy.diff_view.show_word_diff", False)
 
         view.settings().set('git_savvy.diff_view.context_lines', CONTEXT_LINES)
         cmd = module.GsDiffRefreshCommand(view)


### PR DESCRIPTION
For the diff view, we have a 'word-diff' setting, but the output was annoying.

Let's fix that 😝 

![mFpzzXJ9XW](https://user-images.githubusercontent.com/8558/67322538-72283e80-f511-11e9-905f-615d93090e76.gif)

Note that there is actually no one-size regex for word-diffs. Before, we just used `--word-diff` which uses a "default" which doesn't help in our context because it doesn't split enough. (E.g. it does not even split by word, and actually very often still by line.)  So hitting `w` now is a three state toggle, 'off' and then there come two regexes. The first one looks complicated and tries to match words, the second one (simply a `.`) matches single characters. 

Note that all three modes (t.i. the universal diff included) *can* look confusing. It is really to offer choices. 

Note that word diffs often suppress whitespace changes. The previous default did this, and it is probably okay. (That said I didn't find a regex that shows whitespace in a decent or clever way.)

Last: if we had a better ThemeGenerator abstraction this would we a really small PR.