### PR TITLE
Complete `[oOg]` navigation

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -772,6 +772,16 @@
             { "key": "setting.git_savvy.show_file_at_commit_view", "operator": "equal", "operand": true }
         ]
     },
+    {
+        "keys": ["?"],
+        "command": "gs_interface_toggle_popup_help",
+        "args": { "view_name": "show_file_at_commit_view" },
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.show_file_at_commit_view", "operator": "equal", "operand": true }
+        ]
+    },
+
 
 
     ////////////////

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -745,6 +745,36 @@
     },
 
     ////////////////
+    // FILE VIEW //
+    ////////////////
+
+    {
+        "keys": ["o"],
+        "command": "gs_show_file_at_commit_open_commit",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.show_file_at_commit_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["O"],
+        "command": "gs_show_file_at_commit_open_file_on_working_dir",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.show_file_at_commit_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["g"],
+        "command": "gs_show_file_at_commit_open_graph_context",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.show_file_at_commit_view", "operator": "equal", "operand": true }
+        ]
+    },
+
+
+    ////////////////
     // BLAME VIEW //
     ////////////////
 

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1374,6 +1374,14 @@
         ]
     },
     {
+        "keys": ["o"],
+        "command": "gs_log_graph_open_commit",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.log_graph_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
         "keys": ["?"],
         "command": "gs_interface_toggle_popup_help",
         "args": { "view_name": "log_graph_view" },

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -1001,6 +1001,25 @@ class GsLogGraphToggleAllSetting(TextCommand, GitCommand):
         self.view.run_command("gs_log_graph_refresh")
 
 
+class gs_log_graph_open_commit(TextCommand):
+    def run(self, edit):
+        # type: (...) -> None
+        window = self.view.window()
+        if not window:
+            return
+
+        sel = get_simple_selection(self.view)
+        if sel is None:
+            return
+        line_span = self.view.line(sel)
+        line_text = self.view.substr(line_span)
+        commit_hash = extract_commit_hash(line_text)
+        if not commit_hash:
+            return
+
+        window.run_command("gs_show_commit", {"commit_hash": commit_hash})
+
+
 class GsLogGraphCursorListener(EventListener, GitCommand):
     def is_applicable(self, view):
         # type: (sublime.View) -> bool

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -1708,11 +1708,6 @@ class GsLogGraphActionCommand(WindowCommand, GitCommand):
         file_path = self.file_path
         actions = []  # type: List[Tuple[str, Callable[[], None]]]
         actions += [
-            (
-                "Show commit", partial(self.show_commit, commit_hash)
-            )
-        ]
-        actions += [
             ("Checkout '{}'".format(branch_name), partial(self.checkout, branch_name))
             for branch_name in info.get("local_branches", [])
             if info.get("HEAD") != branch_name

--- a/popups/log_graph_view.html
+++ b/popups/log_graph_view.html
@@ -8,6 +8,7 @@
 <h3>Actions</h3>
 <ul>
   <li><code><span class="shortcut-key">enter&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>show commit options</code></li>
+  <li><code><span class="shortcut-key">o&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>open commit</code></li>
   <li><code><span class="shortcut-key">m&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>toggle commit info on the bottom</code></li>
   <li><code><span class="shortcut-key">.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>go to next commit</code></li>
   <li><code><span class="shortcut-key">,&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>go to previous commit</code></li>

--- a/popups/show_commit_view.html
+++ b/popups/show_commit_view.html
@@ -7,7 +7,8 @@
 
 <h3>Actions</h3>
 <ul>
-  <li><code><span class="shortcut-key">o&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>open file at hunk</code></li>
+  <li><code><span class="shortcut-key">o&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>open file revision at hunk</code></li>
+  <li><code><span class="shortcut-key">O&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>open working dir file</code></li>
   <li><code><span class="shortcut-key">s&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>ignore white space</code></li>
   <li><code><span class="shortcut-key">w&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>show word diff</code></li>
   <li><code><span class="shortcut-key">g&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>show in graph</code></li>

--- a/popups/show_file_at_commit_view.html
+++ b/popups/show_file_at_commit_view.html
@@ -1,0 +1,21 @@
+<html>
+<style>
+{css}
+</style>
+<body>
+<div class="header-wrapper"><h2>Keyboard Shortcuts</h2></div>
+
+<h3>Actions</h3>
+<ul>
+  <li><code><span class="shortcut-key">o&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>open commit</code></li>
+  <li><code><span class="shortcut-key">O&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>open working dir file</code></li>
+  <li><code><span class="shortcut-key">g&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>show in graph</code></li>
+</ul>
+
+<h3>Other</h3>
+<ul>
+  <li><code><span class="shortcut-key">?&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>show this help popup</code></li>
+</ul>
+
+</body>
+</html>


### PR DESCRIPTION
- In the graph view, `[o]` to open/show the commit
- For the file revision, `[o]` to open then commit, `[O]` to open the same file but currently checked out, and `[g]` to see the context[1]. 
- Add documentation to the help popups

[1] In the file revision view, we could either show the context of the commit or the context of the file log (t.i. applying a file filter). I took the first one, we'll see.