### PR TITLE
Replace "replace view text" command

### DIFF
--- a/common/commands/debug.py
+++ b/common/commands/debug.py
@@ -9,9 +9,6 @@ from ...core.settings import GitSavvySettings
 from ...core.view import replace_view_content
 
 
-REPORT_URL_TEMPLATE = "https://github.com/timbrel/GitSavvy/issues/new?{q}"
-
-
 class GsReloadModulesDebug(WindowCommand):
 
     """

--- a/common/commands/debug.py
+++ b/common/commands/debug.py
@@ -6,6 +6,8 @@ from sublime_plugin import WindowCommand
 
 from ..util import debug, reload
 from ...core.settings import GitSavvySettings
+from ...core.view import replace_view_content
+
 
 REPORT_URL_TEMPLATE = "https://github.com/timbrel/GitSavvy/issues/new?{q}"
 
@@ -54,7 +56,4 @@ class GsViewGitLog(WindowCommand):
         view = self.window.new_file()
         view.set_scratch(True)
         view.settings().set("syntax", "Packages/JavaScript/JSON.sublime-syntax")
-        view.run_command("gs_replace_view_text", {
-            "text": log,
-            "nuke_cursors": True
-        })
+        replace_view_content(view, log)

--- a/common/commands/view_manipulation.py
+++ b/common/commands/view_manipulation.py
@@ -3,7 +3,7 @@ from sublime_plugin import TextCommand
 from ...core.settings import GitSavvySettings
 
 
-class GsInsertTextAtCursorCommand(TextCommand):
+class gs_insert_text_at_cursor(TextCommand):
 
     """
     Insert the provided text at the current cursor position(s).
@@ -22,7 +22,7 @@ class GsInsertTextAtCursorCommand(TextCommand):
                                  for begin, end in selected_ranges])
 
 
-class GsReplaceRegionCommand(TextCommand):
+class gs_replace_region(TextCommand):
 
     """
     Replace the contents of a region within the view with the provided text.
@@ -35,7 +35,7 @@ class GsReplaceRegionCommand(TextCommand):
         self.view.set_read_only(is_read_only)
 
 
-class GsHandleVintageousCommand(TextCommand):
+class gs_handle_vintageous(TextCommand):
 
     """
     Set the vintageous_friendly view setting if needed.
@@ -51,7 +51,7 @@ class GsHandleVintageousCommand(TextCommand):
                 self.view.run_command("_enter_insert_mode")
 
 
-class GsHandleArrowKeysCommand(TextCommand):
+class gs_handle_arrow_keys(TextCommand):
 
     """
     Set the arrow_keys_navigation view setting if needed.

--- a/common/commands/view_manipulation.py
+++ b/common/commands/view_manipulation.py
@@ -3,25 +3,6 @@ from sublime_plugin import TextCommand
 from ...core.settings import GitSavvySettings
 
 
-class gs_insert_text_at_cursor(TextCommand):
-
-    """
-    Insert the provided text at the current cursor position(s).
-    """
-
-    def run(self, edit, text):
-        text_len = len(text)
-        selected_ranges = []
-
-        for region in self.view.sel():
-            selected_ranges.append((region.begin(), region.end()))
-            self.view.replace(edit, region, text)
-
-        self.view.sel().clear()
-        self.view.sel().add_all([sublime.Region(begin + text_len, end + text_len)
-                                 for begin, end in selected_ranges])
-
-
 class gs_replace_region(TextCommand):
 
     """

--- a/common/commands/view_manipulation.py
+++ b/common/commands/view_manipulation.py
@@ -2,6 +2,12 @@ from sublime_plugin import TextCommand
 from ...core.git_command import GitCommand
 
 
+__all__ = (
+    "gs_handle_vintageous",
+    "gs_handle_arrow_keys"
+)
+
+
 class gs_handle_vintageous(TextCommand, GitCommand):
 
     """

--- a/common/commands/view_manipulation.py
+++ b/common/commands/view_manipulation.py
@@ -22,40 +22,6 @@ class GsInsertTextAtCursorCommand(TextCommand):
                                  for begin, end in selected_ranges])
 
 
-class GsReplaceViewTextCommand(TextCommand):
-
-    """
-    Replace the contents of the view with the provided text and optional callback.
-    If cursors exist, make sure to place them where they were.  Otherwise, add
-    a single cursor at the start of the file.
-    """
-
-    def run(self, edit, text, nuke_cursors=False, restore_cursors=False):
-        cursors_num = len(self.view.sel())
-        if restore_cursors:
-            save_cursors = [self.view.rowcol(s.a) for s in self.view.sel()]
-
-        # Always clear the selection before replacing the view. Otherwise you
-        # will have a flash where all the text is selected.
-        self.view.sel().clear()
-
-        is_read_only = self.view.is_read_only()
-        self.view.set_read_only(False)
-        self.view.replace(edit, sublime.Region(0, self.view.size()), text)
-        self.view.set_read_only(is_read_only)
-
-        if cursors_num == 0 or nuke_cursors:
-            self.view.sel().clear()
-            pt = sublime.Region(0, 0)
-            self.view.sel().add(pt)
-
-        elif restore_cursors:
-            self.view.sel().clear()
-            for (row, col) in save_cursors:
-                cursor = self.view.text_point(row, col)
-                self.view.sel().add(cursor)
-
-
 class GsReplaceRegionCommand(TextCommand):
 
     """

