### PR TITLE
Revert `[o]` opens workspace file

### DIFF
--- a/core/commands/show_commit.py
+++ b/core/commands/show_commit.py
@@ -93,18 +93,11 @@ class gs_show_commit_open_file_at_hunk(diff.GsDiffOpenFileAtHunkCommand):
             return
 
         full_path = os.path.join(self.repo_path, filename)
-        if self.newest_commit_for_file(full_path) == commit_hash:
-            row = self.find_matching_lineno(commit_hash, None, row, full_path)
-            window.open_file(
-                "{file}:{row}:{col}".format(file=full_path, row=row, col=col),
-                sublime.ENCODED_POSITION
-            )
-        else:
-            window.run_command("gs_show_file_at_commit", {
-                "commit_hash": commit_hash,
-                "filepath": full_path,
-                "lineno": row
-            })
+        window.run_command("gs_show_file_at_commit", {
+            "commit_hash": commit_hash,
+            "filepath": full_path,
+            "lineno": row
+        })
 
 
 class gs_show_commit_show_hunk_on_working_dir(diff.GsDiffOpenFileAtHunkCommand):

--- a/core/git_mixins/active_branch.py
+++ b/core/git_mixins/active_branch.py
@@ -130,11 +130,11 @@ class ActiveBranchMixin():
         merge_head = self.merge_head() if self.in_merge() else ""
         return output if not merge_head else output + " (merging {})".format(merge_head)
 
-    def get_commit_hash_for_head(self, short=False):
+    def get_commit_hash_for_head(self):
         """
         Get the SHA1 commit hash for the commit at HEAD.
         """
-        return self.git("rev-parse", "--short" if short else None, "HEAD").strip()
+        return self.git("rev-parse", "HEAD").strip()
 
     def get_latest_commit_msg_for_head(self):
         """


### PR DESCRIPTION
For now revert the new behavior of `[o]` opening the current workdir
file if the change/hunk you're looking at is the most recent change
to that file.

We first just checked if the commit is the "HEAD" commit, then switched
to `newest_commit_for_file` which is more accurate behavior but shows
that this UX is confusing. (It is also relatively slow because we now
always need multiple git queries to answer the action.)

We state for now: either the user is in forensic mode, t.i. searching,
reading and looking around to understand a change; or the user sees a
change and then wants to edit (e.g. "fixup" that particular location).

The first interaction mode is bound to `[o]` again, for the latter we
have `[O]`. There is probably no need to mixmatch both.

The bevahior was first introduced in

  9c05c3d ("Open workspace file if shown commit is the HEAD commit")