### PR TITLE
Do not use "simplify history" features for "File History"

### DIFF
--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -717,20 +717,21 @@ class gs_log_graph_refresh(TextCommand, GitCommand):
         follow = self.savvy_settings.get("log_follow_rename")
         author = settings.get("git_savvy.log_graph_view.filter_by_author")
         all_branches = settings.get("git_savvy.log_graph_view.all_branches")
+        fpath = self.file_path
         args = [
             'log',
             '--graph',
             '--decorate',  # set explicitly for "decorate-refs-exclude" to work
             '--date={}'.format(DATE_FORMAT),
             '--pretty=format:%h%d %<|(80,trunc)%s | %ad, %an',
-            '--follow' if self.file_path and follow else None,
+            '--follow' if fpath and follow else None,
             '--author={}'.format(author) if author else None,
             '--decorate-refs-exclude=refs/remotes/origin/HEAD',  # cosmetics
             '--exclude=refs/stash',
             '--all' if all_branches else None,
         ]
 
-        if settings.get('git_savvy.log_graph_view.decoration') == 'sparse':
+        if not fpath and settings.get('git_savvy.log_graph_view.decoration') == 'sparse':
             args += ['--simplify-by-decoration', '--sparse']
 
         branches = settings.get("git_savvy.log_graph_view.branches")
@@ -741,9 +742,8 @@ class gs_log_graph_refresh(TextCommand, GitCommand):
         if filters:
             args += shlex.split(filters)
 
-        if self.file_path:
-            file_path = self.get_rel_path(self.file_path)
-            args += ["--", file_path]
+        if fpath:
+            args += ["--", self.get_rel_path(fpath)]
 
         return args
 


### PR DESCRIPTION
Fixes #1301

As explained in https://git-scm.com/docs/git-log#_history_simplification
`<file_paths>`, `--simplify-by-decoration`, and `--sparse` interact.

For the common "Repo History" "sparse" is easy to follow and to
understand, but when showing a "File History" it is not a good default
mode anymore. The settings "--sparse", "--dense" etc. become rather fine
grained research methods. Git's "Default mode" (again see their docs)
becomes the only understandable mode.

So we just follow here and use history simplification only when showing
the "Repo History".