### PR TITLE
Optimize `find_matching_lineno`

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -702,7 +702,7 @@
     },
     {
         "keys": ["O"],
-        "command": "gs_show_commit_show_hunk_on_head",
+        "command": "gs_show_commit_show_hunk_on_working_dir",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.show_commit_view", "operator": "equal", "operand": true }

--- a/core/commands/show_commit.py
+++ b/core/commands/show_commit.py
@@ -94,6 +94,7 @@ class gs_show_commit_open_file_at_hunk(diff.GsDiffOpenFileAtHunkCommand):
 
         full_path = os.path.join(self.repo_path, filename)
         if self.newest_commit_for_file(full_path) == commit_hash:
+            row = self.find_matching_lineno(commit_hash, None, row, full_path)
             window.open_file(
                 "{file}:{row}:{col}".format(file=full_path, row=row, col=col),
                 sublime.ENCODED_POSITION

--- a/core/commands/show_commit.py
+++ b/core/commands/show_commit.py
@@ -93,15 +93,14 @@ class gs_show_commit_open_file_at_hunk(diff.GsDiffOpenFileAtHunkCommand):
             return
 
         full_path = os.path.join(self.repo_path, filename)
-        short_hash = self.get_short_hash(commit_hash)
-        if self.get_commit_hash_for_head(short=True) == short_hash:
+        if self.newest_commit_for_file(full_path) == commit_hash:
             window.open_file(
                 "{file}:{row}:{col}".format(file=full_path, row=row, col=col),
                 sublime.ENCODED_POSITION
             )
         else:
             window.run_command("gs_show_file_at_commit", {
-                "commit_hash": short_hash,
+                "commit_hash": commit_hash,
                 "filepath": full_path,
                 "lineno": row
             })

--- a/core/commands/show_commit.py
+++ b/core/commands/show_commit.py
@@ -107,7 +107,7 @@ class gs_show_commit_open_file_at_hunk(diff.GsDiffOpenFileAtHunkCommand):
             })
 
 
-class gs_show_commit_show_hunk_on_head(diff.GsDiffOpenFileAtHunkCommand):
+class gs_show_commit_show_hunk_on_working_dir(diff.GsDiffOpenFileAtHunkCommand):
     def load_file_at_line(self, commit_hash, filename, row, col):
         # type: (Optional[str], str, int, int) -> None
         if not commit_hash:
@@ -118,7 +118,7 @@ class gs_show_commit_show_hunk_on_head(diff.GsDiffOpenFileAtHunkCommand):
             return
 
         full_path = os.path.join(self.repo_path, filename)
-        row = self.find_matching_lineno(commit_hash, "HEAD", row, full_path)
+        row = self.find_matching_lineno(commit_hash, None, row, full_path)
         window.open_file(
             "{file}:{row}:{col}".format(file=full_path, row=row, col=col),
             sublime.ENCODED_POSITION

--- a/core/git_mixins/history.py
+++ b/core/git_mixins/history.py
@@ -253,8 +253,13 @@ class HistoryMixin():
         Get the newest commit for a given file.
         """
         return self.git(
-            "log", "--format=%H",
-            "--follow" if follow else None, "-n", "1", file_path).strip()
+            "log",
+            "--format=%H",
+            "--follow" if follow else None,
+            "-1",
+            "--",
+            file_path,
+        ).strip()
 
     def get_indexed_file_object(self, file_path):
         """

--- a/github/commands/open_on_remote.py
+++ b/github/commands/open_on_remote.py
@@ -89,10 +89,9 @@ class GsGithubOpenFileOnRemoteCommand(TextCommand, GitCommand, git_mixins.Github
 
                 # forward line number if the opening commit is the merge base
                 if base_hash != commit_hash:
-                    start_line = self.find_matching_lineno(
-                        base_hash, commit_hash, line=start_line, file_path=fpath[0])
-                    end_line = self.find_matching_lineno(
-                        base_hash, commit_hash, line=end_line, file_path=fpath[0])
+                    diff = self.no_context_diff(base_hash, commit_hash, fpath[0])
+                    start_line = self.adjust_line_according_to_diff(diff, start_line)
+                    end_line = self.adjust_line_according_to_diff(diff, end_line)
 
         for p in fpath:
             open_file_in_browser(

--- a/github/commands/open_on_remote.py
+++ b/github/commands/open_on_remote.py
@@ -1,6 +1,7 @@
 import sublime
 from sublime_plugin import TextCommand
 
+from GitSavvy.common import util
 from ...core.git_command import GitCommand
 from ..github import open_file_in_browser  # , open_repo, open_issues
 from ..github import open_repo
@@ -74,6 +75,9 @@ class GsGithubOpenFileOnRemoteCommand(TextCommand, GitCommand, git_mixins.Github
                         return
 
                     commit_hash = merge_base
+            else:
+                util.view.flash(self.view, "This revision has not been pushed upstream yet.")
+                return
 
         start_line = None
         end_line = None

--- a/gitlab/commands/open_on_remote.py
+++ b/gitlab/commands/open_on_remote.py
@@ -87,10 +87,9 @@ class GsGitlabOpenFileOnRemoteCommand(TextCommand, GitCommand, GitLabRemotesMixi
 
                 # forward line number if the opening commit is the merge base
                 if base_hash != commit_hash:
-                    start_line = self.find_matching_lineno(
-                        base_hash, commit_hash, line=start_line, file_path=fpath[0])
-                    end_line = self.find_matching_lineno(
-                        base_hash, commit_hash, line=end_line, file_path=fpath[0])
+                    diff = self.no_context_diff(base_hash, commit_hash, fpath[0])
+                    start_line = self.adjust_line_according_to_diff(diff, start_line)
+                    end_line = self.adjust_line_according_to_diff(diff, end_line)
 
         for p in fpath:
             open_file_in_browser(

--- a/tests/test_history_mixin.py
+++ b/tests/test_history_mixin.py
@@ -1,0 +1,32 @@
+from unittesting import DeferrableTestCase
+from GitSavvy.tests.mockito import when, verify
+from GitSavvy.tests.parameterized import parameterized as p
+
+from GitSavvy.core.git_mixins.history import HistoryMixin
+
+
+examples = [
+    ("from commit to working dir", "abc", None, ["abc", None]),
+    ("from commit to commit", "abc", "def", ["abc", "def"]),
+    ("from commit to commit", "abc", "HEAD", ["abc", "HEAD"]),
+    ("from working dir to commit", None, "def", ["-R", "def"]),
+    ("from working dir to HEAD", None, "HEAD", ["-R", "HEAD"]),
+]
+
+
+class TestDescribeGraphLine(DeferrableTestCase):
+    @p.expand(examples)
+    def test_no_context_diff_logic(self, _, base, target, cmd):
+        test = HistoryMixin()
+        when(test, strict=False).git("diff", ...).thenReturn("irrelevant")
+        test.no_context_diff(base, target)
+        common = ["diff", "--no-color", "-U0"]
+        verify(test).git(*(common + cmd))
+
+    def test_no_context_diff_add_file_if_given(self):
+        test = HistoryMixin()
+        when(test, strict=False).git("diff", ...).thenReturn("irrelevant")
+        test.no_context_diff("a", "b", "foofile.py")
+        common = ["diff", "--no-color", "-U0"]
+        cmd = ["a", "b", "--", "foofile.py"]
+        verify(test).git(*(common + cmd))


### PR DESCRIPTION
`find_matching_lineno` uses some obscure technique to compare two blobs, iirc this is the same as we had for the inline-diff. We switch to simple `git diff`. 