### PR TITLE
Defensive stash view actions

### DIFF
--- a/core/commands/intra_line_colorizer.py
+++ b/core/commands/intra_line_colorizer.py
@@ -7,14 +7,15 @@ import time
 import sublime
 from ..fns import accumulate, filter_, flatten
 from ..parse_diff import Hunk, SplittedDiff, Region
-from ..utils import cooperative_thread_hopper, eat_but_log_errors, line_indentation, AWAIT_WORKER
+from ..utils import eat_but_log_errors, line_indentation
+from ..runtime import cooperative_thread_hopper, AWAIT_WORKER
 
 
 MYPY = False
 if MYPY:
     from typing import Callable, List, Tuple, Sequence
     from ..parse_diff import HunkLine
-    from ..utils import HopperR
+    from ..runtime import HopperR
 
     Chunk = List[HunkLine]
 

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -1,6 +1,5 @@
 from functools import lru_cache, partial
 import re
-import threading
 
 import sublime
 from sublime_plugin import WindowCommand, TextCommand, EventListener
@@ -10,6 +9,7 @@ from .log import GsLogActionCommand, GsLogCommand
 from .navigate import GsNavigate
 from ..git_command import GitCommand
 from ..settings import GitSavvySettings
+from ..runtime import run_on_new_thread
 from ..ui_mixins.quick_panel import show_branch_panel
 from ...common import util
 from ...common.theme_generator import XMLThemeGenerator, JSONThemeGenerator
@@ -50,7 +50,7 @@ class LogGraphMixin(object):
         view.set_syntax_file("Packages/GitSavvy/syntax/graph.sublime-syntax")
         view.run_command("gs_handle_vintageous")
         view.run_command("gs_handle_arrow_keys")
-        threading.Thread(target=partial(augment_color_scheme, view)).run()
+        run_on_new_thread(augment_color_scheme, view)
 
         settings = view.settings()
         settings.set("git_savvy.repo_path", repo_path)

--- a/core/commands/stash.py
+++ b/core/commands/stash.py
@@ -3,6 +3,7 @@ import re
 import sublime
 from sublime_plugin import EventListener, TextCommand, WindowCommand
 
+from ..utils import hprint
 from ..runtime import enqueue_on_worker
 from ..git_command import GitCommand
 from ..ui_mixins.quick_panel import PanelCommandMixin
@@ -68,7 +69,7 @@ class SelectStashIdMixin(TextCommand):
                     self.view,
                     "Nothing done, the stash you're looking at is outdated. "
                 )
