### PR TITLE
Reload plugin after install or upgrade

### DIFF
--- a/common/util/reload.py
+++ b/common/util/reload.py
@@ -23,8 +23,10 @@ except ImportError:
         return False
 
 
-def reload_plugin():
-    threading.Thread(target=functools.partial(reload_package, 'GitSavvy')).start()
+def reload_plugin(verbose=True, then=None):
+    threading.Thread(
+        target=functools.partial(reload_package, 'GitSavvy', verbose=verbose, then=then)
+    ).start()
 
 
 def dprint(*args, fill=None, fill_width=60, **kwargs):
@@ -77,7 +79,7 @@ def package_plugins(pkg_name):
     ]
 
 
-def reload_package(pkg_name, dummy=True, verbose=True):
+def reload_package(pkg_name, dummy=True, verbose=True, then=None):
     if pkg_name not in sys.modules:
         dprint("error:", pkg_name, "is not loaded.")
         return
@@ -124,6 +126,9 @@ def reload_package(pkg_name, dummy=True, verbose=True):
 
     if verbose:
         dprint("end", fill='-')
+
+    if then:
+        then()
 
 
 def resolve_dependencies(root_name):

--- a/git_savvy.py
+++ b/git_savvy.py
@@ -1,41 +1,65 @@
-import sys
-
 import sublime
 
-if sys.version_info[0] == 2:
-    raise ImportWarning("GitSavvy does not support Sublime Text 2.")
-else:
-    def plugin_loaded():
-        from .common import util
-        sublime.set_timeout_async(util.file.determine_syntax_files)
+from .common.commands import *
+from .common.ui import *
+from .common.global_events import *
+from .core.commands import *
+from .core.interfaces import *
+from .github.commands import *
+from .gitlab.commands import *
 
-        # Ensure all interfaces are ready.
-        sublime.set_timeout_async(
-            lambda: util.view.refresh_gitsavvy(sublime.active_window().active_view()))
 
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
-        if savvy_settings.get("load_additional_codecs"):
-            sublime.set_timeout_async(reload_codecs, 0)
+def plugin_loaded():
 
-    def reload_codecs():
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
-        fallback_encoding = savvy_settings.get("fallback_encoding")
-        try:
-            import _multibytecodec, imp, codecs, encodings
-            imp.reload(encodings)
-            imp.reload(codecs)
-            codecs.getencoder(fallback_encoding)
-        except (ImportError, LookupError):
-            sublime.error_message(
-                "You have enabled `load_additional_codecs` mode, but the "
-                "`fallback_encoding` codec cannot load.  This probably means "
-                "you don't have the Codecs33 package installed, or you've "
-                "entered an unsupported encoding.")
+    try:
+        import package_control
+    except ImportError:
+        pass
+    else:
+        if (
+            package_control.events.install('GitSavvy') or
+            package_control.events.post_upgrade('GitSavvy')
+        ):
+            # The "event" (flag) is set for 5 seconds. To not get into a
+            # reloader excess we wait for that time, so that the next time
+            # this exact `plugin_loaded` handler runs, the flag is already
+            # unset.
+            sublime.set_timeout_async(reload_plugin, 5000)
+            return
 
-    from .common.commands import *
-    from .common.ui import *
-    from .common.global_events import *
-    from .core.commands import *
-    from .core.interfaces import *
-    from .github.commands import *
-    from .gitlab.commands import *
+    prepare_gitsavvy()
+
+
+def reload_plugin():
+    from .common import util
+    print("GitSavvy: Reloading plugin after install.")
+    util.reload.reload_plugin(verbose=False, then=prepare_gitsavvy)
+
+
+def prepare_gitsavvy():
+    from .common import util
+    sublime.set_timeout_async(util.file.determine_syntax_files)
+
+    # Ensure all interfaces are ready.
+    sublime.set_timeout_async(
+        lambda: util.view.refresh_gitsavvy(sublime.active_window().active_view()))
+
+    savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
+    if savvy_settings.get("load_additional_codecs"):
+        sublime.set_timeout_async(reload_codecs)
+
+
+def reload_codecs():
+    savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
+    fallback_encoding = savvy_settings.get("fallback_encoding")
+    try:
+        import imp, codecs, encodings
+        imp.reload(encodings)
+        imp.reload(codecs)
+        codecs.getencoder(fallback_encoding)
+    except (ImportError, LookupError):
+        sublime.error_message(
+            "You have enabled `load_additional_codecs` mode, but the "
+            "`fallback_encoding` codec cannot load.  This probably means "
+            "you don't have the Codecs33 package installed, or you've "
+            "entered an unsupported encoding.")


### PR DESCRIPTION
Fixes #1190

- Drops ST2 not supported message.
- Add `then` callback to `reload_package` which gets called when
  reloading has finished.
- To avoid a reload loop, we watch for install/upgrade flags set by
  PackageControl. PackageControl takes 5s to finalize an upgrade.
  We need to wait for the same time, to reload after PackageControl
  is actually done.


