### PR TITLE
Fix: A cursor on the border of the viewport counts as in

### DIFF
--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -1276,7 +1276,7 @@ def get_column_range(view, region):
 def is_sel_in_viewport(view):
     # type: (sublime.View) -> bool
     viewport = view.visible_region()
-    return all(viewport.intersects(s) for s in view.sel())
+    return all(viewport.contains(s) or viewport.intersects(s) for s in view.sel())
 
 
 def line_start_of_region(view, region):


### PR DESCRIPTION
Sublime's `intersects` surprisingly does not count the edges as in.
For example `Region(10, 20).intersects(Region(10)) == False`.