--- a/common/commands/view_manipulation.py
+++ b/common/commands/view_manipulation.py
@@ -1,19 +1,5 @@
-import sublime
 from sublime_plugin import TextCommand
 from ...core.settings import GitSavvySettings
-
-
-class gs_replace_region(TextCommand):
-
-    """
-    Replace the contents of a region within the view with the provided text.
-    """
-
-    def run(self, edit, text, begin, end):
-        is_read_only = self.view.is_read_only()
-        self.view.set_read_only(False)
-        self.view.replace(edit, sublime.Region(begin, end), text)
-        self.view.set_read_only(is_read_only)
 
 
 class gs_handle_vintageous(TextCommand):

--- a/common/commands/view_manipulation.py
+++ b/common/commands/view_manipulation.py
@@ -1,8 +1,8 @@
 from sublime_plugin import TextCommand
-from ...core.settings import GitSavvySettings
+from ...core.git_command import GitCommand
 
 
-class gs_handle_vintageous(TextCommand):
+class gs_handle_vintageous(TextCommand, GitCommand):
 
     """
     Set the vintageous_friendly view setting if needed.
@@ -10,15 +10,14 @@ class gs_handle_vintageous(TextCommand):
     """
 
     def run(self, edit):
-        savvy_settings = GitSavvySettings()
-        if savvy_settings.get("vintageous_friendly", False) is True:
+        if self.savvy_settings.get("vintageous_friendly"):
             self.view.settings().set("git_savvy.vintageous_friendly", True)
-            if savvy_settings.get("vintageous_enter_insert_mode", False) is True:
+            if self.savvy_settings.get("vintageous_enter_insert_mode"):
                 self.view.settings().set("vintageous_reset_mode_when_switching_tabs", False)
                 self.view.run_command("_enter_insert_mode")
 
 
-class gs_handle_arrow_keys(TextCommand):
+class gs_handle_arrow_keys(TextCommand, GitCommand):
 
     """
     Set the arrow_keys_navigation view setting if needed.
@@ -26,6 +25,5 @@ class gs_handle_arrow_keys(TextCommand):
     """
 
     def run(self, edit):
-        savvy_settings = GitSavvySettings()
-        if savvy_settings.get("arrow_keys_navigation", False) is True:
+        if self.savvy_settings.get("arrow_keys_navigation"):
             self.view.settings().set("git_savvy.arrow_keys_navigation", True)

--- a/common/util/view.py
+++ b/common/util/view.py
@@ -136,22 +136,6 @@ def handle_closed_view(view):
 # IN-VIEW HELPER FUNCTIONS #
 ############################
 
-def move_cursor(view, line_no, char_no):
-    # type: (sublime.View, int, int) -> None
-    # Line numbers are one-based, rows are zero-based.
-    line_no -= 1
-
-    # Negative line index counts backwards from the last line.
-    if line_no < 0:
-        last_line, _ = view.rowcol(view.size())
-        line_no = last_line + line_no + 1
-
-    pt = view.text_point(line_no, char_no)
-    view.sel().clear()
-    view.sel().add(sublime.Region(pt))
-    view.show(pt)
-
-
 def _region_within_regions(all_outer, inner):
     for outer in all_outer:
         if outer.begin() <= inner.begin() and outer.end() >= inner.end():

--- a/core/commands/changelog.py
+++ b/core/commands/changelog.py
@@ -1,6 +1,5 @@
 from collections import OrderedDict
 
-import sublime
 from sublime_plugin import WindowCommand
 
 from ..git_command import GitCommand
