### PR TITLE
[ST 4] check if view is None in settings

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -9,17 +9,22 @@ class GitSavvySettings:
     def get(self, key, default=None):
         window = sublime.active_window()
         view = window.active_view()
-        project_savvy_settings = view.settings().get("GitSavvy", {}) or {}
 
-        if key in project_savvy_settings:
-            return project_savvy_settings[key]
-
-        # fall back to old style project setting
-        project_data = window.project_data()
-        if project_data and "GitSavvy" in project_data:
-            project_savvy_settings = project_data["GitSavvy"]
+        if view:
+            project_savvy_settings = view.settings().get("GitSavvy", {}) or {}
             if key in project_savvy_settings:
-                return project_savvy_settings.get(key)
+                return project_savvy_settings[key]
+
+        project_data = window.project_data() or {}
+        # get the settings directly from project_data
+        project_savvy_settings = project_data.get("settings", {}).get("GitSavvy", {})
+        if key in project_savvy_settings:
+            return project_savvy_settings.get(key)
+
+        # fallback location of settings
+        project_savvy_settings = project_data.get("GitSavvy", {})
+        if key in project_savvy_settings:
+            return project_savvy_settings.get(key)
 
         return self.global_settings.get(key, default)
 


### PR DESCRIPTION
It seems that `sublime.active_window()` could be None in ST 4.
If that is the cause, we read settings directly from window.project_data()