### PR TITLE
Normalize (live) panel output

### DIFF
--- a/common/util/log.py
+++ b/common/util/log.py
@@ -1,23 +1,27 @@
 import sublime
 
 
-def panel(*msgs, run_async=True):
-    msg = "\n".join(str(msg) for msg in msgs)
+def universal_newlines(string):
+    return string.replace('\r\n', '\n').replace('\r', '\n')
+
+
+def panel(message, run_async=True):
+    message = universal_newlines(str(message))
     view = sublime.active_window().active_view()
     if run_async:
         sublime.set_timeout_async(
-            lambda: view.run_command("gs_display_panel", {"msg": msg})
+            lambda: view.run_command("gs_display_panel", {"msg": message})
         )
     else:
-        view.run_command("gs_display_panel", {"msg": msg})
+        view.run_command("gs_display_panel", {"msg": message})
 
 
-def panel_append(*msgs, run_async=True):
-    msg = "\n".join(str(msg) for msg in msgs)
+def panel_append(message, run_async=True):
+    message = universal_newlines(str(message))
     view = sublime.active_window().active_view()
     if run_async:
         sublime.set_timeout_async(
-            lambda: view.run_command("gs_append_panel", {"msg": msg})
+            lambda: view.run_command("gs_append_panel", {"msg": message})
         )
     else:
-        view.run_command("gs_append_panel", {"msg": msg})
+        view.run_command("gs_append_panel", {"msg": message})

--- a/common/util/log.py
+++ b/common/util/log.py
@@ -1,12 +1,16 @@
+import re
 import sublime
 
 
-def universal_newlines(string):
-    return string.replace('\r\n', '\n').replace('\r', '\n')
+ANSI_ESCAPE_RE = re.compile(r'\x1B\[[0-?]*[ -/]*[@-~]')
+
+
+def normalize(string):
+    return ANSI_ESCAPE_RE.sub('', string.replace('\r\n', '\n').replace('\r', '\n'))
 
 
 def panel(message, run_async=True):
-    message = universal_newlines(str(message))
+    message = normalize(str(message))
     view = sublime.active_window().active_view()
     if run_async:
         sublime.set_timeout_async(
@@ -17,7 +21,7 @@ def panel(message, run_async=True):
 
 
 def panel_append(message, run_async=True):
-    message = universal_newlines(str(message))
+    message = normalize(str(message))
     view = sublime.active_window().active_view()
     if run_async:
         sublime.set_timeout_async(

--- a/core/commands/custom.py
+++ b/core/commands/custom.py
@@ -73,7 +73,7 @@ class GsCustomCommand(WindowCommand, GitCommand):
         self.window.status_message(complete_msg)
 
         if output_to_panel:
-            util.log.panel(stdout.replace("\r", "\n"))
+            util.log.panel(stdout)
         if output_to_buffer:
             view = self.window.new_file()
             view.set_scratch(True)

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -202,7 +202,7 @@ class GitCommand(StatusMixin,
                 if self.savvy_settings.get("show_stdin_in_output") and stdin is not None:
                     util.log.panel_append("STDIN\n{}\n".format(stdin), run_async=False)
                 if self.savvy_settings.get("show_input_in_output"):
-                    util.log.panel_append("> {}\n".format(command_str), run_async=False)
+                    util.log.panel_append("$ {}\n".format(command_str), run_async=False)
 
             if show_panel and live_panel_output:
                 wrapper = LoggingProcessWrapper(p, self.savvy_settings.get("live_panel_output_timeout", 10000))

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -55,9 +55,6 @@ GIT_REQUIRE_MINOR = 9
 GIT_REQUIRE_PATCH = 0
 
 
-ANSI_ESCAPE = re.compile(r'\x1B\[[0-?]*[ -/]*[@-~]')
-
-
 class LoggingProcessWrapper(object):
 
     """
@@ -271,9 +268,6 @@ class GitCommand(StatusMixin,
                     "`{}` failed.".format(command_str),
                     show_panel=show_panel_on_stderr
                 )
-
-        if stdout and decode:
-            stdout = ANSI_ESCAPE.sub('', stdout)
 
         return stdout
 


### PR DESCRIPTION
Fixes #1020 

For the panel output, generally normalize newlines to `\n` only. 

For #1020 we already had a patch at ea98d36 which stripped ANSI sequences from `self.git` output. This is probably not what we want (the OP sees ANSI sequences in the push log, this can only mean in the output panel) because the return value of `self.git` is not passed to the panel. So we revert said commit and instead strip for the panel only.