@@ -27,12 +26,7 @@ class GsGenerateChangeLogCommand(WindowCommand, GitCommand):
     """
 
     def run(self):
-        sublime.set_timeout_async(self.run_async, 0)
-
-    def run_async(self):
-        view = show_single_line_input_panel(
-            REF_PROMPT, self.get_last_local_tag(), self.on_done, None, None)
-        view.run_command("select_all")
+        show_single_line_input_panel(REF_PROMPT, self.get_last_local_tag(), self.on_done)
 
     def on_done(self, ref):
         merge_entries = self.log(
@@ -89,8 +83,7 @@ class GsGenerateChangeLogCommand(WindowCommand, GitCommand):
         view.set_scratch(True)
         replace_view_content(view, changelog)
 
-    @staticmethod
-    def get_message_groups(messages):
+    def get_message_groups(self, messages):
         grouped_msgs = OrderedDict()
 
         for message in messages:

--- a/core/commands/changelog.py
+++ b/core/commands/changelog.py
@@ -5,6 +5,7 @@ from sublime_plugin import WindowCommand
 
 from ..git_command import GitCommand
 from ..ui_mixins.input_panel import show_single_line_input_panel
+from ..view import replace_view_content
 
 REF_PROMPT = "Ref or commit hash:"
 
@@ -86,10 +87,7 @@ class GsGenerateChangeLogCommand(WindowCommand, GitCommand):
 
         view = self.window.new_file()
         view.set_scratch(True)
-        view.run_command("gs_replace_view_text", {
-            "text": changelog,
-            "nuke_cursors": True
-        })
+        replace_view_content(view, changelog)
 
     @staticmethod
     def get_message_groups(messages):

--- a/core/commands/checkout.py
+++ b/core/commands/checkout.py
@@ -3,11 +3,12 @@ from collections import deque
 import sublime
 from sublime_plugin import WindowCommand
 
-from ..git_command import GitCommand
 from .log import LogMixin
-from ...common import util
+from ..git_command import GitCommand
 from ..ui_mixins.quick_panel import show_branch_panel
 from ..ui_mixins.input_panel import show_single_line_input_panel
+from ..view import replace_view_content
+from ...common import util
 
 
 __all__ = (
@@ -185,8 +186,7 @@ class gs_show_file_diff(WindowCommand, GitCommand):
         )
 
         output_view = self.window.create_output_panel("show_file_diff")
-        output_view.set_read_only(False)
-        output_view.run_command("gs_replace_view_text", {"text": text, "nuke_cursors": True})
         output_view.set_syntax_file("Packages/GitSavvy/syntax/diff.sublime-syntax")
         output_view.set_read_only(True)
+        replace_view_content(output_view, text)
         self.window.run_command("show_panel", {"panel": "output.show_file_diff"})

--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -6,7 +6,7 @@ from sublime_plugin import EventListener
 
 from . import intra_line_colorizer
 from ..runtime import enqueue_on_worker
-from ..view import replace_region
+from ..view import replace_view_content
 from ..git_command import GitCommand
 from ...common import util
 from ...core.settings import SettingsMixin
@@ -112,7 +112,7 @@ class gs_commit(WindowCommand, GitCommand):
             with util.file.safe_open(commit_help_extra_path, "r", encoding="utf-8") as f:
                 initial_text += f.read()
 
-        replace_region(view, initial_text)
+        replace_view_content(view, initial_text)
         view.run_command("gs_prepare_commit_refresh_diff")
 
 
@@ -157,7 +157,7 @@ class gs_prepare_commit_refresh_diff(TextCommand, GitCommand):
         except IndexError:
             region = sublime.Region(view.size())
 
-        replace_region(view, final_text, region)
+        replace_view_content(view, final_text, region)
         if shows_diff:
             intra_line_colorizer.annotate_intra_line_differences(view, final_text, region.begin())
 

--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -335,10 +335,7 @@ class gs_commit_view_sign(TextCommand, GitCommand):
 
         view_text = self.view.substr(sublime.Region(0, self.view.size()))
         new_view_text = new_commit_message + view_text[len(commit_message):]
-        self.view.run_command("gs_replace_view_text", {
-            "text": new_view_text,
-            "restore_cursors": True
-        })
+        replace_view_content(self.view, new_view_text)
 
 
 class gs_commit_view_close(TextCommand, GitCommand):

--- a/core/commands/custom.py
+++ b/core/commands/custom.py
@@ -2,10 +2,11 @@ import sublime
 import threading
 from sublime_plugin import WindowCommand
 
-from ..runtime import enqueue_on_worker
 from ..git_command import GitCommand
-from ...common import util
+from ..runtime import enqueue_on_worker
 from ..ui_mixins.input_panel import show_single_line_input_panel
+from ..view import replace_view_content
+from ...common import util
 
 
 __all__ = (
@@ -67,12 +68,9 @@ class gs_custom(WindowCommand, GitCommand):
             if output_to_buffer:
                 view = self.window.new_file()
                 view.set_scratch(True)
-                view.run_command("gs_replace_view_text", {
-                    "text": stdout.replace("\r", "\n"),
-                    "nuke_cursors": True,
-                })
                 if syntax:
                     view.set_syntax_file(syntax)
+                replace_view_content(view, stdout.replace("\r", "\n"))
 
             util.view.refresh_gitsavvy_interfaces(self.window)
 

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -15,10 +15,10 @@ from . import intra_line_colorizer
 from .navigate import GsNavigate
 from ..fns import filter_, flatten
 from ..parse_diff import SplittedDiff
+from ..git_command import GitCommand, GitSavvyError
 from ..runtime import enqueue_on_ui, enqueue_on_worker
 from ..utils import line_indentation
-from ..git_command import GitCommand
-from ..exceptions import GitSavvyError
+from ..view import replace_view_content
 from ...common import util
 
 
@@ -306,9 +306,7 @@ def _draw(view, title, prelude, diff_text, is_word_diff, added_regions, removed_
     # type: (sublime.View, str, str, str, bool, List[sublime.Region], List[sublime.Region], bool) -> None
     view.set_name(title)
     text = prelude + diff_text
-    view.run_command(
-        "gs_replace_view_text", {"text": text, "restore_cursors": True}
-    )
+    replace_view_content(view, text)
     if navigate:
         view.run_command("gs_diff_navigate")
 

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -4,11 +4,12 @@ from collections import namedtuple
 import sublime
 from sublime_plugin import WindowCommand, TextCommand, EventListener
 
-from ...common import util
 from .navigate import GsNavigate
-from ...common.theme_generator import XMLThemeGenerator, JSONThemeGenerator
-from ..git_command import GitCommand
 from ..constants import MERGE_CONFLICT_PORCELAIN_STATUSES
+from ..git_command import GitCommand
+from ..view import replace_view_content
+from ...common import util
+from ...common.theme_generator import XMLThemeGenerator, JSONThemeGenerator
 
 HunkReference = namedtuple("HunkReference", ("section_start", "section_end", "hunk", "line_types", "lines"))
 
@@ -214,10 +215,7 @@ class GsInlineDiffRefreshCommand(TextCommand, GitCommand):
         if match_position is None:
             cur_pos = capture_cur_position(self.view)
 
-        self.view.run_command("gs_replace_view_text", {
-            "text": inline_diff_contents,
-            "restore_cursors": True
-        })
+        replace_view_content(self.view, inline_diff_contents)
 
         if match_position is None:
             if cur_pos == (0, 0) and self.savvy_settings.get("inline_diff_auto_scroll", False):

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -138,9 +138,7 @@ class gs_graph(WindowCommand, GitCommand):
                         # "show_commit_info" will run blocking if the panel
                         # is empty (or closed).
                         panel = show_commit_info.ensure_panel(self.window)
-                        panel.run_command(
-                            "gs_replace_view_text", {"text": "", "restore_cursors": True}
-                        )
+                        replace_view_content(panel, "")
                     navigate_to_symbol(view, follow)
 
                 focus_view(view)

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -26,7 +26,7 @@ from ..runtime import (
     run_or_timeout, run_on_new_thread,
     text_command
 )
-from ..view import replace_region
+from ..view import replace_view_content
 from ..ui_mixins.input_panel import show_single_line_input_panel
 from ..ui_mixins.quick_panel import show_branch_panel
 from ...common import util
@@ -469,7 +469,7 @@ class gs_log_graph_refresh(TextCommand, GitCommand):
         prelude_text = prelude(self.view)
         initial_draw = self.view.size() == 0
         if initial_draw:
-            replace_region(self.view, prelude_text, sublime.Region(0, 1))
+            replace_view_content(self.view, prelude_text, sublime.Region(0, 1))
 
         try:
             current_graph = self.view.substr(
@@ -535,11 +535,11 @@ class gs_log_graph_refresh(TextCommand, GitCommand):
             visible_selection = is_sel_in_viewport(self.view)
 
             current_prelude_region = self.view.find_by_selector('meta.prelude.git_savvy.graph')[0]
-            replace_region(self.view, prelude_text, current_prelude_region)
+            replace_view_content(self.view, prelude_text, current_prelude_region)
             drain_and_draw_queue(self.view, 'initial', follow, col_range, visible_selection)
 
         # Sublime will not run any event handlers until the (outermost) TextCommand exits.
-        # T.i. the (inner) commands `replace_region` and `set_and_show_cursor` will run
+        # T.i. the (inner) commands `replace_view_content` and `set_and_show_cursor` will run
         # through uninterrupted until `drain_and_draw_queue` yields. Then e.g.
         # `on_selection_modified` runs *once* even if we painted multiple times.
         @ensure_not_aborted
@@ -627,7 +627,7 @@ class gs_log_graph_refresh(TextCommand, GitCommand):
             region = sublime.Region(computed_start, computed_end)
 
             current_graph_splitted = apply_diff(current_graph_splitted, [token])
-            replace_region(view, text, region)
+            replace_view_content(view, text, region)
             occupied_space = sublime.Region(computed_start, computed_start + len(text))
             return occupied_space
 

--- a/core/commands/show_commit.py
+++ b/core/commands/show_commit.py
@@ -6,6 +6,7 @@ from sublime_plugin import WindowCommand, TextCommand
 from . import diff
 from . import intra_line_colorizer
 from ..git_command import GitCommand
+from ..view import replace_view_content
 
 
 __all__ = (
@@ -41,6 +42,7 @@ class gs_show_commit(WindowCommand, GitCommand):
         nice_hash = self.get_short_hash(commit_hash) if len(commit_hash) >= 40 else commit_hash
         view.set_name(SHOW_COMMIT_TITLE.format(nice_hash))
         view.set_scratch(True)
+        view.set_read_only(True)
         view.run_command("gs_show_commit_refresh")
         view.run_command("gs_handle_vintageous")
 
@@ -62,8 +64,7 @@ class gs_show_commit_refresh(TextCommand, GitCommand):
             "--format=fuller",
             "--no-color",
             commit_hash)
-        self.view.run_command("gs_replace_view_text", {"text": content, "restore_cursors": True})
-        self.view.set_read_only(True)
+        replace_view_content(self.view, content)
         intra_line_colorizer.annotate_intra_line_differences(self.view)
 
 

--- a/core/commands/show_commit_info.py
+++ b/core/commands/show_commit_info.py
@@ -7,6 +7,7 @@ from sublime_plugin import WindowCommand
 from . import intra_line_colorizer
 from ..git_command import GitCommand
 from ..runtime import enqueue_on_worker, enqueue_on_ui, throttled
+from ..view import replace_view_content
 
 
 __all__ = (
@@ -97,7 +98,7 @@ class gs_show_commit_info(WindowCommand, GitCommand):
 def _draw(window, view, text, commit):
     # type: (sublime.Window, sublime.View, str, str) -> None
     with restore_viewport_position(view, commit):
-        view.run_command("gs_replace_view_text", {"text": text, "nuke_cursors": True})
+        replace_view_content(view, text)
 
     intra_line_colorizer.annotate_intra_line_differences(view)
 

--- a/core/commands/show_file_at_commit.py
+++ b/core/commands/show_file_at_commit.py
@@ -5,6 +5,7 @@ from sublime_plugin import TextCommand, WindowCommand
 
 from ..git_command import GitCommand
 from ..runtime import enqueue_on_ui, enqueue_on_worker
+from ..view import replace_view_content
 from ...common import util
 from .log import LogMixin
 
@@ -59,7 +60,7 @@ class gs_show_file_at_commit(WindowCommand, GitCommand):
         enqueue_on_ui(self.render_text, view, text, lineno)
 
     def render_text(self, view, text, lineno):
-        view.run_command("gs_replace_view_text", {"text": text, "nuke_cursors": True})
+        replace_view_content(view, text)
         util.view.move_cursor(view, lineno, 0)
 
 

--- a/core/commands/stage_diff.py
+++ b/core/commands/stage_diff.py
@@ -3,17 +3,17 @@ Implements a special view that displays an editable diff of unstaged changes.
 """
 
 import os
