### PR TITLE
Fix: Allow unstaging merge conflicted files

### DIFF
--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -600,7 +600,7 @@ class GsStatusUnstageFileCommand(TextCommand, GitCommand):
         if not (window and interface):
             return
 
-        file_paths = get_selected_subjects(self.view, 'staged')
+        file_paths = get_selected_subjects(self.view, 'staged', 'merge-conflicts')
         if file_paths:
             self.unstage_file(*file_paths)
             window.status_message("Unstaged files successfully.")


### PR DESCRIPTION
Use-case: If you really dislike the changes you can unstage and then
discard the introduced changes.