### PR TITLE
Bump required git version to "2.16.0"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
-dist: trusty
-
-sudo: required
-
 env:
     global:
         - PACKAGE="GitSavvy"
@@ -12,19 +8,16 @@ matrix:
     include:
         - name: Linux
           os: linux
-          dist: trusty
           language: python
-          python: 3.6
         - name: OSX
           os: osx
           language: generic
 
+services:
+  - xvfb
+
 before_install:
     - curl -OL https://raw.githubusercontent.com/SublimeText/UnitTesting/master/sbin/travis.sh
-    - if [ "$TRAVIS_OS_NAME" == "linux"  ]; then
-            export DISPLAY=:99.0;
-            sh -e /etc/init.d/xvfb start;
-      fi
     - git config --global user.email gitsavvy@gitsavvy.com
     - git config --global user.name GitSavvy
 
@@ -39,12 +32,6 @@ script:
 
 after_success:
     - coveralls
-
-# deploy:
-#     provider: script
-#     script: ./scripts/deploy.sh
-#     on:
-#         branch: master
 
 notifications:
     email: false

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Sublime Text 3 plugin providing the following features:
 - `git diff` view, allowing user to (un)stage hunks across all files
 - status, branch, tag, and rebase dashboards
 
-**Note:** GitSavvy only supports Git versions at or greater than 1.9.0.
+**Note:** GitSavvy partially requires Git versions at or greater than 2.16.0.
 
 **Note:** Sublime Text 2 is not supported.  Also, GitSavvy takes advantage of certain features of ST3 that have bugs in earlier ST3 releases.  For the best experience, use the latest ST3 dev build.
 

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -47,12 +47,8 @@ FALLBACK_PARSE_ERROR_MSG = (
     "operation has been aborted."
 )
 
+MIN_GIT_VERSION = (2, 16, 0)
 GIT_TOO_OLD_MSG = "Your Git version is too old. GitSavvy requires {:d}.{:d}.{:d} or above."
-
-# git minimum requirement
-GIT_REQUIRE_MAJOR = 1
-GIT_REQUIRE_MINOR = 9
-GIT_REQUIRE_PATCH = 0
 
 
 class LoggingProcessWrapper(object):
@@ -346,16 +342,9 @@ class GitCommand(StatusMixin,
 
             match = re.match(r"git version ([0-9]+)\.([0-9]+)\.([0-9]+)", stdout)
             if match:
-                major = int(match.group(1))
-                minor = int(match.group(2))
-                patch = int(match.group(3))
-                if major < GIT_REQUIRE_MAJOR \
-                        or (major == GIT_REQUIRE_MAJOR and minor < GIT_REQUIRE_MINOR) \
-                        or (major == GIT_REQUIRE_MAJOR and minor == GIT_REQUIRE_MINOR and patch < GIT_REQUIRE_PATCH):
-                    msg = GIT_TOO_OLD_MSG.format(
-                        GIT_REQUIRE_MAJOR,
-                        GIT_REQUIRE_MINOR,
-                        GIT_REQUIRE_PATCH)
+                version = tuple(map(int, match.groups()))
+                if version < MIN_GIT_VERSION:
+                    msg = GIT_TOO_OLD_MSG.format(*MIN_GIT_VERSION)
                     git_path = None
                     if not error_message_displayed:
                         sublime.error_message(msg)


### PR DESCRIPTION
#1287 and #1289 revealed that we require "2.16.0" since GitSavvy
"2.22.0". Make this hidden requirement explicit so that users know
what to do.

Note: The version jump was actually not intended, I misread the release notes. Then we could also revert some introduced changes. But just clearly bumping gives us the advantage of knowing a good minimum version as the new base. Clearly not all parts were 1.9.0 before. Having "2.16.0" makes it possible to use basically all known git features. 