### PR TITLE
[ST 4] set a default value for syntax

### DIFF
--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -194,7 +194,7 @@ class GsPedanticEnforceEventListener(EventListener, SettingsMixin):
     """
 
     def on_selection_modified(self, view):
-        if 'make_commit' not in view.settings().get('syntax'):
+        if 'make_commit' not in view.settings().get('syntax', ''):
             return
 
         if not self.savvy_settings.get('pedantic_commit'):


### PR DESCRIPTION
Also in ST 4. For a brief moment before the syntax is applied, `view.settings().get('syntax')` could be `None` and an exception is thrown (Nonetype is not iterable).