### PR TITLE
Fix: Markup diffstat for merge commits again

### DIFF
--- a/syntax/show_commit.sublime-syntax
+++ b/syntax/show_commit.sublime-syntax
@@ -46,6 +46,9 @@ contexts:
         - meta_scope: meta.commit_message
         - match: (?=^diff\s)
           set: "scope:git-savvy.diff"
+        # Merge commits "just" start the diffstat without the "---" line
+        - match: (?=^ \S)
+          set: "scope:git-savvy.diff"
         - match: ^---$\n?
           scope: meta.commit-header-and-stat-splitter
           set: "scope:git-savvy.diff"


### PR DESCRIPTION
For merge commits git does not output "---\n" before the diffstat, so
we expplicitly check for it.