### PR TITLE
Fix/Enhancement: Improve newline handling in IgnoreMixin

### DIFF
--- a/core/git_mixins/ignore.py
+++ b/core/git_mixins/ignore.py
@@ -23,5 +23,15 @@ class IgnoreMixin():
                 linesep = os.linesep
 
         gitignore = os.path.join(self.repo_path, ".gitignore")
-        with util.file.safe_open(gitignore, "at", encoding="utf-8", newline=linesep) as ignore_file:
-            ignore_file.write("\n" + path_or_pattern + "\n")
+        with util.file.safe_open(gitignore, "a+t", encoding="utf-8", newline=linesep) as ignore_file:
+            self._ensure_on_new_line(ignore_file)
+            ignore_file.write(path_or_pattern + "\n")
+
+    @staticmethod
+    def _ensure_on_new_line(ignore_file):
+        ignore_file_size = ignore_file.tell()
+        if ignore_file_size:
+            ignore_file.seek(ignore_file_size - 1)
+            ignore_file_end = ignore_file.read(1)
+            if ignore_file_end != "\n":
+                ignore_file.write("\n")

--- a/core/git_mixins/ignore.py
+++ b/core/git_mixins/ignore.py
@@ -23,15 +23,12 @@ class IgnoreMixin():
                 linesep = os.linesep
 
         gitignore = os.path.join(self.repo_path, ".gitignore")
-        with util.file.safe_open(gitignore, "a+t", encoding="utf-8", newline=linesep) as ignore_file:
-            self._ensure_on_new_line(ignore_file)
-            ignore_file.write(path_or_pattern + "\n")
+        if os.path.exists(gitignore):
+            with util.file.safe_open(gitignore, "r", encoding="utf-8") as fp:
+                ignore_lines = fp.read().splitlines()
+        else:
+            ignore_lines = []
 
-    @staticmethod
-    def _ensure_on_new_line(ignore_file):
-        ignore_file_size = ignore_file.tell()
-        if ignore_file_size:
-            ignore_file.seek(ignore_file_size - 1)
-            ignore_file_end = ignore_file.read(1)
-            if ignore_file_end != "\n":
-                ignore_file.write("\n")
+        ignore_lines += [path_or_pattern, ""]
+        with util.file.safe_open(gitignore, "w", encoding="utf-8", newline=linesep) as fp:
+            fp.write("\n".join(ignore_lines))

--- a/core/git_mixins/ignore.py
+++ b/core/git_mixins/ignore.py
@@ -23,5 +23,5 @@ class IgnoreMixin():
                 linesep = os.linesep
 
         gitignore = os.path.join(self.repo_path, ".gitignore")
-        with util.file.safe_open(gitignore, "at", encoding="utf-8") as ignore_file:
-            ignore_file.write(linesep + path_or_pattern + linesep)
+        with util.file.safe_open(gitignore, "at", encoding="utf-8", newline=linesep) as ignore_file:
+            ignore_file.write("\n" + path_or_pattern + "\n")


### PR DESCRIPTION
Python automatically converts newlines ('\n') for files opened in text
mode (e.g. 'at') to the OS's preferred line endings ('\n' on Linux and
'\r\n' on Windows). The manual line-ending handling in the IgnoreMixin
class therefore leads to extra '\r' bytes on Windows. This can be fixed
using the 'newline' argument of open().

Further, the IgnoreMixin currently always appends a newline before and after
the new entry. This leads to every second line being blank. The second
commit fixes the issue by appending the first newline only if the file does not
already end with a newline.