### PR TITLE
Fix: nearest branch throwing if there is only one branch

### DIFF
--- a/core/git_mixins/rebase.py
+++ b/core/git_mixins/rebase.py
@@ -1,8 +1,5 @@
 import re
 
-from ..exceptions import GitSavvyError
-from ...common import util
-
 
 MYPY = False
 if MYPY:
@@ -59,17 +56,8 @@ class NearestBranchMixin(object):
         specified).
 
         """
-        try:
-            relatives = self.branch_relatives(branch)
-        except GitSavvyError:
-            return default
-
+        relatives = self.branch_relatives(branch)
         if not relatives:
-            util.debug.add_to_log('nearest_branch: No relatives found. '
-                                  'Possibly on a root branch!')
             return default
-
-        util.debug.add_to_log('nearest_branch: found {} relatives: {}'.format(
-                              len(relatives), relatives))
 
         return relatives[0]

--- a/core/git_mixins/rebase.py
+++ b/core/git_mixins/rebase.py
@@ -18,24 +18,34 @@ class NearestBranchMixin(object):
     def branch_relatives(self, branch):
         # type: (str) -> List[str]
         """ Get list of all relatives from ``git show-branch`` results """
-        output = self.git("show-branch", "--no-color")
+        output = self.git("show-branch", "--no-color")  # type: str
 
-        prelude, body = re.split(r'^-+$', output, flags=re.M)
+        try:
+            prelude, body = re.split(r'^-+$', output, flags=re.M)
+        except ValueError:
+            # If there is only one branch, git changes the output format
+            # and omits the prelude and column indicator.
+            lines = filter(None, output.splitlines())
+        else:
+            match = re.search(r'^(\s+)\*', prelude, re.M)
+            if not match:
+                print("branch {} not found in header information".format(branch))
+                return []
 
-        match = re.search(r'^(\s+)\*', prelude, re.M)
-        if not match:
-            print("branch {} not found in header information".format(branch))
-            return []
+            branch_column = len(match.group(1))
+            lines = (
+                line
+                for line in filter(None, body.splitlines())
+                if line[branch_column] != ' '
+            )
 
-        branch_column = len(match.group(1))
         relatives = []  # type: List[str]
-        for line in filter(None, body.splitlines()):  # type: str
-            if line[branch_column] != ' ':
-                match = EXTRACT_BRANCH_NAME.match(line)
-                if match:
-                    branch_name = match.group(1)
-                    if branch_name != branch and branch_name not in relatives:
-                        relatives.append(branch_name)
+        for line in lines:
+            match = EXTRACT_BRANCH_NAME.match(line)
+            if match:
+                branch_name = match.group(1)
+                if branch_name != branch and branch_name not in relatives:
+                    relatives.append(branch_name)
 
         return relatives
 

--- a/core/git_mixins/rebase.py
+++ b/core/git_mixins/rebase.py
@@ -55,16 +55,9 @@ class NearestBranchMixin(object):
         Find the nearest commit in current branch history that exists
         on a different branch and return that branch name.
 
-        We filter these branches through a list of known ancestors which have
-        an initial branch point with current branch, and pick the first one
-        that matches both.
-
-        If no such branch is found, returns the given default ("master" if not
+        If no such branch is found, return the given default ("master" if not
         specified).
 
-        Solution snagged from:
-        http://stackoverflow.com/a/17843908/484127
-        http://stackoverflow.com/questions/1527234
         """
         try:
             relatives = self.branch_relatives(branch)