-import sys
 
 import sublime
 from sublime_plugin import WindowCommand, TextCommand
 
-from ..git_command import GitCommand, GitSavvyError
+from ..git_command import GitCommand
 from ..view import replace_view_content
 from ...common import util
 
 
 TITLE = "STAGE-DIFF: {}"
+MESSAGE = "Press {}-Enter to apply the diff.  Close the window to cancel.".format(util.super_key)
 
 
 class GsStageDiffCommand(WindowCommand, GitCommand):
@@ -22,51 +22,16 @@ class GsStageDiffCommand(WindowCommand, GitCommand):
     Create a new view to display the project's unstaged changes.
     """
 
-    def run(self, **kwargs):
-        sublime.set_timeout_async(lambda: self.run_async(**kwargs), 0)
-
-    def run_async(self):
+    def run(self):
+        repo_path = self.repo_path
         stage_diff_view = util.view.get_scratch_view(self, "git_stage_diff", read_only=False)
-        stage_diff_view.set_name(TITLE.format(os.path.basename(self.repo_path)))
+        stage_diff_view.set_name(TITLE.format(os.path.basename(repo_path)))
         stage_diff_view.set_syntax_file("Packages/GitSavvy/syntax/diff.sublime_syntax")
-        stage_diff_view.settings().set("git_savvy.repo_path", self.repo_path)
+        stage_diff_view.settings().set("git_savvy.repo_path", repo_path)
 
-        self.window.focus_view(stage_diff_view)
-        stage_diff_view.sel().clear()
-        stage_diff_view.run_command("gs_stage_diff_refresh")
-
-
-class GsStageDiffRefreshCommand(TextCommand, GitCommand):
-
-    """
-    Refresh the view with the latest unstaged changes.
-    """
-
-    def run(self, edit, cursors=None):
-        if self.view.settings().get("git_savvy.disable_diff"):
-            return
-
-        try:
-            stdout = self.git("diff", "--no-color")
-        except GitSavvyError as err:
-            # When the output of the above Git command fails to correctly parse,
-            # the expected notification will be displayed to the user.  However,
-            # once the userpresses OK, a new refresh event will be triggered on
-            # the view.
-            #
-            # This causes an infinite loop of increasingly frustrating error
-            # messages, ultimately resulting in psychosis and serious medical
-            # bills.  This is a better, though somewhat cludgy, alternative.
-            #
-            if err.args and type(err.args[0]) == UnicodeDecodeError:
-                self.view.settings().set("git_savvy.disable_diff", True)
-                return
-            raise err
-
-        super_key = "SUPER" if sys.platform == "darwin" else "CTRL"
-        message = "Press {}-Enter to apply the diff.  Close the window to cancel.".format(super_key)
-        content = message + "\n\n" + stdout
-        replace_view_content(self.view, content)
+        stdout = self.git("diff", "--no-color")
+        content = MESSAGE + "\n\n" + stdout
+        replace_view_content(stage_diff_view, content)
 
 
 class GsStageDiffApplyCommand(TextCommand, GitCommand):
@@ -76,10 +41,6 @@ class GsStageDiffApplyCommand(TextCommand, GitCommand):
     """
 
     def run(self, edit):
