### PR TITLE
Iterate on stash view

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1949,5 +1949,14 @@
             { "key": "setting.git_savvy.vintageous_friendly", "operator": "equal", "operand": true },
             { "key": "setting.git_savvy.stash_view", "operator": "equal", "operand": true }
         ]
+    },
+    {
+        "keys": ["?"],
+        "command": "gs_interface_toggle_popup_help",
+        "args": { "view_name": "stash_view" },
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.stash_view", "operator": "equal", "operand": true }
+        ]
     }
 ]

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1912,4 +1912,42 @@
             { "key": "setting.git_savvy.stash_view", "operator": "equal", "operand": true }
         ]
     },
+    {
+        "keys": ["."],
+        "command": "gs_diff_navigate",
+        "args": { "forward": true },
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.stash_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": [","],
+        "command": "gs_diff_navigate",
+        "args": { "forward": false },
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.stash_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["j"],
+        "command": "gs_diff_navigate",
+        "args": { "forward": true },
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.vintageous_friendly", "operator": "equal", "operand": true },
+            { "key": "setting.git_savvy.stash_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["k"],
+        "command": "gs_diff_navigate",
+        "args": { "forward": false },
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.vintageous_friendly", "operator": "equal", "operand": true },
+            { "key": "setting.git_savvy.stash_view", "operator": "equal", "operand": true }
+        ]
+    }
 ]

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1878,5 +1878,38 @@
         "keys": ["ctrl+enter"],
         "command": "noop",
         "context": [{ "key": "setting.git_savvy.single_line_input_panel" }]
