### PR TITLE
Fix parsing of `show-branch` output

### DIFF
--- a/core/git_mixins/rebase.py
+++ b/core/git_mixins/rebase.py
@@ -3,28 +3,44 @@ import re
 from ..exceptions import GitSavvyError
 from ...common import util
 
-NEAREST_NODE_PATTERN = re.compile(r'.*\*.*\[(.*?)(?:[\^\~]+[\d]*)+\]')  # https://regexr.com/3kuv3
+
+MYPY = False
+if MYPY:
+    from typing import List
+
+
+EXTRACT_BRANCH_NAME = re.compile(r'^.*\[(.*?)(?:[\^\~]+[\d]*)*\]')
 
 
 class NearestBranchMixin(object):
     """ Provide reusable methods for detecting the nearest of a branch relatives """
 
     def branch_relatives(self, branch):
-        """ Geta  list of all relatives from ``git show-branch`` results """
-        branch_tree = self.git("show-branch", "--no-color").splitlines()
-        util.debug.add_to_log('nearest_branch: found {} show-branch results'.format(
-                              len(branch_tree)))
-        relatives = []
-        for rel in branch_tree:
-            match = re.search(NEAREST_NODE_PATTERN, rel)
-            if not match:
-                continue
-            branch_name = match.group(1)
-            if branch_name != branch and branch_name not in relatives:
-                relatives.append(branch_name)
+        # type: (str) -> List[str]
+        """ Get list of all relatives from ``git show-branch`` results """
+        output = self.git("show-branch", "--no-color")
+
+        prelude, body = re.split(r'^-+$', output, flags=re.M)
+
+        match = re.search(r'^(\s+)\*', prelude, re.M)
+        if not match:
+            print("branch {} not found in header information".format(branch))
+            return []
+
+        branch_column = len(match.group(1))
+        relatives = []  # type: List[str]
+        for line in filter(None, body.splitlines()):  # type: str
+            if line[branch_column] != ' ':
+                match = EXTRACT_BRANCH_NAME.match(line)
+                if match:
+                    branch_name = match.group(1)
+                    if branch_name != branch and branch_name not in relatives:
+                        relatives.append(branch_name)
+
         return relatives
 
     def nearest_branch(self, branch, default="master"):
+        # type: (str, str) -> str
         """
         Find the nearest commit in current branch history that exists
         on a different branch and return that branch name.


### PR DESCRIPTION
Fixes #1224

We proper parse the `show-branch` output, t.i. we first lookup the
column our branch got in the prelude and then traverse the body content
always just looking if that exact column has an indicator.

Note that this doesn't make `nearest_branch` super-smart. It just fixes
the parsing. I.e. it might be the better option to present a list of
good candidates to the user instead of popping the first one. 


