### PR TITLE
Merge pull request #1247 from timbrel/fixup-branch-extraction

### DIFF
--- a/core/git_mixins/rebase.py
+++ b/core/git_mixins/rebase.py
@@ -9,7 +9,7 @@ if MYPY:
     from typing import List
 
 
-EXTRACT_BRANCH_NAME = re.compile(r'^.*\[(.*?)(?:[\^\~]+[\d]*)*\]')
+EXTRACT_BRANCH_NAME = re.compile(r'^[^[]+\[(.*?)(?:[\^\~]+[\d]*)*\]')
 
 
 class NearestBranchMixin(object):


### PR DESCRIPTION
The previous `.*\[` in the regex is greedy that means it matches `[something]` from subject lines. We switch to `[^[]+\[` (which reads anything not being an `[`) to match the first `[` on a line. 