-    }
+    },
+
+    /////////////////
+    // STASH VIEW //
+    ////////////////
+
+    {
+        "keys": ["enter"],
+        "command": "gs_stash",
+        "context": [
+            { "key": "setting.git_savvy.stash_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["a"],
+        "command": "gs_stash_apply",
+        "context": [
+            { "key": "setting.git_savvy.stash_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["p"],
+        "command": "gs_stash_pop",
+        "context": [
+            { "key": "setting.git_savvy.stash_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["D"],
+        "command": "gs_stash_drop",
+        "context": [
+            { "key": "setting.git_savvy.stash_view", "operator": "equal", "operand": true }
+        ]
+    },
 ]

--- a/common/util/view.py
+++ b/common/util/view.py
@@ -175,3 +175,11 @@ def disable_other_plugins(view):
     # https://github.com/guillermooo/Vintageous/wiki/Disabling
     if GitSavvySettings().get("vintageous_friendly", False) is False:
         view.settings().set("__vi_external_disable", False)
+
+
+def flash(view, message):
+    # type: (sublime.View, str) -> None
+    """ Flash status message on view's window. """
+    window = view.window()
+    if window:
+        window.status_message(message)

--- a/core/commands/stash.py
+++ b/core/commands/stash.py
@@ -64,7 +64,11 @@ class GsStashPopCommand(SelectStashIdMixin, GitCommand):
         # type: (StashId) -> None
         self.pop_stash(stash_id)
         util.view.flash(self.view, "Successfully popped stash ({}).".format(stash_id))
-        util.view.refresh_gitsavvy(self.view)
+
+        if self.view.settings().get("git_savvy.stash_view.stash_id", None) == stash_id:
+            self.view.close()
+        else:
+            util.view.refresh_gitsavvy(self.view)
 
 
 DROP_UNDO_MESSAGE = """\
@@ -89,7 +93,11 @@ class GsStashDropCommand(SelectStashIdMixin, GitCommand):
             commit = match.group(1)
             print(DROP_UNDO_MESSAGE.format(stash_id, commit))
         util.view.flash(self.view, "Successfully dropped stash ({}).".format(stash_id))
-        util.view.refresh_gitsavvy(self.view)
+
+        if self.view.settings().get("git_savvy.stash_view.stash_id", None) == stash_id:
+            self.view.close()
+        else:
+            util.view.refresh_gitsavvy(self.view)
 
 
 class GsStashCommand(PanelCommandMixin, WindowCommand, GitCommand):

--- a/core/commands/stash.py
+++ b/core/commands/stash.py
@@ -48,6 +48,7 @@ class GsStashApplyCommand(SelectStashIdMixin, GitCommand):
     def do(self, stash_id):
         # type: (StashId) -> None
         self.apply_stash(stash_id)
+        util.view.flash(self.view, "Successfully applied stash ({}).".format(stash_id))
         util.view.refresh_gitsavvy(self.view)
 
 
@@ -60,6 +61,7 @@ class GsStashPopCommand(SelectStashIdMixin, GitCommand):
     def do(self, stash_id):
         # type: (StashId) -> None
         self.pop_stash(stash_id)
+        util.view.flash(self.view, "Successfully popped stash ({}).".format(stash_id))
         util.view.refresh_gitsavvy(self.view)
 
 
@@ -73,6 +75,7 @@ class GsStashDropCommand(SelectStashIdMixin, GitCommand):
     def do(self, stash_id):
         # type: (StashId) -> None
         self.drop_stash(stash_id)
+        util.view.flash(self.view, "Successfully dropped stash ({}).".format(stash_id))
         util.view.refresh_gitsavvy(self.view)
 
 

--- a/core/commands/stash.py
+++ b/core/commands/stash.py
@@ -1,4 +1,4 @@
-from sublime_plugin import WindowCommand
+from sublime_plugin import TextCommand, WindowCommand
 
 from ..git_command import GitCommand
 from ..ui_mixins.quick_panel import PanelCommandMixin
@@ -10,22 +10,22 @@ from ...common import util
 MYPY = False
 if MYPY:
     from typing import Optional, Union
+    import sublime
+
     StashId = Union[int, str]
 
 
-class SelectStashIdMixin(WindowCommand):
-    def run(self, stash_id=None):
-        # type: (Optional[StashId]) -> None
+class SelectStashIdMixin(TextCommand):
+    def run(self, edit, stash_id=None):
+        # type: (sublime.Edit, Optional[StashId]) -> None
         if stash_id is not None:
             self.do(stash_id)
             return
 
-        view = self.window.active_view()
-        if view:
-            stash_id = view.settings().get("git_savvy.stash_view.stash_id", None)
-            if stash_id is not None:
-                self.do(stash_id)
-                return
+        stash_id = self.view.settings().get("git_savvy.stash_view.stash_id", None)
+        if stash_id is not None:
+            self.do(stash_id)
+            return
 
         show_stash_panel(self.on_done)
 
@@ -48,7 +48,7 @@ class GsStashApplyCommand(SelectStashIdMixin, GitCommand):
     def do(self, stash_id):
         # type: (StashId) -> None
         self.apply_stash(stash_id)
-        util.view.refresh_gitsavvy(self.window.active_view())
+        util.view.refresh_gitsavvy(self.view)
 
 
 class GsStashPopCommand(SelectStashIdMixin, GitCommand):
@@ -60,7 +60,7 @@ class GsStashPopCommand(SelectStashIdMixin, GitCommand):
     def do(self, stash_id):
         # type: (StashId) -> None
         self.pop_stash(stash_id)
-        util.view.refresh_gitsavvy(self.window.active_view())
+        util.view.refresh_gitsavvy(self.view)
 
 
 class GsStashDropCommand(SelectStashIdMixin, GitCommand):
@@ -73,7 +73,7 @@ class GsStashDropCommand(SelectStashIdMixin, GitCommand):
     def do(self, stash_id):
         # type: (StashId) -> None
         self.drop_stash(stash_id)
-        util.view.refresh_gitsavvy(self.window.active_view())
+        util.view.refresh_gitsavvy(self.view)
 
 
 class GsStashCommand(PanelCommandMixin, WindowCommand, GitCommand):

--- a/core/git_mixins/stash.py
+++ b/core/git_mixins/stash.py
@@ -45,4 +45,4 @@ class StashMixin():
         """
         Drop stash with provided id.
         """
-        self.git("stash", "drop", "stash@{{{}}}".format(id))
+        return self.git("stash", "drop", "stash@{{{}}}".format(id))

--- a/popups/stash_view.html
+++ b/popups/stash_view.html
@@ -1,0 +1,31 @@
+<html>
+<style>
+{css}
+</style>
+<body>
+<div class="header-wrapper"><h2>Keyboard Shortcuts</h2></div>
+
+<h3>Actions</h3>
+<ul>
+  <li><code><span class="shortcut-key">enter&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>Open action panel</code></li>
+  <li><code><span class="shortcut-key">a&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>apply stash</code></li>
+  <li><code><span class="shortcut-key">p&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>pop stash </code></li>
+  <li><code><span class="shortcut-key">D&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>drop stash </code></li>
+  <li><code><span class="shortcut-key">.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>go to next hunk</code></li>
+  <li><code><span class="shortcut-key">,&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>go to previous hunk</code></li>
+</ul>
+
+
+<h3>Vintageous friendly mode</h3>
+<ul>
+  <li><code><span class="shortcut-key">j&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>go to next hunk</code></li>
+  <li><code><span class="shortcut-key">k&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>go to previous hunk</code></li>
+</ul>
+
+<h3>Settings</h3>
+<ul>
+  <li><code><span class="shortcut-key">{super_key}-,&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>Change Settings for current syntax</code></li>
+</ul>
+
+</body>
+</html>


### PR DESCRIPTION
- Make `apply`, `pop`, and `drop` commands more DRY
- Save `stash_id` on the view

  BREAKING: If a user now issues a command e.g. `gs_stash_apply` via
  the Palette, it will select the current open/visible stash (if she
  is looking at such a stash view.)

- Add typical shortcuts for the stash view.

  `<enter>`: will open an action panel to 'apply', 'pop', or 'drop' the
           current stash
  `<a>`:     apply current stash
  `<p>`:     pop current stash
  `<D>`:     drop current stash


TODO:

- [x] If you're looking on a stash, 'pop' and 'drop' should close the window.
- [x] All commands should flash the status bar with some success info.
- [x] Add help.html thingy? Don't remember how this works right now.
~~- [ ] Really difficult to tell if or why we need three commands here, instead of one 
  parametrized?~~
- [x] Helpful message for undo after 'drop'

MOTIVATION:

Mostly psycho-safety. Stashes are part of my daily workflow, and often have lots of them. 'dropping' and 'popping' is destructive (well the reflog but..). Before I 'drop' a stash I usually `ts` and look at it long enough if I really want to discard this work. Then it feels safer to just call 'drop this' from the view, instead of going e.g. to the status dashboard and then to check trice if the cursor is *really* at the correct line.

