### PR TITLE
assume the default value of confirm_force_push is True

### DIFF
--- a/core/commands/push.py
+++ b/core/commands/push.py
@@ -23,7 +23,7 @@ class PushBase(GitCommand):
         """
         Perform `git push remote branch`.
         """
-        if self.savvy_settings.get("confirm_force_push"):
+        if self.savvy_settings.get("confirm_force_push", True):
             if force:
                 if not sublime.ok_cancel_dialog(CONFIRM_FORCE_PUSH.format("--force")):
                     return


### PR DESCRIPTION
I don't know how it happened but it actually did happen that the value of `confirm_force_push` becomes `None` after I disable and re-enable GitSavvy.
Anyway, it is a bit safer to assume the default value of True here.