-        sublime.set_timeout_async(lambda: self.run_async(), 0)
-
-    def run_async(self):
         diff_content = self.view.substr(sublime.Region(0, self.view.size()))
         self.git("apply", "--cached", "-", stdin=diff_content)
-        self.view.window().focus_view(self.view)
-        self.view.window().run_command("close_file")
+        self.view.close()

--- a/core/commands/stage_diff.py
+++ b/core/commands/stage_diff.py
@@ -8,9 +8,9 @@ import sys
 import sublime
 from sublime_plugin import WindowCommand, TextCommand
 
+from ..git_command import GitCommand, GitSavvyError
+from ..view import replace_view_content
 from ...common import util
-from ..git_command import GitCommand
-from ..exceptions import GitSavvyError
 
 
 TITLE = "STAGE-DIFF: {}"
@@ -66,8 +66,7 @@ class GsStageDiffRefreshCommand(TextCommand, GitCommand):
         super_key = "SUPER" if sys.platform == "darwin" else "CTRL"
         message = "Press {}-Enter to apply the diff.  Close the window to cancel.".format(super_key)
         content = message + "\n\n" + stdout
-
-        self.view.run_command("gs_replace_view_text", {"text": content})
+        replace_view_content(self.view, content)
 
 
 class GsStageDiffApplyCommand(TextCommand, GitCommand):

