### PR TITLE
Show command and working dir on fatal git errors

### DIFF
--- a/core/git_command.py
+++ b/core/git_command.py
@@ -228,8 +228,9 @@ class GitCommand(StatusMixin,
         except Exception as e:
             # this should never be reached
             raise GitSavvyError(
+                "$ {} ({})\n\n"
                 "Please report this error to GitSavvy:\n\n{}\n\n{}".format(
-                    e, traceback.format_exc()
+                    command_str, working_dir, e, traceback.format_exc()
                 ),
                 cmd=command,
                 show_panel=show_panel_on_stderr)


### PR DESCRIPTION
To show the command and working dir us usually useful information.  Otherwise
you probably see a "Verzeichnis ungültig" without ever seeing which directory was used.