### PR TITLE
Iterate on `show commit`

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -709,6 +709,14 @@
         ]
     },
     {
+        "keys": ["g"],
+        "command": "gs_show_commit_open_graph_context",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.show_commit_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
         "keys": ["s"],
         "command": "gs_show_commit_toggle_setting",
         "args": { "setting": "ignore_whitespace" },

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -701,6 +701,14 @@
         ]
     },
     {
+        "keys": ["O"],
+        "command": "gs_show_commit_show_hunk_on_head",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.show_commit_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
         "keys": ["s"],
         "command": "gs_show_commit_toggle_setting",
         "args": { "setting": "ignore_whitespace" },

--- a/core/commands/blame.py
+++ b/core/commands/blame.py
@@ -426,6 +426,7 @@ class GsBlameActionCommand(BlameMixin, PanelActionMixin, TextCommand, GitCommand
         self.view.window().run_command("gs_show_file_at_commit", {
             "commit_hash": commit_hash,
             "filepath": self.file_path,
+            "check_for_renames": True,
             "lineno": lineno,
             "lang": settings.get('git_savvy.original_syntax', None)
         })

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -528,6 +528,20 @@ class GsDiffStageOrResetHunkCommand(TextCommand, GitCommand):
         self.view.run_command("gs_diff_refresh")
 
 
+MYPY = False
+if MYPY:
+    from typing import NamedTuple
+    JumpTo = NamedTuple('JumpTo', [
+        ('commit_hash', Optional[str]),
+        ('filename', str),
+        ('row', int),
+        ('col', int)
+    ])
+else:
+    from collections import namedtuple
+    JumpTo = namedtuple('JumpTo', 'commit_hash filename row col')
+
+
 class GsDiffOpenFileAtHunkCommand(TextCommand, GitCommand):
 
     """
@@ -541,12 +555,11 @@ class GsDiffOpenFileAtHunkCommand(TextCommand, GitCommand):
         cursor_pts = tuple(cursor.a for cursor in self.view.sel() if cursor.a == cursor.b)
 
         def first_per_file(items):
-            # type: (Iterator[Tuple[str, int, int]]) -> Iterator[Tuple[str, int, int]]
+            # type: (Iterator[JumpTo]) -> Iterator[JumpTo]
             seen = set()  # type: Set[str]
             for item in items:
-                filename, _, _ = item
-                if filename not in seen:
-                    seen.add(filename)
+                if item.filename not in seen:
+                    seen.add(item.filename)
                     yield item
 
         word_diff_mode = bool(self.view.settings().get('git_savvy.diff_view.show_word_diff'))
@@ -560,13 +573,13 @@ class GsDiffOpenFileAtHunkCommand(TextCommand, GitCommand):
         for jp in first_per_file(jump_positions):
             self.load_file_at_line(*jp)
 
-    def load_file_at_line(self, filename, row, col):
-        # type: (str, int, int) -> None
+    def load_file_at_line(self, commit_hash, filename, row, col):
+        # type: (Optional[str], str, int, int) -> None
         """
         Show file at target commit if `git_savvy.diff_view.target_commit` is non-empty.
         Otherwise, open the file directly.
         """
-        target_commit = self.view.settings().get("git_savvy.diff_view.target_commit")
+        target_commit = commit_hash or self.view.settings().get("git_savvy.diff_view.target_commit")
         full_path = os.path.join(self.repo_path, filename)
         window = self.view.window()
         if not window:
@@ -585,7 +598,7 @@ class GsDiffOpenFileAtHunkCommand(TextCommand, GitCommand):
             )
 
     def jump_position_to_file(self, diff, pt):
-        # type: (SplittedDiff, int) -> Optional[Tuple[str, int, int]]
+        # type: (SplittedDiff, int) -> Optional[JumpTo]
         head_and_hunk = diff.head_and_hunk_for_pt(pt)
         if not head_and_hunk:
             return None
@@ -603,10 +616,12 @@ class GsDiffOpenFileAtHunkCommand(TextCommand, GitCommand):
         if not filename:
             return None
 
-        return filename, row, col
+        commit_header = diff.commit_for_hunk(hunk)
+        commit_hash = commit_header.commit_hash() if commit_header else None
+        return JumpTo(commit_hash, filename, row, col)
 
     def jump_position_to_file_for_word_diff_mode(self, diff, pt):
-        # type: (SplittedDiff, int) -> Optional[Tuple[str, int, int]]
+        # type: (SplittedDiff, int) -> Optional[JumpTo]
         head_and_hunk = diff.head_and_hunk_for_pt(pt)
         if not head_and_hunk:
             return None
@@ -659,7 +674,9 @@ class GsDiffOpenFileAtHunkCommand(TextCommand, GitCommand):
 
         row = row - removed_lines_before_pt
         col = col + 1 - removed_chars_before_pt
-        return filename, row, col
+        commit_header = diff.commit_for_hunk(hunk)
+        commit_hash = commit_header.commit_hash() if commit_header else None
+        return JumpTo(commit_hash, filename, row, col)
 
 
 def relative_rowcol_in_hunk(view, hunk, pt):

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -772,8 +772,7 @@ class GsDiffNavigateCommand(GsNavigate):
     offset = 0
 
     def get_available_regions(self):
-        return [self.view.line(region) for region in
-                self.view.find_by_selector("meta.diff.range.unified")]
+        return self.view.find_by_selector("meta.diff.range.unified, meta.commit-info.header")
 
 
 class GsDiffUndo(TextCommand, GitCommand):

--- a/core/commands/show_commit.py
+++ b/core/commands/show_commit.py
@@ -15,7 +15,7 @@ if MYPY:
 SHOW_COMMIT_TITLE = "COMMIT: {}"
 
 
-class GsShowCommitCommand(WindowCommand, GitCommand):
+class gs_show_commit(WindowCommand, GitCommand):
 
     def run(self, commit_hash):
         # need to get repo_path before the new view is created.
@@ -37,7 +37,7 @@ class GsShowCommitCommand(WindowCommand, GitCommand):
         view.run_command("gs_handle_vintageous")
 
 
-class GsShowCommitRefreshCommand(TextCommand, GitCommand):
+class gs_show_commit_refresh(TextCommand, GitCommand):
 
     def run(self, edit):
         settings = self.view.settings()
@@ -59,7 +59,7 @@ class GsShowCommitRefreshCommand(TextCommand, GitCommand):
         intra_line_colorizer.annotate_intra_line_differences(self.view)
 
 
-class GsShowCommitToggleSetting(TextCommand):
+class gs_show_commit_toggle_setting(TextCommand):
 
     """
     Toggle view settings: `ignore_whitespace` or `show_word_diff`.

--- a/core/commands/show_commit.py
+++ b/core/commands/show_commit.py
@@ -124,3 +124,19 @@ class gs_show_commit_show_hunk_on_head(diff.GsDiffOpenFileAtHunkCommand):
             "{file}:{row}:{col}".format(file=full_path, row=row, col=col),
             sublime.ENCODED_POSITION
         )
+
+
+class gs_show_commit_open_graph_context(TextCommand, GitCommand):
+    def run(self, edit):
+        # type: (...) -> None
+        window = self.view.window()
+        if not window:
+            return
+
+        settings = self.view.settings()
+        commit_hash = settings.get("git_savvy.show_commit_view.commit")
+
+        window.run_command("gs_graph", {
+            "all": True,
+            "follow": self.get_short_hash(commit_hash)
+        })

--- a/core/commands/show_commit.py
+++ b/core/commands/show_commit.py
@@ -1,5 +1,6 @@
 import os
 
+import sublime
 from sublime_plugin import WindowCommand, TextCommand
 
 from . import diff
@@ -68,7 +69,7 @@ class GsShowCommitToggleSetting(TextCommand):
         self.view.run_command("gs_show_commit_refresh")
 
 
-class GsShowCommitOpenFileAtHunkCommand(diff.GsDiffOpenFileAtHunkCommand):
+class gs_show_commit_open_file_at_hunk(diff.GsDiffOpenFileAtHunkCommand):
 
     """
     For each cursor in the view, identify the hunk in which the cursor lies,
@@ -87,8 +88,15 @@ class GsShowCommitOpenFileAtHunkCommand(diff.GsDiffOpenFileAtHunkCommand):
         if not window:
             return
 
-        window.run_command("gs_show_file_at_commit", {
-            "commit_hash": commit_hash,
-            "filepath": full_path,
-            "lineno": row
-        })
+        short_hash = self.get_short_hash(commit_hash)
+        if self.get_commit_hash_for_head(short=True) == short_hash:
+            window.open_file(
+                "{file}:{row}:{col}".format(file=full_path, row=row, col=col),
+                sublime.ENCODED_POSITION
+            )
+        else:
+            window.run_command("gs_show_file_at_commit", {
+                "commit_hash": short_hash,
+                "filepath": full_path,
+                "lineno": row
+            })

--- a/core/commands/show_commit.py
+++ b/core/commands/show_commit.py
@@ -100,3 +100,19 @@ class gs_show_commit_open_file_at_hunk(diff.GsDiffOpenFileAtHunkCommand):
                 "filepath": full_path,
                 "lineno": row
             })
+
+
+class gs_show_commit_show_hunk_on_head(diff.GsDiffOpenFileAtHunkCommand):
+    def load_file_at_line(self, filename, row, col):
+        # type: (str, int, int) -> None
+        commit_hash = self.view.settings().get("git_savvy.show_commit_view.commit")
+        full_path = os.path.join(self.repo_path, filename)
+        window = self.view.window()
+        if not window:
+            return
+
+        row = self.find_matching_lineno(commit_hash, "HEAD", row, full_path)
+        window.open_file(
+            "{file}:{row}:{col}".format(file=full_path, row=row, col=col),
+            sublime.ENCODED_POSITION
+        )

--- a/core/commands/show_commit.py
+++ b/core/commands/show_commit.py
@@ -33,7 +33,6 @@ class gs_show_commit(WindowCommand, GitCommand):
         view.set_name(SHOW_COMMIT_TITLE.format(nice_hash))
         view.set_scratch(True)
         view.run_command("gs_show_commit_refresh")
-        view.run_command("gs_diff_navigate")
         view.run_command("gs_handle_vintageous")
 
 

--- a/core/commands/show_commit_info.py
+++ b/core/commands/show_commit_info.py
@@ -65,6 +65,7 @@ class gs_show_commit_info(WindowCommand, GitCommand):
 
     def run_impl(self, commit_hash, file_path=None):
         output_view = ensure_panel(self.window)
+        output_view.settings().set("git_savvy.repo_path", self.repo_path)
 
         if commit_hash:
             show_full = self.savvy_settings.get("show_full_commit_info")

--- a/core/commands/show_commit_info.py
+++ b/core/commands/show_commit_info.py
@@ -43,7 +43,7 @@ def ensure_panel_is_visible(window, name=PANEL_NAME):
         window.run_command("show_panel", {"panel": "output.{}".format(name)})
 
 
-class GsShowCommitInfoCommand(WindowCommand, GitCommand):
+class gs_show_commit_info(WindowCommand, GitCommand):
     def run(self, commit_hash, file_path=None):
         # We're running either blocking or lazy, and currently choose
         # automatically.  Generally, we run blocking to reduce multiple

--- a/core/commands/show_commit_info.py
+++ b/core/commands/show_commit_info.py
@@ -28,6 +28,7 @@ def ensure_panel(window, name=PANEL_NAME, syntax="Packages/GitSavvy/syntax/show_
     output_view.set_read_only(True)
     if syntax:
         output_view.set_syntax_file(syntax)
+    output_view.settings().set("git_savvy.show_commit_view", True)
     return output_view
 
 
@@ -102,12 +103,12 @@ def _draw(window, view, text, commit):
 
 @contextmanager
 def restore_viewport_position(view, next_commit):
-    prev_commit = view.settings().get("git_savvy.show_commit_info.commit")
+    prev_commit = view.settings().get("git_savvy.show_commit_view.commit")
     if prev_commit:
         storage[prev_commit] = view.viewport_position()
 
     yield
 
-    view.settings().set("git_savvy.show_commit_info.commit", next_commit)
+    view.settings().set("git_savvy.show_commit_view.commit", next_commit)
     prev_position = storage.get(next_commit, (0, 0))
     view.set_viewport_position(prev_position, False)

--- a/core/commands/show_file_at_commit.py
+++ b/core/commands/show_file_at_commit.py
@@ -9,7 +9,7 @@ from .log import LogMixin
 SHOW_COMMIT_TITLE = "FILE: {} --{}"
 
 
-class GsShowFileAtCommitCommand(WindowCommand, GitCommand):
+class gs_show_file_at_commit(WindowCommand, GitCommand):
 
     def run(self, commit_hash, filepath, lineno=1, lang=None):
         sublime.set_timeout_async(
@@ -46,7 +46,7 @@ class GsShowFileAtCommitCommand(WindowCommand, GitCommand):
         util.view.move_cursor(view, lineno, 0)
 
 
-class GsShowCurrentFileAtCommitCommand(GsShowFileAtCommitCommand):
+class gs_show_current_file_at_commit(gs_show_file_at_commit):
 
     @util.view.single_cursor_coords
     def run(self, coords, commit_hash, lineno=None, lang=None):
@@ -61,7 +61,7 @@ class GsShowCurrentFileAtCommitCommand(GsShowFileAtCommitCommand):
             lang=lang)
 
 
-class GsShowCurrentFileCommand(LogMixin, WindowCommand, GitCommand):
+class gs_show_current_file(LogMixin, WindowCommand, GitCommand):
     """
     Show a panel of commits of current file on current branch and
     then open the file at the selected commit.

--- a/core/commands/show_file_at_commit.py
+++ b/core/commands/show_file_at_commit.py
@@ -1,8 +1,8 @@
 import os
-import sublime
 from sublime_plugin import WindowCommand
 
 from ..git_command import GitCommand
+from ..runtime import enqueue_on_ui, enqueue_on_worker
 from ...common import util
 from .log import LogMixin
 
@@ -11,35 +11,40 @@ SHOW_COMMIT_TITLE = "FILE: {} --{}"
 
 class gs_show_file_at_commit(WindowCommand, GitCommand):
 
-    def run(self, commit_hash, filepath, lineno=1, lang=None):
-        sublime.set_timeout_async(
-            lambda: self.run_async(
-                commit_hash=commit_hash,
-                filepath=filepath,
-                lineno=lineno,
-                lang=lang))
+    def run(self, commit_hash, filepath, check_for_renames=False, lineno=1, lang=None):
+        enqueue_on_worker(
+            self.run_impl,
+            commit_hash,
+            filepath,
+            check_for_renames,
+            lineno,
+            lang,
+        )
 
-    def run_async(self, commit_hash, filepath, lineno=1, lang=None):
+    def run_impl(self, commit_hash, file_path, check_for_renames=False, lineno=1, lang=None):
         # need to get repo_path before the new view is created.
         repo_path = self.repo_path
         view = util.view.get_scratch_view(self, "show_file_at_commit")
         settings = view.settings()
         settings.set("git_savvy.show_file_at_commit_view.commit", commit_hash)
-        settings.set("git_savvy.file_path", filepath)
+        settings.set("git_savvy.file_path", file_path)
         settings.set("git_savvy.repo_path", repo_path)
         if not lang:
-            lang = util.file.get_syntax_for_file(filepath)
+            lang = util.file.get_syntax_for_file(file_path)
         nice_hash = self.get_short_hash(commit_hash) if len(commit_hash) >= 40 else commit_hash
         title = SHOW_COMMIT_TITLE.format(
-            os.path.basename(filepath),
+            os.path.basename(file_path),
             nice_hash,
         )
 
         view.set_syntax_file(lang)
         view.set_name(title)
 
-        text = self.get_file_content_at_commit(self.file_path, commit_hash)
-        sublime.set_timeout(lambda: self.render_text(view, text, lineno))
+        if check_for_renames:
+            file_path = self.filename_at_commit(file_path, commit_hash)
+
+        text = self.get_file_content_at_commit(file_path, commit_hash)
+        enqueue_on_ui(self.render_text, view, text, lineno)
 
     def render_text(self, view, text, lineno):
         view.run_command("gs_replace_view_text", {"text": text, "nuke_cursors": True})

--- a/core/git_mixins/active_branch.py
+++ b/core/git_mixins/active_branch.py
@@ -130,11 +130,11 @@ class ActiveBranchMixin():
         merge_head = self.merge_head() if self.in_merge() else ""
         return output if not merge_head else output + " (merging {})".format(merge_head)
 
-    def get_commit_hash_for_head(self):
+    def get_commit_hash_for_head(self, short=False):
         """
         Get the SHA1 commit hash for the commit at HEAD.
         """
-        return self.git("rev-parse", "HEAD").strip()
+        return self.git("rev-parse", "--short" if short else None, "HEAD").strip()
 
     def get_latest_commit_msg_for_head(self):
         """

--- a/core/git_mixins/history.py
+++ b/core/git_mixins/history.py
@@ -146,6 +146,7 @@ class HistoryMixin():
         return sha != ""
 
     def get_short_hash(self, commit_hash):
+        # type: (str) -> str
         return self.git("rev-parse", "--short", commit_hash).strip()
 
     def filename_at_commit(self, filename, commit_hash, follow=False):

--- a/core/git_mixins/history.py
+++ b/core/git_mixins/history.py
@@ -177,7 +177,6 @@ class HistoryMixin():
     def get_file_content_at_commit(self, filename, commit_hash):
         filename = self.get_rel_path(filename)
         filename = filename.replace('\\', '/')
-        filename = self.filename_at_commit(filename, commit_hash)
         return self.git("show", commit_hash + ':' + filename)
 
     def find_matching_lineno(self, base_commit, target_commit, line, file_path=None):

--- a/core/git_mixins/history.py
+++ b/core/git_mixins/history.py
@@ -2,6 +2,10 @@ from collections import namedtuple
 from ...common import util
 
 
+MYPY = False
+if MYPY:
+    from typing import Optional
+
 LogEntry = namedtuple("LogEntry", (
     "short_hash",
     "long_hash",
@@ -177,6 +181,7 @@ class HistoryMixin():
         return self.git("show", commit_hash + ':' + filename)
 
     def find_matching_lineno(self, base_commit, target_commit, line, file_path=None):
+        # type: (Optional[str], str, int, str) -> int
         """
         Return the matching line of the target_commit given the line number of the base_commit.
         """

--- a/core/parse_diff.py
+++ b/core/parse_diff.py
@@ -118,7 +118,12 @@ class TextRange:
 
 
 class CommitHeader(TextRange):
-    pass
+    def commit_hash(self):
+        # type: () -> Optional[str]
+        first_line = self.text[:self.text.index('\n')]
+        if first_line.startswith('commit '):
+            return first_line[7:]
+        return None
 
 
 class FileHeader(TextRange):

--- a/syntax/make_commit.sublime-syntax
+++ b/syntax/make_commit.sublime-syntax
@@ -5,7 +5,7 @@ name: GitSavvy Make Commit
 hidden: true
 scope: git-savvy.make-commit
 contexts:
-  main:
+  references:
     - match: \@\w*
       comment: github username
       scope: constant.other.git-savvy.make-commit.github-username
@@ -14,6 +14,8 @@ contexts:
       comment: issue
       scope: constant.other.git-savvy.make-commit.issue-ref
 
+  main:
+    - include: references
     - match: ^(#{1,2}).*\n$
       comment: commit header
       scope: comment.git-savvy.make-commit

--- a/syntax/show_commit.sublime-syntax
+++ b/syntax/show_commit.sublime-syntax
@@ -6,14 +6,14 @@ hidden: true
 scope: git-savvy.commit
 contexts:
   main:
-    - match: ^(commit)(.+)
+    - match: ^(commit)(.+)$\n?
       comment: commit header
       scope: meta.commit-info.header.key-value
       captures:
         1: string.other.commit-info.header.key.git-savvy
         2: meta.commit-info.header.value.git-savvy meta.commit-info.header.sha.git-savvy
 
-    - match: ^(Author|Date|Merge|AuthorDate|Commit|CommitDate)(:)(.+)
+    - match: ^(Author|Date|Merge|AuthorDate|Commit|CommitDate)(:)(.+)$\n?
       comment: author and date info
       scope: meta.commit-info.header.key-value
       captures:

--- a/syntax/show_commit.sublime-syntax
+++ b/syntax/show_commit.sublime-syntax
@@ -6,6 +6,11 @@ hidden: true
 scope: git-savvy.commit
 contexts:
   main:
+    - match: (?=^commit)
+      push: commit-header
+
+  commit-header:
+    - meta_scope: meta.commit-info.header
     - match: ^(commit)(.+)$\n?
       comment: commit header
       scope: meta.commit-info.header.key-value
@@ -21,8 +26,27 @@ contexts:
         2: string.other.commit-info.header.key.punctuation.git-savvy
         3: meta.commit-info.header.value.git-savvy
 
-    - match: ^---$
-      scope: meta.commit-header-and-stat-splitter
-      comment: Separator between commit message and diffstat
+    - match: ^$
+      set: commit-message
 
-    - include: "scope:git-savvy.diff"
+  commit-message:
+    - meta_scope: meta.commit_message
+    - match: ^\s*(?=\S+)
+      set: commit-subject
+
+  commit-subject:
+    - meta_scope: meta.commit_message meta.subject.git.commit markup.heading.subject.git.commit
+    - match: $\n?
+      set: commit-message-body
+    - include: make_commit.sublime-syntax#references
+
+  commit-message-body:
+    - match: ^
+      push:
+        - meta_scope: meta.commit_message
+        - match: (?=^diff\s)
+          set: "scope:git-savvy.diff"
+        - match: ^---$\n?
+          scope: meta.commit-header-and-stat-splitter
+          set: "scope:git-savvy.diff"
+        - include: make_commit.sublime-syntax#references

--- a/tests/test_diff_view.py
+++ b/tests/test_diff_view.py
@@ -219,7 +219,8 @@ diff --git a/foxx b/boxx
 
         cmd.run({'unused_edit'})
 
-        verify(cmd).load_file_at_line(*EXPECTED)
+        # In all cases here "commit" is `None`
+        verify(cmd).load_file_at_line(None, *EXPECTED)
 
 
 class TestDiffViewHunking(DeferrableTestCase):

--- a/tests/test_graph_view.py
+++ b/tests/test_graph_view.py
@@ -11,7 +11,7 @@ from GitSavvy.core.commands.log_graph import (
     extract_commit_hash,
     navigate_to_symbol
 )
-from GitSavvy.core.commands.show_commit_info import GsShowCommitInfoCommand
+from GitSavvy.core.commands.show_commit_info import gs_show_commit_info
 from GitSavvy.core.settings import GitSavvySettings
 
 
@@ -162,7 +162,7 @@ class TestDiffViewInteractionWithCommitInfoPanel(DeferrableTestCase):
 
     def register_commit_info(self, info):
         for sha1, info in info.items():
-            when(GsShowCommitInfoCommand).show_commit(sha1, ...).thenReturn(info)
+            when(gs_show_commit_info).show_commit(sha1, ...).thenReturn(info)
 
     def create_graph_view_async(self, repo_path, log, wait_for):
         when(GsLogGraphRefreshCommand).git('log', ...).thenReturn(log)

--- a/tests/test_graph_view.py
+++ b/tests/test_graph_view.py
@@ -166,6 +166,11 @@ class TestDiffViewInteractionWithCommitInfoPanel(DeferrableTestCase):
 
     def create_graph_view_async(self, repo_path, log, wait_for):
         when(GsLogGraphRefreshCommand).git('log', ...).thenReturn(log)
+        # `GitCommand.get_repo_path` "validates" a given repo using
+        # `os.path.exists`.
+        exists = os.path.exists
+        when(os.path).exists(...).thenAnswer(exists)
+        when(os.path).exists(repo_path).thenReturn(True)
         self.window.run_command('gs_graph', {'repo_path': repo_path})
         yield lambda: self.window.active_view().settings().get('git_savvy.log_graph_view') is True
         log_view = self.window.active_view()
@@ -178,6 +183,7 @@ class TestDiffViewInteractionWithCommitInfoPanel(DeferrableTestCase):
         LOG = fixture('log_graph_1.txt')
 
         self.set_global_setting('graph_show_more_commit_info', show_commit_info_setting)
+        self.set_global_setting('git_status_in_status_bar', False)
         self.register_commit_info({
             'fec0aca': COMMIT_1,
             'f461ea1': COMMIT_2


### PR DESCRIPTION
Fixes #1204 
Fixes #1242 

- Enable keyboard shortcuts for the commit info *panel* (#1204)

- If the commit you're looking at is actually the `HEAD`, open the workspace file on `[o]`. (T.i. the normal writable version.)

- Add `[O]` to open the workspace (checked out) file a hunk is showing. 

(T.i. `[o]` shows the historical version of the file (readable) except you're looking at the HEAD commit, and `[O]` shows the current version of the hunk (read- and writeable).)

- Add `[g]` to open a graph focusing the current commit. (Aka: What is the context of this commit?)

Minor syntax improvements: highlight references (for example to issues or users) in the commit message, style commit meta header as a block.