### PR TITLE
Optimize graph render

### DIFF
--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -557,26 +557,6 @@ class GsLogGraphRefreshCommand(TextCommand, GitCommand):
             enqueue_on_ui(draw)
             put_on_queue(token_queue, tokens)
 
-        def apply_token(view, token, next_prelude_len):
-            # type: (sublime.View, Replace, int) -> sublime.Region
-            nonlocal current_graph_splitted
-            start, end, text_ = token
-            text = ''.join(text_)
-            computed_start = (
-                sum(len(line) for line in current_graph_splitted[:start])
-                + next_prelude_len
-            )
-            computed_end = (
-                sum(len(line) for line in current_graph_splitted[start:end])
-                + computed_start
-            )
-            region = sublime.Region(computed_start, computed_end)
-
-            current_graph_splitted = apply_diff(current_graph_splitted, [token])
-            replace_region(view, text, region)
-            occupied_space = sublime.Region(computed_start, computed_start + len(text))
-            return occupied_space
-
         @ensure_not_aborted
         def draw():
             # TODO: Preserve column if possible instead of going to the beginning
@@ -649,6 +629,26 @@ class GsLogGraphRefreshCommand(TextCommand, GitCommand):
                 navigate_to_symbol(view, follow)
 
             mark_perf('==> LAST PAINT')
+
+        def apply_token(view, token, next_prelude_len):
+            # type: (sublime.View, Replace, int) -> sublime.Region
+            nonlocal current_graph_splitted
+            start, end, text_ = token
+            text = ''.join(text_)
+            computed_start = (
+                sum(len(line) for line in current_graph_splitted[:start])
+                + next_prelude_len
+            )
+            computed_end = (
+                sum(len(line) for line in current_graph_splitted[start:end])
+                + computed_start
+            )
+            region = sublime.Region(computed_start, computed_end)
+
+            current_graph_splitted = apply_diff(current_graph_splitted, [token])
+            replace_region(view, text, region)
+            occupied_space = sublime.Region(computed_start, computed_start + len(text))
+            return occupied_space
 
         run_on_new_thread(reader)
 

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -548,10 +548,11 @@ class GsLogGraphRefreshCommand(TextCommand, GitCommand):
             put_on_queue(token_queue, tokens)
 
         def apply_token(view, token, next_prelude_len):
+            # type: (sublime.View, Replace, int) -> sublime.Region
             nonlocal current_graph_splitted
             managers = [stable_viewport, restore_cursors]
