### PR TITLE
Add "delete branch" as graph action

### DIFF
--- a/core/commands/__init__.py
+++ b/core/commands/__init__.py
@@ -1,5 +1,6 @@
 from .amend import *
 from .blame import *
+from .branch import *
 from .changelog import *
 from .checkout import *
 from .cherry_pick import *

--- a/core/commands/branch.py
+++ b/core/commands/branch.py
@@ -1,0 +1,67 @@
+import re
+
+from sublime_plugin import WindowCommand
+
+from ..git_command import GitCommand
+from ..runtime import enqueue_on_worker
+from ...common import util
+from ..ui_mixins.quick_panel import show_branch_panel
+
+
+__all__ = (
+    "gs_delete_branch",
+)
+
+MYPY = False
+if MYPY:
+    from typing import Optional
+
+
+DELETE_UNDO_MESSAGE = """\
+GitSavvy: Deleted branch ({0}), in case you want to undo, run:
+  $ git branch {0} {1}
+"""
+EXTRACT_COMMIT = re.compile(r"\(was (.+)\)")
+
+
+class gs_delete_branch(WindowCommand, GitCommand):
+    def run(self, branch=None, force=False):
+        # type: (Optional[str], bool) -> None
+        self.force = force
+        enqueue_on_worker(self.run_impl, branch)
+
+    def run_impl(self, branch):
+        # type: (Optional[str]) -> None
+        if branch:
+            self.on_branch_selection(branch)
+        else:
+            show_branch_panel(
+                self.on_branch_selection,
+                local_branches_only=True,
+                ignore_current_branch=True,
+            )
+
+    def on_branch_selection(self, branch):
+        # type: (Optional[str]) -> None
+        if not branch:
+            return
+
+        self.delete_local_branch(branch)
+
+    @util.actions.destructive(description="delete a local branch")
+    def delete_local_branch(self, branch_name):
+        # type: (str) -> None
+        rv = self.git(
+            "branch",
+            "-D" if self.force else "-d",
+            branch_name
+        )
+        match = EXTRACT_COMMIT.search(rv.strip())
+        if match:
+            commit = match.group(1)
+            print(DELETE_UNDO_MESSAGE.format(branch_name, commit))
+        self.window.status_message(
+            "Deleted local branch ({}).".format(branch_name)
+            + (" Open Sublime console for undo instructions." if match else "")
+        )
+        util.view.refresh_gitsavvy_interfaces(self.window)

--- a/core/commands/branch.py
+++ b/core/commands/branch.py
@@ -1,8 +1,9 @@
 import re
 
+import sublime
 from sublime_plugin import WindowCommand
 
-from ..git_command import GitCommand
+from ..git_command import GitCommand, GitSavvyError
 from ..runtime import enqueue_on_worker
 from ...common import util
 from ..ui_mixins.quick_panel import show_branch_panel
@@ -22,6 +23,7 @@ GitSavvy: Deleted branch ({0}), in case you want to undo, run:
   $ git branch {0} {1}
 """
 EXTRACT_COMMIT = re.compile(r"\(was (.+)\)")
+NOT_MERGED_WARNING = re.compile(r"The branch.*is not fully merged\.")
 
 
 class gs_delete_branch(WindowCommand, GitCommand):
@@ -51,11 +53,34 @@ class gs_delete_branch(WindowCommand, GitCommand):
     @util.actions.destructive(description="delete a local branch")
     def delete_local_branch(self, branch_name):
         # type: (str) -> None
-        rv = self.git(
-            "branch",
-            "-D" if self.force else "-d",
-            branch_name
-        )
+        if self.force:
+            rv = self.git(
+                "branch",
+                "-D",
+                branch_name
+            )
+        else:
+            try:
+                rv = self.git(
+                    "branch",
+                    "-d",
+                    branch_name,
+                    throw_on_stderr=True,
+                    show_status_message_on_stderr=False,
+                    show_panel_on_stderr=False,
+                )
+            except GitSavvyError as e:
+                if NOT_MERGED_WARNING.search(e.stderr):
+                    self.offer_force_deletion(branch_name)
+                    return
+                raise GitSavvyError(
+                    e.message,
+                    cmd=e.cmd,
+                    stdout=e.stdout,
+                    stderr=e.stderr,
+                    show_panel=True,
+                )
+
         match = EXTRACT_COMMIT.search(rv.strip())
         if match:
             commit = match.group(1)
@@ -65,3 +90,26 @@ class gs_delete_branch(WindowCommand, GitCommand):
             + (" Open Sublime console for undo instructions." if match else "")
         )
         util.view.refresh_gitsavvy_interfaces(self.window)
+
+    def offer_force_deletion(self, branch_name):
+        # type: (str) -> None
+
+        actions = [
+            "Abort, '{}' is not fully merged.".format(branch_name),
+            "Delete anyway."
+        ]
+
+        def on_action_selection(index):
+            if index < 1:
+                return
+
+            self.window.run_command("gs_delete_branch", {
+                "branch": branch_name,
+                "force": True
+            })
+
+        self.window.show_quick_panel(
+            actions,
+            on_action_selection,
+            flags=sublime.MONOSPACE_FONT,
+        )

--- a/core/commands/branch.py
+++ b/core/commands/branch.py
@@ -30,14 +30,11 @@ class gs_delete_branch(WindowCommand, GitCommand):
     def run(self, branch=None, force=False):
         # type: (Optional[str], bool) -> None
         self.force = force
-        enqueue_on_worker(self.run_impl, branch)
-
-    def run_impl(self, branch):
-        # type: (Optional[str]) -> None
         if branch:
-            self.on_branch_selection(branch)
+            self.delete_local_branch(branch)
         else:
-            show_branch_panel(
+            enqueue_on_worker(
+                show_branch_panel,
                 self.on_branch_selection,
                 local_branches_only=True,
                 ignore_current_branch=True,

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -1808,6 +1808,12 @@ class gs_log_graph_action(WindowCommand, GitCommand):
                 for branch_name in info.get("local_branches", [])
             ]
 
+        actions += [
+            ("Delete branch '{}'".format(branch_name), partial(self.delete_branch, branch_name))
+            for branch_name in info.get("local_branches", [])
+            if info.get("HEAD") != branch_name
+        ]
+
         if "HEAD" not in info:
             actions += [
                 ("Cherry-pick commit", partial(self.cherry_pick, commit_hash)),
@@ -1833,6 +1839,9 @@ class gs_log_graph_action(WindowCommand, GitCommand):
     def checkout_b(self, branch_name):
         self.git("checkout", "-B", branch_name)
         util.view.refresh_gitsavvy_interfaces(self.window, refresh_sidebar=True)
+
+    def delete_branch(self, branch_name):
+        self.window.run_command("gs_delete_branch", {"branch": branch_name})
 
     def show_commit(self, commit_hash):
         self.window.run_command("gs_show_commit", {"commit_hash": commit_hash})


### PR DESCRIPTION
We add a "delete branch" command to the graph actions. In the graph you can clearly see for example if a branch has been merged, and is not needed anymore. So this is a good fit.

We generally extract the command from the `branch` dashboard, and add the feature to offer a forceful deletion if the branch is not fully merged yet. (This is thus available for both views.) Before we just showed the git error to the user.