--- a/core/commands/stash.py
+++ b/core/commands/stash.py
@@ -187,7 +187,6 @@ class GsStashShowCommand(WindowCommand, GitCommand):
         replace_view_content(stash_view, content)
 
     def create_stash_view(self, stash_id):
-        window = self.window
         repo_path = self.repo_path
         stash_view = util.view.get_scratch_view(self, "stash", read_only=True)
         title = "stash@{{{}}}".format(stash_id)
@@ -196,8 +195,6 @@ class GsStashShowCommand(WindowCommand, GitCommand):
         stash_view.settings().set("git_savvy.repo_path", repo_path)
         stash_view.settings().set("git_savvy.stash_view.stash_id", stash_id)
         stash_view.settings().set("git_savvy.stash_view.status", "valid")
-        window.focus_view(stash_view)
-
         return stash_view
 
 

--- a/core/commands/stash.py
+++ b/core/commands/stash.py
@@ -9,6 +9,7 @@ from ..git_command import GitCommand
 from ..ui_mixins.quick_panel import PanelCommandMixin
 from ..ui_mixins.quick_panel import show_stash_panel
 from ..ui_mixins.input_panel import show_single_line_input_panel
+from ..view import replace_view_content
 from ...common import util
 
 
@@ -182,7 +183,8 @@ class GsStashShowCommand(WindowCommand, GitCommand):
             return
 
         stash_view = self.create_stash_view(stash_id)
