### PR TITLE
Optimize fetching descriptions

### DIFF
--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -394,14 +394,6 @@
     "use_reset_mode": null,
 
     /*
-        By default, GitSavvy allows you attach arbitrary text meta-data to the
-        branches that you track locally.  If, however, you experience performance
-        problems because of this, feel free to turn this setting off, and the
-        descriptions will not be displayed.
-     */
-    "enable_branch_descriptions": true,
-
-    /*
         When set to `true`, you can navigate the dashboards by using arrow keys.
      */
     "arrow_keys_navigation": false,

--- a/core/git_mixins/branches.py
+++ b/core/git_mixins/branches.py
@@ -29,13 +29,12 @@ class BranchesMixin():
         return (
             branch
             for branch in (
-                self._parse_branch_line(self, line, fetch_descriptions)
+                self._parse_branch_line(line, fetch_descriptions)
                 for line in stdout.split("\n")
             )
             if branch and branch.name != "HEAD"
         )
 
-    @staticmethod
     def _parse_branch_line(self, line, fetch_descriptions=False):
         line = line.strip()
         if not line:

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -82,7 +82,7 @@ class BranchInterface(ui.Interface, GitCommand):
 
     def pre_render(self):
         sort_by_recent = self.savvy_settings.get("sort_by_recent_in_branch_dashboard")
-        self._branches = tuple(self.get_branches(sort_by_recent))
+        self._branches = tuple(self.get_branches(sort_by_recent, fetch_descriptions=True))
 
     def on_new_dashboard(self):
         self.view.run_command("gs_branches_set_cursor")

--- a/tests/test_fetch_branch_descriptions.py
+++ b/tests/test_fetch_branch_descriptions.py
@@ -1,0 +1,37 @@
+from textwrap import dedent
+
+from unittesting import DeferrableTestCase
+from GitSavvy.tests.mockito import when
+from GitSavvy.tests.parameterized import parameterized as p
+
+from GitSavvy.core.git_mixins.branches import BranchesMixin
+
+
+examples = [
+    (
+        dedent("""\
+        branch.status-bar-updater.description One\\nTwo
+        branch.revert-o-behavior.description Another branch.asd.description
+        branch.opt-fetching-descriptions.description This is the subject
+
+        And here is more text
+        and even more
+
+        branch.description.description Another description
+        """.rstrip()),
+        {
+            "status-bar-updater": "One\\nTwo",
+            "revert-o-behavior": "Another branch.asd.description",
+            "opt-fetching-descriptions": "This is the subject",
+            "description": "Another description"
+        }
+    ),
+]
+
+
+class TestFetchBranchDescriptions(DeferrableTestCase):
+    @p.expand(examples)
+    def test_description_subjects(self, git_output, expected):
+        test = BranchesMixin()
+        when(test, strict=False).git("config", ...).thenReturn(git_output)
+        self.assertEqual(expected, test.fetch_branch_description_subjects())


### PR DESCRIPTION
- Only fetch descriptions for the branch dashboard. It's the only place where we actually use them, all other calls to `get_branches()` just throw that costly information away.

- If we fetch the descriptions, fetch them in one-go, and not per branch in a for-loop which never scales on any earth. 

- Fix bug: Descriptions can actually be real messages. If you `git branch--edit-description` a normal editor will pop up, only within GitSavvy we restrict it to one liners. Anyhow, we actually read the whole message and just printed it in the dashboard. This breaks the UI of the dashboard; only subject lines are supported here. I try to address this as well

- Remove the setting "enable_branch_descriptions" which seems not necessary anymore. (Iirc the UI still shows the `[E]` shortcut etc. even if you disallow descriptions so this was half-way implemented anyway.)