### PR TITLE
Permissive reloader

### DIFF
--- a/common/util/reload.py
+++ b/common/util/reload.py
@@ -112,7 +112,7 @@ def reload_package(pkg_name, dummy=True, verbose=True, then=None):
 
     # Reload packages
     try:
-        with intercepting_imports(all_modules, verbose), importing_fromlist_aggresively(all_modules):
+        with intercepting_imports(all_modules, verbose), importing_fromlist_aggressively(all_modules):
             for pkg_name in packages:
                 for plugin in package_plugins(pkg_name):
                     sublime_plugin.reload_plugin(plugin)
@@ -245,7 +245,7 @@ def intercepting_imports(modules, verbose):
 
 
 @contextmanager
-def importing_fromlist_aggresively(modules):
+def importing_fromlist_aggressively(modules):
     orig___import__ = builtins.__import__
 
     @functools.wraps(orig___import__)

--- a/common/util/reload.py
+++ b/common/util/reload.py
@@ -119,6 +119,13 @@ def reload_package(pkg_name, dummy=True, verbose=True, then=None):
     except Exception:
         dprint("reload failed.", fill='-')
         reload_missing(all_modules, verbose)
+        # Try reloading again to get the commands back. Here esp. the
+        # reload command itself.
+        for pkg_name in packages:
+            for plugin in package_plugins(pkg_name):
+                sublime_plugin.reload_plugin(plugin)
+        print('--- Reloading GitSavvy failed. Restarting Sublime is highly recommended. ---')
+        sublime.active_window().status_message('GitSavvy reloading 💣ed. 😒.')
         raise
 
     if dummy:

--- a/common/util/reload.py
+++ b/common/util/reload.py
@@ -7,6 +7,7 @@ import builtins
 import functools
 import importlib
 import sys
+import traceback
 from inspect import ismodule
 from contextlib import contextmanager
 from .debug import StackMeter
@@ -126,9 +127,11 @@ def reload_package(pkg_name, dummy=True, verbose=True, then=None):
         # reload command itself.
         for plugin in plugins:
             sublime_plugin.reload_plugin(plugin)
+
+        traceback.print_exc()
         print('--- Reloading GitSavvy failed. Restarting Sublime is highly recommended. ---')
         sublime.active_window().status_message('GitSavvy reloading 💣ed. 😒.')
-        raise
+        return
 
     if dummy:
         load_dummy(verbose)


### PR DESCRIPTION
Fixes #1205

Before we reload we `unload_module` every plugin. In case of a hard
error while reloading (e.g. often a syntax error), we actually try
to bring the old modules back via `reload_missing` but did not register
the actual plugins. We thus have all the code somehow (inconsistent)
loaded but none of the commands for the plugins which actually raised.
(In GitSavvy we only have *one* plugin, so actually no commands are
registered after that.)

With this patch we call `reload_plugin` again after failures. The goal
is to keep at least the reload command itself working.

This is good for developers but could be bad for users. However, we
really don't expect reload failures for end-users.