-                print(
+                hprint(
                     "GitSavvy: The stash you're looking at is outdated. "
                     "Maybe its number ({}) changed because you modified the "
                     "stash list since opening this view. ".format(stash_id)

--- a/core/runtime.py
+++ b/core/runtime.py
@@ -67,9 +67,9 @@ def cooperative_thread_hopper(fn):
             raise ex from None
 
         if rv == AWAIT_UI_THREAD:
-            sublime.set_timeout(lambda: tick(gen))
+            enqueue_on_ui(tick, gen)
         elif rv == AWAIT_WORKER:
-            sublime.set_timeout_async(lambda: tick(gen))
+            enqueue_on_worker(tick, gen)
 
     def decorated(*args, **kwargs):
         gen = fn(*args, **kwargs)

--- a/core/runtime.py
+++ b/core/runtime.py
@@ -1,5 +1,8 @@
+from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 import inspect
+import threading
+
 import sublime
 
 
@@ -7,6 +10,8 @@ MYPY = False
 if MYPY:
     from typing import Any, Callable, Iterator, Literal
 
+
+savvy_executor = ThreadPoolExecutor(max_workers=1)
 
 # `enqueue_on_*` functions emphasize that we run two queues and
 # just put tasks on it.  In contrast to `set_timeout_*` which
@@ -19,6 +24,7 @@ if MYPY:
 # the functions to change the behavior without changing the
 # arguments.
 
+
 def enqueue_on_ui(fn, *args, **kwargs):
     # type: (Callable, Any, Any) -> None
     sublime.set_timeout(partial(fn, *args, **kwargs))
@@ -27,6 +33,16 @@ def enqueue_on_ui(fn, *args, **kwargs):
 def enqueue_on_worker(fn, *args, **kwargs):
     # type: (Callable, Any, Any) -> None
     sublime.set_timeout_async(partial(fn, *args, **kwargs))
+
+
+def enqueue_on_savvy(fn, *args, **kwargs):
+    # type: (Callable, Any, Any) -> None
+    savvy_executor.submit(fn, *args, **kwargs)
+
+
+def run_on_new_thread(fn, *args, **kwargs):
+    # type: (Callable, Any, Any) -> None
+    threading.Thread(target=fn, args=args, kwargs=kwargs).start()
 
 
 AWAIT_UI_THREAD = 'AWAIT_UI_THREAD'  # type: Literal["AWAIT_UI_THREAD"]

--- a/core/runtime.py
+++ b/core/runtime.py
@@ -1,0 +1,30 @@
+from functools import partial
+import sublime
+
+
+MYPY = False
+if MYPY:
+    from typing import Any, Callable, Iterator, Literal
+
+
+# `enqueue_on_*` functions emphasize that we run two queues and
+# just put tasks on it.  In contrast to `set_timeout_*` which
+# emphasizes that we delay or defer something. (In particular
+# `set_timeout_async` is somewhat a misnomer because both calls
+# return immediately.)
+# Both functions have the standard python callable interface
+# `(f, *a, *kw)`, which is used in e.g. `partial` or
+# `executor.submit`. This has the advantage that we can swap
+# the functions to change the behavior without changing the
+# arguments.
+
+def enqueue_on_ui(fn, *args, **kwargs):
+    # type: (Callable, Any, Any) -> None
+    sublime.set_timeout(partial(fn, *args, **kwargs))
+
+
+def enqueue_on_worker(fn, *args, **kwargs):
+    # type: (Callable, Any, Any) -> None
+    sublime.set_timeout_async(partial(fn, *args, **kwargs))
+
+

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,15 +1,12 @@
 from contextlib import contextmanager
-import inspect
 import time
 import threading
 import traceback
 
-import sublime
-
 
 MYPY = False
 if MYPY:
-    from typing import Callable, Iterator, Literal
+    ...
 
 
 @contextmanager
@@ -28,56 +25,6 @@ def eat_but_log_errors(exception=Exception):
         yield
     except exception:
         traceback.print_exc()
-
-
-AWAIT_UI_THREAD = 'AWAIT_UI_THREAD'  # type: Literal["AWAIT_UI_THREAD"]
-AWAIT_WORKER = 'AWAIT_WORKER'  # type: Literal["AWAIT_WORKER"]
-if MYPY:
-    HopperR = Iterator[Literal["AWAIT_UI_THREAD", "AWAIT_WORKER"]]
-    HopperFn = Callable[..., HopperR]
-
-
-def cooperative_thread_hopper(fn):
-    # type: (HopperFn) -> Callable[..., None]
-    """Mark given function as cooperative.
-
-    `fn` must return `HopperR` t.i. it must yield AWAIT_UI_THREAD
-    or AWAIT_UI_THREAD at some point.
-
-    When calling `fn` it will run on the same thread as the caller
-    until the function yields.  It then schedules a task on the
-    desired thread which will continue execution the function.
-
-    It is thus cooperative in the sense that all other tasks
-    already queued will get a chance to run before we continue.
-    It is "async" in the sense that the function does not run
-    from start to end in a blocking manner but can be suspended.
-
-    However, it is sync till the first yield (but you could of
-    course yield on the first line!), only then execution returns
-    to the call site.
-    Be aware that, if the call site and the thread you request are
-    _not_ the same, you can get concurrent execution afterwards!
-    """
-    def tick(gen, send_value=None):
-        try:
-            rv = gen.send(send_value)
-        except StopIteration:
-            return
-        except Exception as ex:
-            raise ex from None
-
-        if rv == AWAIT_UI_THREAD:
-            sublime.set_timeout(lambda: tick(gen))
-        elif rv == AWAIT_WORKER:
-            sublime.set_timeout_async(lambda: tick(gen))
-
-    def decorated(*args, **kwargs):
-        gen = fn(*args, **kwargs)
-        if inspect.isgenerator(gen):
-            tick(gen)
-
-    return decorated
 
 
 def line_indentation(line):

--- a/core/utils.py
+++ b/core/utils.py
@@ -27,6 +27,16 @@ def eat_but_log_errors(exception=Exception):
         traceback.print_exc()
 
 
+def hprint(msg):
+    # type: (str) -> None
+    """Print help message for e.g. a failed action"""
+    # Note this does a plain and boring print. We use it to
+    # mark some usages of print throughout the code-base.
+    # We later might find better ways to show these help
+    # messages to the user.
+    print(msg)
+
+
 def line_indentation(line):
     # type: (str) -> int
     return len(line) - len(line.lstrip())


### PR DESCRIPTION
Fixes #1233

Stash views can be long-lived. Since we identify stashs using a list
index (number), this number can get outdated rather quickly, e.g.
the user created a new stash, or dropped any of the previous ones.

We thus revalidate before we actually apply an action.

Some minor drive-by refactorings, also fixes one wrong `Thread` usage in `log_graph`. 