-            start, end, text = token
-            text = ''.join(text)
+            start, end, text_ = token
+            text = ''.join(text_)
             computed_start = (
                 sum(len(line) for line in current_graph_splitted[:start])
                 + next_prelude_len
@@ -564,7 +565,8 @@ class GsLogGraphRefreshCommand(TextCommand, GitCommand):
 
             current_graph_splitted = apply_diff(current_graph_splitted, [token])
             replace_region(view, text, region, managers)
-            return region
+            occupied_space = sublime.Region(computed_start, computed_start + len(text))
+            return occupied_space
 
         def draw():
             # TODO: Preserve column if possible instead of going to the beginning

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -454,7 +454,7 @@ def log_git_command(fn):
 if MYPY:
     class SimpleQueue(Generic[T]):
         def put(self, item: T) -> None: ...  # noqa: E704
-        def get(self, block=True) -> T: ...  # noqa: E704
+        def get(self, block=True, timeout=float) -> T: ...  # noqa: E704
 else:
     class SimpleQueue:
         def __init__(self):
@@ -574,6 +574,7 @@ class GsLogGraphRefreshCommand(TextCommand, GitCommand):
         @ensure_not_aborted
         @text_command
         def drain_and_draw_queue(view, token_queue, prelude_height, did_navigate, follow):
+            # type: (sublime.View, SimpleQueue[Replace], int, bool, Optional[str]) -> None
             block_time_passed = block_time_passed_factory(1000 if not did_navigate else 13)
             while True:
                 # If only the head commits changed, and the cursor (and with it `follow`)

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -701,9 +701,16 @@ class GsLogGraphRefreshCommand(TextCommand, GitCommand):
                 if e.stderr and DATE_FORMAT in e.stderr:
                     DATE_FORMAT = FALLBACK_DATE_FORMAT
                     DATE_FORMAT_STATE = 'final'
-
-                enqueue_on_worker(self.view.run_command, "gs_log_graph_refresh")
-                return iter('')
+                    enqueue_on_worker(self.view.run_command, "gs_log_graph_refresh")
+                    return iter('')
+                else:
+                    raise GitSavvyError(
+                        e.message,
+                        cmd=e.cmd,
+                        stdout=e.stdout,
+                        stderr=e.stderr,
+                        show_panel=True,
+                    )
             else:
                 DATE_FORMAT_STATE = 'final'
 

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -1,4 +1,4 @@
-from contextlib import contextmanager
+from contextlib import contextmanager, ExitStack
 from functools import lru_cache, partial
 from itertools import chain, islice, takewhile
 import os
@@ -186,8 +186,19 @@ DATE_FORMAT_STATE = 'trying'
 
 
 @text_command
-def replace_region(view, edit, text, region):
-    view.replace(edit, region, text)
+def replace_region(view, edit, text, region=None, wrappers=[]):
+    if region is None:
+        # If you "replace" (or expand) directly at the cursor,
+        # the cursor expands into a selection.
+        # This is a common case for an empty view so we take
+        # care of it out of box.
+        region = sublime.Region(0, max(1, view.size()))
+
+    with ExitStack() as stack:
+        for wrapper in wrappers:
+            stack.enter_context(wrapper(view))
+        stack.enter_context(writable_view(view))
+        view.replace(edit, region, text)
 
 
 @contextmanager
@@ -198,6 +209,36 @@ def writable_view(view):
         yield
     finally:
         view.set_read_only(is_read_only)
+
+
+@contextmanager
+def restore_cursors(view):
+    save_cursors = [
+        (view.rowcol(s.begin()), view.rowcol(s.end()))
+        for s in view.sel()
+    ] or [((0, 0), (0, 0))]
+
+    try:
+        yield
+    finally:
+        view.sel().clear()
+        for (begin, end) in save_cursors:
+            view.sel().add(
+                sublime.Region(view.text_point(*begin), view.text_point(*end))
+            )
+
+
+@contextmanager
+def stable_viewport(view):
+    # Ref: https://github.com/SublimeTextIssues/Core/issues/2560
+    # See https://github.com/jonlabelle/SublimeJsPrettier/pull/171/files
+    # for workaround.
+    vx, vy = view.viewport_position()
+    try:
+        yield
+    finally:
+        view.set_viewport_position((0, 0))  # intentional!
+        view.set_viewport_position((vx, vy))
 
 
 def slice_new_content(old_content, new_content):

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -476,6 +476,14 @@ def try_kill_proc(proc):
         utils.kill_proc(proc)
 
 
+def selection_is_before_region(view, region):
+    # type: (sublime.View, sublime.Region) -> bool
+    try:
+        return view.sel()[-1].end() <= region.end()
+    except IndexError:
+        return True
+
+
 class GsLogGraphRefreshCommand(TextCommand, GitCommand):
 
     """
@@ -607,6 +615,8 @@ class GsLogGraphRefreshCommand(TextCommand, GitCommand):
                     elif navigate_after_draw:  # on init
                         view.run_command("gs_log_graph_navigate")
                         did_navigate = True
+                    else:
+                        did_navigate = selection_is_before_region(view, region)
 
                     if did_navigate:
                         just_navigated = True

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -513,8 +513,6 @@ class GsLogGraphRefreshCommand(TextCommand, GitCommand):
         if initial_draw:
             replace_region(self.view, prelude_text, sublime.Region(0, 1))
 
-        mark_perf = utils.measure_runtime()
-
         try:
             current_graph = self.view.substr(
                 self.view.find_by_selector('meta.content.git_savvy.graph')[0]
@@ -536,7 +534,6 @@ class GsLogGraphRefreshCommand(TextCommand, GitCommand):
             def decorated(*args, **kwargs):
                 if should_abort():
                     try_kill_proc(current_proc)
-                    mark_perf('ABORT')
                 else:
                     return fn(*args, **kwargs)
             return decorated
@@ -632,7 +629,6 @@ class GsLogGraphRefreshCommand(TextCommand, GitCommand):
 
                 if painter_state == 'navigated':
                     if region.end() >= view.visible_region().end():
-                        mark_perf('==> FIRST PAINT')
                         painter_state = 'viewport_readied'
 
                 if block_time.passed(13 if painter_state == 'viewport_readied' else 1000):
@@ -653,8 +649,6 @@ class GsLogGraphRefreshCommand(TextCommand, GitCommand):
                 if not follow or not try_navigate_to_symbol():
                     if visible_selection:
                         view.show(view.sel(), True)
-
-            mark_perf('==> LAST PAINT')
 
         def apply_token(view, token, offset):
             # type: (sublime.View, Replace, int) -> sublime.Region

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -570,7 +570,7 @@ class GsLogGraphRefreshCommand(TextCommand, GitCommand):
                 if should_abort():
                     mark_perf('ABORT')
                     return
-                block_time_passed = block_time_passed_factory(13)
+                block_time_passed = block_time_passed_factory(1000 if not did_navigate else 13)
                 while True:
                     # If only the head commits changed, and the cursor (and with it `follow`)
                     # is a few lines below, the `if_before=region` will probably never catch.
@@ -588,6 +588,7 @@ class GsLogGraphRefreshCommand(TextCommand, GitCommand):
 
                     region = apply_token(view, token, prelude_height)
 
+                    just_navigated = False
                     if not did_navigate:
                         if follow:
                             did_navigate = navigate_to_symbol(self.view, follow, if_before=region)
@@ -597,8 +598,9 @@ class GsLogGraphRefreshCommand(TextCommand, GitCommand):
 
                         if did_navigate:
                             mark_perf('==> FIRST PAINT')
+                            just_navigated = True
 
-                    if did_navigate and block_time_passed():
+                    if just_navigated or block_time_passed():
                         enqueue_on_worker(draw_, view, token_queue, prelude_height, did_navigate)
                         return
 

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -581,6 +581,10 @@ class GsLogGraphRefreshCommand(TextCommand, GitCommand):
             replace_region(self.view, prelude_text, current_prelude_region)
             drain_and_draw_queue(self.view, token_queue, len(prelude_text), False, follow, col_range)
 
+        # Sublime will not run any event handlers until the (outermost) TextCommand exits.
+        # T.i. the (inner) commands `replace_region` and `set_and_show_cursor` will run
+        # through uninterrupted until `drain_and_draw_queue` yields. Then e.g.
+        # `on_selection_modified` runs *once* even if we painted multiple times.
         @ensure_not_aborted
         @text_command
         def drain_and_draw_queue(view, token_queue, offset, did_navigate, follow, col_range):

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -652,6 +652,7 @@ class GsLogGraphRefreshCommand(TextCommand, GitCommand):
         proc = self.git(*args, just_the_proc=True, **kwargs)
         if got_proc:
             got_proc(proc)
+        received_some_stdout = False
         with proc:
             while True:
                 # Block size 2**14 taken from Sublime's `exec.py`. This
@@ -665,13 +666,15 @@ class GsLogGraphRefreshCommand(TextCommand, GitCommand):
                 lines = proc.stdout.readlines(2**14)
                 if not lines:
                     break
+                elif not received_some_stdout:
+                    received_some_stdout = True
                 for line in lines:
                     yield decode(line)
 
             stderr = ''.join(map(decode, proc.stderr.readlines()))
 
         if throw_on_stderr and stderr:
-            stdout = "<SNIP>"
+            stdout = "<STDOUT SNIPPED>\n" if received_some_stdout else ""
             raise GitSavvyError(
                 "$ {}\n\n{}".format(
                     " ".join(["git"] + list(filter(None, args))),

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -423,6 +423,13 @@ def put_on_queue(queue, it):
         queue.put(TheEnd)
 
 
+def wait_for_first_item(it):
+    # type: (Iterable[T]) -> Iterator[T]
+    iterable = iter(it)
+    head = take(1, iterable)
+    return chain(head, iterable)
+
+
 def log_git_command(fn):
     # type: (Callable[..., Iterator[T]]) -> Callable[..., Iterator[T]]
     def decorated(self, *args, **kwargs):
@@ -504,10 +511,9 @@ class GsLogGraphRefreshCommand(TextCommand, GitCommand):
                 diff(current_graph_splitted, next_graph_splitted),
                 max_size=100
             ))
-            graph = iter(tokens)
-            head = take(1, graph)
+            tokens = wait_for_first_item(tokens)
             enqueue_on_ui(draw)
-            put_on_queue(token_queue, chain(head, graph))
+            put_on_queue(token_queue, tokens)
 
         def apply_token(view, token, next_prelude_len):
             nonlocal current_graph_splitted

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -626,11 +626,16 @@ class GsLogGraphRefreshCommand(TextCommand, GitCommand):
                     )
                     return
 
-            if follow and not did_navigate:
+            if not did_navigate:
                 # If we still did not navigate the symbol is either
                 # gone, or happens to be after the fold of fresh
                 # content.
-                navigate_to_symbol(view, follow)
+                if follow:
+                    did_navigate = navigate_to_symbol(view, follow)
+                # The symbol is gone, ensure the user can see the
+                # cursor.
+                if not did_navigate:
+                    view.show(view.sel(), True)
 
             mark_perf('==> LAST PAINT')
 

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -487,6 +487,10 @@ class GsLogGraphRefreshCommand(TextCommand, GitCommand):
 
     def run(self, edit, navigate_after_draw=False):
         # type: (object, bool) -> None
+        # Edge case: If you restore a workspace/project, the view might still be
+        # loading and hence not ready for refresh calls.
+        if self.view.is_loading():
+            return
         should_abort, previous_run_unfinished = register_running(self.view)
         enqueue_on_worker(self.run_impl, previous_run_unfinished, should_abort, navigate_after_draw)
 

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -610,9 +610,9 @@ class GsLogGraphRefreshCommand(TextCommand, GitCommand):
                     just_navigated = False
                     if not did_navigate:
                         if follow:
-                            did_navigate = navigate_to_symbol(self.view, follow, if_before=region)
+                            did_navigate = navigate_to_symbol(view, follow, if_before=region)
                         elif navigate_after_draw:  # on init
-                            self.view.run_command("gs_log_graph_navigate")
+                            view.run_command("gs_log_graph_navigate")
                             did_navigate = True
 
                         if did_navigate:
@@ -627,9 +627,9 @@ class GsLogGraphRefreshCommand(TextCommand, GitCommand):
                     # If we still did not navigate the symbol is either
                     # gone, or happens to be after the fold of fresh
                     # content.
-                    navigate_to_symbol(self.view, follow)
+                    navigate_to_symbol(view, follow)
 
-                mark_finished(self.view, should_abort)
+                mark_finished(view, should_abort)
                 mark_perf('==> LAST PAINT')
 
             current_prelude_region = self.view.find_by_selector('meta.prelude.git_savvy.graph')[0]

--- a/core/fns.py
+++ b/core/fns.py
@@ -1,5 +1,5 @@
 from functools import partial
-from itertools import accumulate as accumulate_, chain, tee
+from itertools import accumulate as accumulate_, chain, islice, tee
 
 MYPY = False
 if MYPY:
@@ -35,3 +35,43 @@ def unique(iterable):
             continue
         seen.add(item)
         yield item
+
+
+# Below functions taken from https://github.com/erikrose/more-itertools
+# Copyright (c) 2012 Erik Rose
+
+
+def take(n, iterable):
+    """Return first *n* items of the iterable as a list.
+        >>> take(3, range(10))
+        [0, 1, 2]
+    If there are fewer than *n* items in the iterable, all of them are
+    returned.
+        >>> take(10, range(3))
+        [0, 1, 2]
+    """
+    return list(islice(iterable, n))
+
+
+def chunked(iterable, n):
+    """Break *iterable* into lists of length *n*:
+
+        >>> list(chunked([1, 2, 3, 4, 5, 6], 3))
+        [[1, 2, 3], [4, 5, 6]]
+
+    If the length of *iterable* is not evenly divisible by *n*, the last
+    returned list will be shorter:
+
+        >>> list(chunked([1, 2, 3, 4, 5, 6, 7, 8], 3))
+        [[1, 2, 3], [4, 5, 6], [7, 8]]
+
+    To use a fill-in value instead, see the :func:`grouper` recipe.
+
+    :func:`chunked` is useful for splitting up a computation on a large number
+    of keys into batches, to be pickled and sent off to worker processes. One
+    example is operations on rows in MySQL, which does not implement
+    server-side cursors properly and would otherwise load the entire dataset
+    into RAM on the client.
+
+    """
+    return iter(partial(take, n, iter(iterable)), [])

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,4 +1,8 @@
 from contextlib import contextmanager
+import os
+import signal
+import subprocess
+import sys
 import time
 import threading
 import traceback
@@ -56,3 +60,17 @@ def hprint(msg):
 def line_indentation(line):
     # type: (str) -> int
     return len(line) - len(line.lstrip())
+
+
+def kill_proc(proc):
+    if sys.platform == "win32":
+        # terminate would not kill process opened by the shell cmd.exe,
+        # it will only kill cmd.exe leaving the child running
+        startupinfo = subprocess.STARTUPINFO()
+        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+        subprocess.Popen(
+            "taskkill /PID %d /T /F" % proc.pid,
+            startupinfo=startupinfo)
+    else:
+        os.killpg(proc.pid, signal.SIGTERM)
+        proc.terminate()

--- a/core/utils.py
+++ b/core/utils.py
@@ -6,11 +6,12 @@ import traceback
 
 MYPY = False
 if MYPY:
-    ...
+    from typing import Callable, Iterator, Type
 
 
 @contextmanager
 def print_runtime(message):
+    # type: (str) -> Iterator[None]
     start_time = time.perf_counter()
     yield
     end_time = time.perf_counter()
@@ -19,8 +20,23 @@ def print_runtime(message):
     print('{} took {}ms [{}]'.format(message, duration, thread_name))
 
 
+def measure_runtime():
+    # type: () -> Callable[[str], None]
+    start_time = time.perf_counter()
+
+    def print_mark(message):
+        # type: (str) -> None
+        end_time = time.perf_counter()
+        duration = round((end_time - start_time) * 1000)
+        thread_name = threading.current_thread().name[0]
+        print('{} after {}ms [{}]'.format(message, duration, thread_name))
+
+    return print_mark
+
+
 @contextmanager
 def eat_but_log_errors(exception=Exception):
+    # type: (Type[Exception]) -> Iterator[None]
     try:
         yield
     except exception:

--- a/core/utils.py
+++ b/core/utils.py
@@ -38,6 +38,17 @@ def measure_runtime():
     return print_mark
 
 
+class timer:
+    def __init__(self):
+        self._start_time = time.perf_counter()
+
+    def passed(self, ms):
+        # type: (int) -> bool
+        cur_time = time.perf_counter()
+        duration = (cur_time - self._start_time) * 1000
+        return duration > ms
+
+
 @contextmanager
 def eat_but_log_errors(exception=Exception):
     # type: (Type[Exception]) -> Iterator[None]

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,7 @@
 [mypy]
 check_untyped_defs = True
 warn_unused_ignores = True
+warn_unreachable = True
 mypy_path =
     stubs,
     ..

--- a/syntax/graph.sublime-syntax
+++ b/syntax/graph.sublime-syntax
@@ -119,14 +119,14 @@ contexts:
       scope: punctuation.separator.key-value.git-savvy
 
 
-    - match: '(?=\s+\|)'
+    - match: '(?=\s+(\|) ([^|]+), ([^|]+)$\n?)'
       set: date-author-info
 
     - match: $
       pop: true
 
   date-author-info:
-    - match: '(\|) (.*), (.*)$\n?'
+    - match: '\s+(\|) ([^|]+), ([^|]+)$\n?'
       scope: meta.git-savvy.grph.info
       captures:
         1: punctuation.separator.git-savvy

--- a/tests/test_graph_diff.py
+++ b/tests/test_graph_diff.py
@@ -1,0 +1,101 @@
+
+from unittesting import DeferrableTestCase
+from GitSavvy.tests.parameterized import parameterized as p
+
+
+from GitSavvy.core.commands.log_graph import (
+    diff, simplify, normalize_tokens, apply_diff, Ins, Del, Replace
+)
+
+
+def _(string):
+    return [__(s) for s in iter(string)]
+
+
+def __(string):
+    return '* ' + string
+
+
+def tx(tokens):
+    return [
+        t._replace(line=__(t.line)) if isinstance(t, Ins)
+        else t._replace(text=_(t.text)) if isinstance(t, Replace)
+        else t
+        for t in tokens
+    ]
+
+
+class TestGraphDiff(DeferrableTestCase):
+    @p.expand([
+        ('abcdef', 'abcdef', []),
+        ('bcdef', 'abcdef', [Ins(0, 'a')]),
+        ('a', 'xay', [Ins(0, 'x'), Ins(2, 'y')]),
+        ('ab', 'xay', [Ins(0, 'x'), Ins(2, 'y'), Del(3, 4)]),
+        #                 xabc         xaybc        xayc       xaycz
+        ('abc', 'xaycz', [Ins(0, 'x'), Ins(2, 'y'), Del(3, 4), Ins(4, 'z')]),
+        ('abcd', 'xbcd', [Ins(0, 'x'), Del(1, 2)]),
+        ('abcd', 'pqabcd', [Ins(0, 'p'), Ins(1, 'q')]),
+        ('abcd', 'pqab', [Ins(0, 'p'), Ins(1, 'q'), Del(4, 6)]),
+        ('abpqcd', 'abcd', [Del(2, 4)]),
+        ('abpqcd', 'abc', [Del(2, 4), Del(3, 4)]),
+    ])
+    def test_a(self, A, B, ops):
+        A = _(A)
+        B = _(B)
+        ops = tx(ops)
+        self.assertEqual(list(diff(A, B)), ops)
+
+    @p.expand([
+        ('abcdef', 'abcdef', []),
+        ('bcdef', 'abcdef', [Ins(0, 'a')]),
+        ('a', 'xay', [Ins(0, 'x'), Ins(2, 'y')]),
+        ('ab', 'xay', [Ins(0, 'x'), Replace(2, 3, 'y')]),
+        ('abc', 'xayc', [Ins(0, 'x'), Replace(2, 3, 'y')]),
+        #                 xabc         xayc                     xaycz
+        ('abc', 'xaycz', [Ins(0, 'x'), Replace(2, 3, 'y'), Ins(4, 'z')]),
+        ('abcd', 'xbcd', [Replace(0, 1, 'x')]),
+        ('abcd', 'pqabcd', [Replace(0, 0, 'pq')]),
+        ('abcd', 'pqrabcd', [Replace(0, 0, 'pqr')]),
+        ('abcd', '', [Del(0, 4)]),
+        ('abcd', 'pqr', [Replace(0, 4, 'pqr')]),
+        ('abcd', 'pqab', [Replace(0, 0, 'pq'), Del(4, 6)]),
+        ('abpqcd', 'abcd', [Del(2, 4)]),
+        ('abpqcd', 'abc', [Del(2, 4), Del(3, 4)]),
+        ('abpqcd', '', [Del(0, 6)]),
+        ('', 'abpqcd', [Replace(0, 0, 'abpqcd')]),
+    ])
+    def test_b(self, A, B, ops):
+        A = _(A)
+        B = _(B)
+        ops = tx(ops)
+        self.assertEqual(list(simplify(diff(A, B))), ops)
+
+    @p.expand([
+        ('abcdef', 'abcdef', []),
+        ('bcdef', 'abcdef', [Replace(0, 0, 'a')]),
+        ('abcd', 'xbcd', [Replace(0, 1, 'x')]),
+        ('abcd', 'pqabcd', [Replace(0, 0, 'pq')]),
+        ('abcd', 'pqab', [Replace(0, 0, 'pq'), Replace(4, 6, '')]),
+        ('abpqcd', 'abcd', [Replace(2, 4, '')]),
+        ('abpqcd', 'abc', [Replace(2, 4, ''), Replace(3, 4, '')]),
+    ])
+    def test_c(self, A, B, ops):
+        A = _(A)
+        B = _(B)
+        ops = tx(ops)
+        self.assertEqual(list(normalize_tokens(simplify(diff(A, B)))), ops)
+
+    @p.expand([
+        ('abcdef', 'abcdef', []),
+        ('bcdef', 'abcdef', [Replace(0, 0, 'a')]),
+        ('abcd', 'xbcd', [Replace(0, 1, 'x')]),
+        ('abcd', 'pqabcd', [Replace(0, 1, 'pq')]),
+        ('abcd', 'pqab', [Replace(0, 1, 'pq'), Replace(4, 6, '')]),
+        ('abpqcd', 'abcd', [Replace(2, 4, '')]),
+        ('abpqcd', 'abc', [Replace(2, 4, ''), Replace(3, 4, '')]),
+    ])
+    def test_d(self, A, B, ops):
+        A = _(A)
+        B = _(B)
+        ops = tx(ops)
+        self.assertEqual(apply_diff(A, normalize_tokens(simplify(diff(A, B)))), B)

--- a/tests/test_graph_diff.py
+++ b/tests/test_graph_diff.py
@@ -4,7 +4,7 @@ from GitSavvy.tests.parameterized import parameterized as p
 
 
 from GitSavvy.core.commands.log_graph import (
-    diff, simplify, normalize_tokens, apply_diff, Ins, Del, Replace
+    diff, simplify, normalize_tokens, apply_diff, Ins, Del, Replace, Same
 )
 
 
@@ -25,6 +25,10 @@ def tx(tokens):
     ]
 
 
+def filter_same(it):
+    return filter(lambda t: t is not Same, it)
+
+
 class TestGraphDiff(DeferrableTestCase):
     @p.expand([
         ('abcdef', 'abcdef', []),
@@ -43,7 +47,7 @@ class TestGraphDiff(DeferrableTestCase):
         A = _(A)
         B = _(B)
         ops = tx(ops)
-        self.assertEqual(list(diff(A, B)), ops)
+        self.assertEqual(list(filter_same(diff(A, B))), ops)
 
     @p.expand([
         ('abcdef', 'abcdef', []),
@@ -68,7 +72,7 @@ class TestGraphDiff(DeferrableTestCase):
         A = _(A)
         B = _(B)
         ops = tx(ops)
-        self.assertEqual(list(simplify(diff(A, B))), ops)
+        self.assertEqual(list(simplify(diff(A, B), 100)), ops)
 
     @p.expand([
         ('abcdef', 'abcdef', []),
@@ -83,7 +87,7 @@ class TestGraphDiff(DeferrableTestCase):
         A = _(A)
         B = _(B)
         ops = tx(ops)
-        self.assertEqual(list(normalize_tokens(simplify(diff(A, B)))), ops)
+        self.assertEqual(list(normalize_tokens(simplify(diff(A, B), 100))), ops)
 
     @p.expand([
         ('abcdef', 'abcdef', []),
@@ -98,4 +102,4 @@ class TestGraphDiff(DeferrableTestCase):
         A = _(A)
         B = _(B)
         ops = tx(ops)
-        self.assertEqual(apply_diff(A, normalize_tokens(simplify(diff(A, B)))), B)
+        self.assertEqual(apply_diff(A, normalize_tokens(simplify(diff(A, B), 100))), B)

--- a/tests/test_graph_view.py
+++ b/tests/test_graph_view.py
@@ -165,7 +165,7 @@ class TestDiffViewInteractionWithCommitInfoPanel(DeferrableTestCase):
             when(gs_show_commit_info).show_commit(sha1, ...).thenReturn(info)
 
     def create_graph_view_async(self, repo_path, log, wait_for):
-        when(GsLogGraphRefreshCommand).git('log', ...).thenReturn(log)
+        when(GsLogGraphRefreshCommand).read_graph(...).thenReturn(log.splitlines(keepends=True))
         # `GitCommand.get_repo_path` "validates" a given repo using
         # `os.path.exists`.
         exists = os.path.exists

--- a/tests/test_run_for_timeout.py
+++ b/tests/test_run_for_timeout.py
@@ -1,0 +1,25 @@
+from GitSavvy.core.runtime import run_or_timeout
+
+from unittesting import DeferrableTestCase
+
+
+class TestRunForTimeout(DeferrableTestCase):
+    def testReturnsFunctionResult(self):
+        def main():
+            return "Ok"
+
+        self.assertEquals("Ok", run_or_timeout(main, timeout=1.0))
+
+    def testReraisesException(self):
+        def main():
+            1 / 0
+
+        self.assertRaises(ZeroDivisionError, lambda: run_or_timeout(main, timeout=1.0))
+
+    def testRaisesTimeoutIfFunctionTakesTooLong(self):
+        def main():
+            import time
+            time.sleep(0.1)
+            1 / 0
+
+        self.assertRaises(TimeoutError, lambda: run_or_timeout(main, timeout=0.01))


### PR DESCRIPTION
For the graph view the real bottleneck is painting huge graphs. 

- We switch to reading the git output in streaming mode.  Doing so we get the first meaningful bytes fast.
- We implement a view differ so that redraws get cheap.
- We implement a chunker so that long histories are drawn over a long time rather than blocking (in cases basically freezing) Sublime.
- We implement an aborter which aborts long running git processes or more often just aborts the draw-queue.

Notable:

- Implement a variadic `replace_region` render function.

Basically before:

![oldsV2S7ioioV](https://user-images.githubusercontent.com/8558/76167095-6c4f9480-6164-11ea-8402-a13d2acc0447.gif)

And after: 

![new17i2IEPQcz](https://user-images.githubusercontent.com/8558/76167096-72457580-6164-11ea-9673-49a6307a28ab.gif)