-        stash_view.run_command("gs_replace_view_text", {"text": self.show_stash(stash_id), "nuke_cursors": True})
+        content = self.show_stash(stash_id)
+        replace_view_content(stash_view, content)
 
     def create_stash_view(self, stash_id):
         window = self.window

--- a/core/view.py
+++ b/core/view.py
@@ -5,8 +5,27 @@ import sublime
 from .runtime import text_command
 
 
+MYPY = False
+if MYPY:
+    from typing import Callable, ContextManager, Iterator, List
+    WrapperFn = Callable[[sublime.View], ContextManager[None]]
+
+
+# `replace_view_content` is a wrapper for `_replace_region` to get some
+# typing support from mypy.
+def replace_view_content(view, text, region=None, wrappers=[]):
+    # type: (sublime.View, str, sublime.Region, List[WrapperFn]) -> None
+    """Replace the content of the view
+
+    If no region is given the whole content will get replaced. Otherwise
+    only the selected region.
+    """
+    _replace_region(view, text, region, wrappers)
+
+
 @text_command
-def replace_region(view, edit, text, region=None, wrappers=[]):
+def _replace_region(view, edit, text, region=None, wrappers=[]):
+    # type: (sublime.View, sublime.Edit, str, sublime.Region, List[WrapperFn]) -> None
     if region is None:
         # If you "replace" (or expand) directly at the cursor,
         # the cursor expands into a selection.
@@ -30,6 +49,7 @@ def replace_region(view, edit, text, region=None, wrappers=[]):
 
 @contextmanager
 def writable_view(view):
+    # type: (sublime.View) -> Iterator[None]
     is_read_only = view.is_read_only()
     view.set_read_only(False)
     try:
@@ -40,6 +60,7 @@ def writable_view(view):
 
 @contextmanager
 def restore_cursors(view):