--- a/tests/test_nearest_branch.py
+++ b/tests/test_nearest_branch.py
@@ -1,0 +1,96 @@
+from textwrap import dedent
+
+from unittesting import DeferrableTestCase
+from GitSavvy.tests.mockito import when
+from GitSavvy.tests.parameterized import parameterized as p
+
+from GitSavvy.core.git_mixins.rebase import NearestBranchMixin
+
+
+examples = [
+    (
+        "single branch",
+        dedent("""\
+        [master] 0.22.2
+        """.rstrip()),
+        "master",
+        "master"
+    ),
+    (
+        "normal commit",
+        dedent("""\
+        ! [alt-buffering] Use stdout buffer size as chunk size
+         ! [better-follow-line] Abort "open file on remote" for unpushed revisions
+          ! [better-general-navigate] Do not render dashboards twice on resurrect
+           ! [dev] Merge pull request #1270 from timbrel/fixes
+            * [fix-1261] Simplify `nearest_branch`
+             ! [fixes] Do not offer "reset" on the head commit
+              ! [follow-path-upwards] Stash
+               ! [go-branches] Filter state by `repo_path` in a private method
+                ! [inline-diff-stage-toggle] Allow toggling between staged/unstaged via `<TAB>`
+                 ! [master] Merge branch 'dev'
+                  ! [status-bar-updater] Remove `debug.disable_logging`
+                   ! [throttle-status-bar-updates] Rewrite throttler for the status bar
+        ------------
+            *        [fix-1261] Simplify `nearest_branch`
+         +           [better-follow-line] Abort "open file on remote" for unpushed revisions
+         + +*+       [fixes] Do not offer "reset" on the head commit
+        """.rstrip()),
+        "fix-1261",
+        "fixes"
+    ),
+    (
+        "merge commit",
+        dedent("""\
+        ! [alt-buffering] Use stdout buffer size as chunk size
+         ! [better-follow-line] Abort "open file on remote" for unpushed revisions
+          ! [better-general-navigate] Do not render dashboards twice on resurrect
+           ! [dev] Merge pull request #1270 from timbrel/fixes
+            * [fix-1261] Simplify `nearest_branch`
+             ! [fixes] Do not offer "reset" on the head commit
+              ! [follow-path-upwards] Stash
+               ! [go-branches] Filter state by `repo_path` in a private method
+                ! [inline-diff-stage-toggle] Allow toggling between staged/unstaged via `<TAB>`
+                 ! [master] Merge branch 'dev'
+                  ! [status-bar-updater] Remove `debug.disable_logging`
+                   ! [throttle-status-bar-updates] Rewrite throttler for the status bar
+        ------------
+            *        [fix-1261] Simplify `nearest_branch`
+         +           [better-follow-line] Abort "open file on remote" for unpushed revisions
+         - --        [dev] Merge pull request #1270 from timbrel/fixes
+        """.rstrip()),
+        "fix-1261",
+        "dev"
+    ),
+    (
+        "regex does not catch [x] pattern within the commit message",
+        dedent("""\
+        ! [alt-buffering] Use stdout buffer size as chunk size
+         ! [better-follow-line] Abort "open file on remote" for unpushed revisions
+          ! [better-general-navigate] Do not render dashboards twice on resurrect
+           ! [dev] Merge pull request #1270 from timbrel/fixes
+            * [fix-1261] Simplify `nearest_branch`
+             ! [fixes] Do not offer "reset" on the head commit
+              ! [follow-path-upwards] Stash
+               ! [go-branches] Filter state by `repo_path` in a private method
+                ! [inline-diff-stage-toggle] Allow toggling between staged/unstaged via `<TAB>`
+                 ! [master] Merge branch 'dev'
+                  ! [status-bar-updater] Remove `debug.disable_logging`
+                   ! [throttle-status-bar-updates] Rewrite throttler for the status bar
+        ------------
+            *        [fix-1261] Simplify `nearest_branch`
+         +           [better-follow-line] Abort "open file on remote" for unpushed revisions
+         + +*+       [fixes] Do not `[offer]` "reset" on the head commit
+        """.rstrip()),
+        "fix-1261",
+        "fixes"
+    )
+]
+
+
+class TestNearestBranch(DeferrableTestCase):
+    @p.expand(examples)
+    def test_a(self, _, show_branch_output, active_branch, nearest_branch):
+        test = NearestBranchMixin()
+        when(test, strict=False).git("show-branch", "--no-color").thenReturn(show_branch_output)
+        self.assertEqual(nearest_branch, test.nearest_branch(active_branch))


### PR DESCRIPTION
Fixes #1261

If the repo has only one branch git changes the output format of
`git show-branch` completely and doesn't show a prelude anymore.
Also no column indicator. Example output:

```
$ git show-branch
[master] 0.22.2
```

We branch that off by handling the `ValueError` because it is an
edge-case.