### PR TITLE
Redo the graph actions

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1296,6 +1296,30 @@
         ]
     },
     {
+        "keys": ["b"],
+        "command": "gs_log_graph_edit_branches",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.log_graph_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["f"],
+        "command": "gs_log_graph_edit_filters",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.log_graph_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["F"],
+        "command": "gs_log_graph_reset_filters",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.log_graph_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
         "keys": ["h"],
         "command": "gs_log_graph_navigate_to_head",
         "context": [

--- a/core/commands/commit_compare.py
+++ b/core/commands/commit_compare.py
@@ -95,6 +95,13 @@ class GsCompareAgainstCommand(PanelActionMixin, WindowCommand, GitCommand):
         self._file_path = self.file_path if current_file else file_path
         self._base_commit = base_commit
         self._target_commit = target_commit
+        if base_commit and target_commit:
+            self.window.run_command("gs_compare_commit", {
+                "base_commit": self._base_commit,
+                "target_commit": self._target_commit,
+                "file_path": self._file_path
+            })
+            return
         super().run()
 
     def update_actions(self):

--- a/core/commands/commit_compare.py
+++ b/core/commands/commit_compare.py
@@ -26,7 +26,10 @@ class GsCompareCommitCommand(WindowCommand, GitCommand):
             self.window.status_message("No common base for {} and {}".format(base_commit, target_commit))
             return
 
-        branches = [base_commit, target_commit] + ['{}^!'.format(base) for base in merge_bases]
+        branches = (
+            [base_commit, target_commit]
+            + ['{}^!'.format(base) for base in map(self.get_short_hash, merge_bases)]
+        )
         self.window.run_command("gs_graph", {
             'all': False,
             'file_path': file_path,

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -213,6 +213,9 @@ class GsDiffRefreshCommand(TextCommand, GitCommand):
                 if base_commit and target_commit:
                     prelude += "  {}..{}\n".format(base_commit, target_commit)
                     title += ["{}..{}".format(base_commit, target_commit)]
+                elif base_commit and "..." in base_commit:
+                    prelude += "  {}\n".format(base_commit)
+                    title += [base_commit]
                 else:
                     prelude += "  {}..WORKING DIR\n".format(base_commit or target_commit)
                     title += ["{}..WORKING DIR".format(base_commit or target_commit)]
@@ -375,6 +378,12 @@ class GsDiffToggleCachedMode(TextCommand):
         if base_commit and target_commit:
             settings.set("git_savvy.diff_view.base_commit", target_commit)
             settings.set("git_savvy.diff_view.target_commit", base_commit)
+            self.view.run_command("gs_diff_refresh")
+            return
+
+        if base_commit and "..." in base_commit:
+            a, b = base_commit.split("...")
+            settings.set("git_savvy.diff_view.base_commit", "{}...{}".format(b, a))
             self.view.run_command("gs_diff_refresh")
             return
 

--- a/core/commands/log.py
+++ b/core/commands/log.py
@@ -23,8 +23,11 @@ class LogMixin(object):
 
     selected_index = 0
 
-    def run(self, *args, file_path=None, **kwargs):
-        sublime.set_timeout_async(lambda: self.run_async(file_path=file_path, **kwargs), 0)
+    def run(self, *args, commit_hash=None, file_path=None, **kwargs):
+        if commit_hash:
+            self.do_action(commit_hash, file_path=file_path, **kwargs)
+        else:
+            sublime.set_timeout_async(lambda: self.run_async(file_path=file_path, **kwargs))
 
     def run_async(self, file_path=None, **kwargs):
         follow = self.savvy_settings.get("log_follow_rename") if file_path else False

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -1139,7 +1139,9 @@ class GsLogGraphActionCommand(WindowCommand, GitCommand):
         ]
 
         good_reset_target = (
-            info["branches"][0]
+            info["local_branches"][0]
+            if info.get("local_branches")
+            else info["branches"][0]
             if info.get("branches")
             else good_commit_name
         )

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -1146,12 +1146,16 @@ class GsLogGraphActionCommand(WindowCommand, GitCommand):
         self.window.run_command("gs_reset", {"commit_hash": commitish})
 
     def cherry_pick(self, *commit_hash):
-        self.git("cherry-pick", *commit_hash)
-        util.view.refresh_gitsavvy_interfaces(self.window, refresh_sidebar=True)
+        try:
+            self.git("cherry-pick", *commit_hash)
+        finally:
+            util.view.refresh_gitsavvy_interfaces(self.window, refresh_sidebar=True)
 
     def revert_commit(self, *commit_hash):
-        self.git("revert", *commit_hash)
-        util.view.refresh_gitsavvy_interfaces(self.window, refresh_sidebar=True)
+        try:
+            self.git("revert", *commit_hash)
+        finally:
+            util.view.refresh_gitsavvy_interfaces(self.window, refresh_sidebar=True)
 
     def compare_against(self, base_commit, target_commit=None, file_path=None):
         self.window.run_command("gs_compare_against", {

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -997,25 +997,20 @@ class GsLogGraphActionCommand(WindowCommand, GitCommand):
 
         sel = view.sel()
         if all(s.empty() for s in sel) and len(sel) == 2:
-            first, second = infos[0], infos[1]
-            base_commit = (
-                first["local_branches"][0]
-                if first.get("local_branches")
-                else first["branches"][0]
-                if first.get("branches") and len(first["branches"]) == 1
-                else first["tags"][0]
-                if first.get("tags") and not first.get("branches")
-                else first["commit"]
-            )
-            target_commit = (
-                second["local_branches"][0]
-                if second.get("local_branches")
-                else second["branches"][0]
-                if second.get("branches")
-                else second["tags"][0]
-                if second.get("tags") and not second.get("branches")
-                else second["commit"]
-            )
+            def display_name(info):
+                # type: (LineInfo) -> str
+                if info.get("local_branches"):
+                    return info["local_branches"][0]
+                branches = info.get("branches", [])
+                if len(branches) == 1:
+                    return branches[0]
+                elif len(branches) == 0 and info.get("tags"):
+                    return info["tags"][0]
+                else:
+                    return info["commit"]
+
+            base_commit = display_name(infos[0])
+            target_commit = display_name(infos[1])
 
             actions += [
                 (

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -931,6 +931,14 @@ class GsLogGraphActionCommand(WindowCommand, GitCommand):
                 )
             ]
 
+        actions += [
+            ("Create tag", partial(self.create_tag, commit_hash))
+        ]
+        actions += [
+            ("Delete '{}'".format(tag_name), partial(self.delete_tag, tag_name))
+            for tag_name in info.get("tags", [])
+        ]
+
         if "HEAD" not in info:
             actions += [
                 ("Cherry-pick commit", partial(self.cherry_pick, commit_hash)),
@@ -969,6 +977,13 @@ class GsLogGraphActionCommand(WindowCommand, GitCommand):
 
     def show_commit(self, commit_hash):
         self.window.run_command("gs_show_commit", {"commit_hash": commit_hash})
+
+    def create_tag(self, commit_hash):
+        self.window.run_command("gs_tag_create", {"target_commit": commit_hash})
+
+    def delete_tag(self, tag_name):
+        self.git("tag", "-d", tag_name)
+        util.view.refresh_gitsavvy_interfaces(self.window, refresh_sidebar=True)
 
     def cherry_pick(self, commit_hash):
         self.git("cherry-pick", commit_hash)

--- a/core/commands/reset.py
+++ b/core/commands/reset.py
@@ -40,9 +40,9 @@ class ResetMixin(object):
 
     def on_reset_mode_selection(self, index):
         if index == -1:
+            return
             sublime.set_timeout_async(self.run_async, 100)
-        elif 0 <= index < len(GIT_RESET_MODES):
-            self.on_reset(GIT_RESET_MODES[index][0].strip())
+        self.on_reset(GIT_RESET_MODES[index][0].strip())
 
     def on_reset(self, reset_mode):
         # Split the reset mode to support multiple args, e.g. "--mixed -N"

--- a/core/commands/tag.py
+++ b/core/commands/tag.py
@@ -59,8 +59,9 @@ class GsTagCreateCommand(TextCommand, GitCommand):
     Through a series of panels, allow the user to add a tag and message.
     """
 
-    def run(self, edit, tag_name=""):
+    def run(self, edit, tag_name="", target_commit=None):
         self.window = self.view.window()
+        self.target_commit = target_commit
         show_single_line_input_panel(TAG_CREATE_PROMPT, tag_name, self.on_entered_name)
 
     def on_entered_name(self, tag_name):
@@ -93,9 +94,9 @@ class GsTagCreateCommand(TextCommand, GitCommand):
         Create a tag with the specified tag name and message.
         """
         if not message:
-            self.git("tag", self.tag_name)
+            self.git("tag", self.tag_name, self.target_commit)
         else:
-            self.git("tag", self.tag_name, "-F", "-", stdin=message)
+            self.git("tag", self.tag_name, self.target_commit, "-F", "-", stdin=message)
         self.view.window().status_message(TAG_CREATE_MESSAGE.format(self.tag_name))
         util.view.refresh_gitsavvy(self.view)
 

--- a/core/commands/tag.py
+++ b/core/commands/tag.py
@@ -61,6 +61,8 @@ class GsTagCreateCommand(TextCommand, GitCommand):
 
     def run(self, edit, tag_name="", target_commit=None):
         self.window = self.view.window()
+        if not self.window:
+            return
         self.target_commit = target_commit
         show_single_line_input_panel(TAG_CREATE_PROMPT, tag_name, self.on_entered_name)
 
@@ -97,8 +99,8 @@ class GsTagCreateCommand(TextCommand, GitCommand):
             self.git("tag", self.tag_name, self.target_commit)
         else:
             self.git("tag", self.tag_name, self.target_commit, "-F", "-", stdin=message)
-        self.view.window().status_message(TAG_CREATE_MESSAGE.format(self.tag_name))
-        util.view.refresh_gitsavvy(self.view)
+        self.window.status_message(TAG_CREATE_MESSAGE.format(self.tag_name))
+        util.view.refresh_gitsavvy_interfaces(self.window)
 
 
 class GsSmartTagCommand(PanelActionMixin, TextCommand, GitCommand):

--- a/core/commands/tag.py
+++ b/core/commands/tag.py
@@ -61,14 +61,7 @@ class GsTagCreateCommand(TextCommand, GitCommand):
 
     def run(self, edit, tag_name=""):
         self.window = self.view.window()
-        self.tag_name = tag_name
-        sublime.set_timeout_async(self.run_async)
-
-    def run_async(self):
-        """
-        Prompt the user for a tag name.
-        """
-        show_single_line_input_panel(TAG_CREATE_PROMPT, self.tag_name, self.on_entered_name)
+        show_single_line_input_panel(TAG_CREATE_PROMPT, tag_name, self.on_entered_name)
 
     def on_entered_name(self, tag_name):
         """

--- a/core/commands/tag.py
+++ b/core/commands/tag.py
@@ -100,9 +100,9 @@ class GsTagCreateCommand(TextCommand, GitCommand):
         Create a tag with the specified tag name and message.
         """
         if not message:
-            return
-
-        self.git("tag", self.tag_name, "-F", "-", stdin=message)
+            self.git("tag", self.tag_name)
+        else:
+            self.git("tag", self.tag_name, "-F", "-", stdin=message)
         self.view.window().status_message(TAG_CREATE_MESSAGE.format(self.tag_name))
         util.view.refresh_gitsavvy(self.view)
 

--- a/core/fns.py
+++ b/core/fns.py
@@ -3,7 +3,7 @@ from itertools import accumulate as accumulate_, chain, tee
 
 MYPY = False
 if MYPY:
-    from typing import Callable, Iterable, Iterator, Optional, Tuple, TypeVar
+    from typing import Callable, Iterable, Iterator, Optional, Set, Tuple, TypeVar
     T = TypeVar('T')
 
 
@@ -25,3 +25,13 @@ def pairwise(iterable):
     a, b = tee(iterable)
     next(b, None)
     return zip(a, b)
+
+
+def unique(iterable):
+    # type: (Iterable[T]) -> Iterator[T]
+    seen = set()  # type: Set[T]
+    for item in iterable:
+        if item in seen:
+            continue
+        seen.add(item)
+        yield item

--- a/core/fns.py
+++ b/core/fns.py
@@ -7,7 +7,7 @@ if MYPY:
     T = TypeVar('T')
 
 
-filter_ = partial(filter, None)  # type: Callable[[Iterator[Optional[T]]], Iterator[T]]
+filter_ = partial(filter, None)  # type: Callable[[Iterable[Optional[T]]], Iterator[T]]
 flatten = chain.from_iterable
 
 

--- a/tests/test_describe_graph_line.py
+++ b/tests/test_describe_graph_line.py
@@ -1,0 +1,73 @@
+from unittesting import DeferrableTestCase
+from GitSavvy.tests.parameterized import parameterized as p
+
+from GitSavvy.core.commands.log_graph import describe_graph_line
+
+
+examples = [
+    (
+        "|",
+        {},
+        None
+    ),
+    (
+        "● a3062b2 (HEAD -> optimize-graph-render, origin/optimize-graph-render) Abort .. | Thu 21:07, herr kaste",
+        {"origin"},
+        {
+            "commit": "a3062b2",
+            "HEAD": "optimize-graph-render",
+            "branches": ["optimize-graph-render", "origin/optimize-graph-render"],
+            "local_branches": ["optimize-graph-render"]
+        }
+    ),
+    (
+        "● a3062b2 (HEAD, origin/optimize-graph-render) Abort re.. | Thu 21:07, herr kaste",
+        {"origin"},
+        {
+            "commit": "a3062b2",
+            "HEAD": "a3062b2",
+            "branches": ["origin/optimize-graph-render"]
+        }
+    ),
+    (
+        "● a3062b2 (HEAD -> optimize-graph-render, feat/optimize-graph-render) Abort .. | Thu 21:07, herr kaste",
+        {"origin"},
+        {
+            "commit": "a3062b2",
+            "HEAD": "optimize-graph-render",
+            "branches": ["optimize-graph-render", "feat/optimize-graph-render"],
+            "local_branches": ["optimize-graph-render", "feat/optimize-graph-render"]
+        }
+    ),
+    (
+        "● ad6d88c (HEAD) Use view from the argument instead of on self                   | Thu 20:56, herr kaste",
+        {"origin"},
+        {
+            "commit": "ad6d88c",
+            "HEAD": "ad6d88c",
+        }
+    ),
+    (
+        "● ad6d88c Use view from the argument instead of on self                          | Thu 20:56, herr kaste",
+        {"origin"},
+        {
+            "commit": "ad6d88c",
+        }
+
+    ),
+    (
+        "| ●   153dca0 (HEAD, tag: 2.20.0) Merge branch 'dev' (2 months ago) <herr kaste>",
+        {"origin"},
+        {
+            "commit": "153dca0",
+            "HEAD": "153dca0",
+            "tags": ["2.20.0"]
+        }
+    ),
+]
+
+
+class TestDescribeGraphLine(DeferrableTestCase):
+    @p.expand(examples)
+    def test_a(self, input_line, remotes, output):
+        self.assertEqual(output, describe_graph_line(input_line, remotes))


### PR DESCRIPTION
Fixes #1260 

The graph actions were really limited. We add all commands usually found e.g. in `git k` or possibly `Sublime Merge`. 

Esp. 

- Checkout a branch (not only a commit detached)
- Create and delete tags
- Reset HEAD to 
- Allow cherry-picking and reverting multiple commits

![image](https://user-images.githubusercontent.com/8558/76160967-f1b85200-612e-11ea-8a48-0ba4d1585dc4.png)

Add `[f]` (unset `F`) to enter additonal filters via a typical input panel.  That's not the best UI because it requires the user to know all the flags (it is thus not really accessible) but it is otherwise just too useful. 

Examples: 

- set `--reflog` to immediately display "gone" commits e.g. after a rebase or deletion of a tag, branch. 

- set `-Ssearch_term` or `-Gsearch_term` to quickly pick-axe
- quickly limit via `-n` or `--since` etc.

Probably all these use-cases could be supported more directly, e.g. since we're in an editor, ususally just selecting a word and tell git to pick-axe should be probably a command accessible in the editor views. And "reflog" could be a switch.

But I guess we have add and fine-tune this over time. (No excuse to not add something immediately useful.)