+    # type: (sublime.View) -> Iterator[None]
     save_cursors = [
         (view.rowcol(s.begin()), view.rowcol(s.end()))
         for s in view.sel()
@@ -57,6 +78,7 @@ def restore_cursors(view):
 
 @contextmanager
 def stable_viewport(view):
+    # type: (sublime.View) -> Iterator[None]
     # Ref: https://github.com/SublimeTextIssues/Core/issues/2560
     # See https://github.com/jonlabelle/SublimeJsPrettier/pull/171/files
     # for workaround.

--- a/github/commands/commit.py
+++ b/github/commands/commit.py
@@ -80,7 +80,7 @@ class GsGithubShowIssuesCommand(TextCommand, GitCommand, git_mixins.GithubRemote
         if not issue:
             return
 
-        self.view.run_command("gs_insert_text_at_cursor", {"text": str(issue["number"])})
+        self.view.run_command("insert", {"characters": str(issue["number"])})
 
 
 class GsGithubShowContributorsCommand(TextCommand, GitCommand):
@@ -118,4 +118,4 @@ class GsGithubShowContributorsCommand(TextCommand, GitCommand):
         if not contributor:
             return
 
-        self.view.run_command("gs_insert_text_at_cursor", {"text": contributor["login"]})
+        self.view.run_command("insert", {"characters": contributor["login"]})

--- a/github/commands/pull_request.py
+++ b/github/commands/pull_request.py
@@ -3,14 +3,15 @@ from sublime_plugin import WindowCommand
 from webbrowser import open as open_in_browser
 import urllib
 
-from ...core.git_command import GitCommand
-from ...core.ui_mixins.quick_panel import show_paginated_panel
-from ...core.ui_mixins.input_panel import show_single_line_input_panel
 from .. import github
 from .. import git_mixins
 from ...common import interwebs
 from ...common import util
 from ...core.commands.push import GsPushToBranchNameCommand
+from ...core.git_command import GitCommand
+from ...core.ui_mixins.quick_panel import show_paginated_panel
+from ...core.ui_mixins.input_panel import show_single_line_input_panel
+from ...core.view import replace_view_content
 
 
 PUSH_PROMPT = ("You have not set an upstream for the active branch.  "
@@ -136,9 +137,7 @@ class GsGithubPullRequestCommand(WindowCommand, GitCommand, git_mixins.GithubRem
 
         self.window.focus_view(diff_view)
         diff_view.sel().clear()
-        diff_view.run_command("gs_replace_view_text", {
-            "text": response.payload.decode("utf-8")
-        })
+        replace_view_content(diff_view, response.payload.decode("utf-8"))
 
     def open_pr_in_browser(self):
         open_in_browser(self.pr["html_url"])

--- a/github/commands/pull_request.py
+++ b/github/commands/pull_request.py
@@ -134,9 +134,6 @@ class GsGithubPullRequestCommand(WindowCommand, GitCommand, git_mixins.GithubRem
         diff_view = util.view.get_scratch_view(self, "pr_diff", read_only=True)
         diff_view.set_name("PR #{}".format(self.pr["number"]))
         diff_view.set_syntax_file("Packages/GitSavvy/syntax/diff.sublime-syntax")
-
-        self.window.focus_view(diff_view)
-        diff_view.sel().clear()
         replace_view_content(diff_view, response.payload.decode("utf-8"))
 
     def open_pr_in_browser(self):

--- a/gitlab/commands/merge_request.py
+++ b/gitlab/commands/merge_request.py
@@ -1,16 +1,14 @@
 import sublime
 from sublime_plugin import WindowCommand
 from webbrowser import open as open_in_browser
-# import urllib
 
+from .. import gitlab
+from .. import git_mixins
 from ...core.git_command import GitCommand
 from ...core.ui_mixins.quick_panel import show_paginated_panel
 from ...core.ui_mixins.input_panel import show_single_line_input_panel
-from .. import gitlab
-from .. import git_mixins
-# from ...common import interwebs
+from ...core.view import replace_view_content
 from ...common import util
-# from ...core.commands.push import GsPushToBranchNameCommand
 
 
 PUSH_PROMPT = ("You have not set an upstream for the active branch.  "
@@ -118,68 +116,8 @@ class GsGitlabMergeRequestCommand(WindowCommand, GitCommand, git_mixins.GitLabRe
         diff_view.set_name("MR #{}".format(self.mr["iid"]))
         diff_view.set_syntax_file("Packages/GitSavvy/syntax/diff.sublime-syntax")
 
-        self.window.focus_view(diff_view)
-        diff_text = (change['diff'] for change in mr_changes['changes'])
-        diff_view.sel().clear()
-        diff_view.run_command("gs_replace_view_text", {
-            "text": '\n'.join(diff_text)
-        })
+        diff_text = '\n'.join(change['diff'] for change in mr_changes['changes'])
+        replace_view_content(diff_view, diff_text)
 
     def open_mr_in_browser(self):
         open_in_browser(self.mr["web_url"])
-
-
-# class GsCreateMergeRequestCommand(WindowCommand, GitCommand, git_mixins.GithubRemotesMixin):
-#     """
-#     Create merge request of the current commit on the current repo.
-#     """
-
-#     def run(self):
-#         sublime.set_timeout_async(self.run_async, 0)
-
-#     def run_async(self):
-#         if not self.get_upstream_for_active_branch():
-#             if sublime.ok_cancel_dialog(PUSH_PROMPT):
-#                 self.window.run_command(
-#                     "gs_push_and_create_merge_request",
-#                     {"set_upstream": True})
-
-#         else:
-#             remote_branch = self.get_active_remote_branch()
-#             if not remote_branch:
-#                 sublime.message_dialog("Unable to determine remote.")
-#            else:
-#                status, secondary = self.get_branch_status()
-#                if secondary:
-#                    secondary = "\n".join(secondary)
-#                    if "ahead" in secondary or "behind" in secondary:
-#                        sublime.message_dialog(
-#                            "Your current branch is different from its remote counterpart.\n" +
-#                            secondary)
-#                        return
-
-#                owner = github.parse_remote(self.get_remotes()[remote_branch.remote]).owner
-#                self.open_comparision_in_browser(
-#                    owner,
-#                    remote_branch.name
-#                )
-
-#     def open_comparision_in_browser(self, owner, branch):
-#         base_remote = github.parse_remote(self.get_integrated_remote_url())
-#         remote_url = base_remote.url
-#         base_owner = base_remote.owner
-#         base_branch = self.get_integrated_branch_name()
-#         url = "{}/compare/{}:{}...{}:{}?expand=1".format(
-#             remote_url,
-#             base_owner,
-#             urllib.parse.quote_plus(base_branch),
-#             owner,
-#             urllib.parse.quote_plus(branch)
-#         )
-#         open_in_browser(url)
-
-# class GsPushAndCreateMergeRequestCommand(GsPushToBranchNameCommand):
-
-#     def do_push(self, *args, **kwargs):
-#         super().do_push(*args, **kwargs)
-#         self.window.run_command("gs_create_merge_request")


### PR DESCRIPTION
A rather boring refactoring PR. We apply the `replace_view_content` function all over the place. This function has been introduced by the rewrite (or rather the diff rendering implementation) of the `log_graph`. 

Some drive-by refactorings has been made in some modules.

Fixes #1194 
Fixes #1196 