### PR TITLE
Do not force a "cached" mode when reusing views

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -237,6 +237,7 @@
     {
         "keys": ["f"],
         "command": "gs_diff",
+        "args": { "in_cached_mode": false },
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.status_view", "operator": "equal", "operand": true }

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -118,7 +118,7 @@ class gs_diff(WindowCommand, GitCommand):
         self,
         repo_path=None,
         file_path=None,
-        in_cached_mode=False,
+        in_cached_mode=None,  # type: Optional[bool]
         current_file=False,
         base_commit=None,
         target_commit=None,
@@ -128,6 +128,7 @@ class gs_diff(WindowCommand, GitCommand):
         show_word_diff=False,
         context_lines=3
     ):
+        # type: (...) -> None
         if repo_path is None:
             repo_path = self.repo_path
         assert repo_path
@@ -142,8 +143,9 @@ class gs_diff(WindowCommand, GitCommand):
         )
         for view in self.window.views():
             if compute_identifier_for_view(view) == this_id:
-                settings = view.settings()
-                settings.set("git_savvy.diff_view.in_cached_mode", in_cached_mode)
+                if in_cached_mode is not None:
+                    settings = view.settings()
+                    settings.set("git_savvy.diff_view.in_cached_mode", in_cached_mode)
                 focus_view(view)
                 break
 
@@ -154,7 +156,7 @@ class gs_diff(WindowCommand, GitCommand):
             settings = diff_view.settings()
             settings.set("git_savvy.repo_path", repo_path)
             settings.set("git_savvy.file_path", file_path)
-            settings.set("git_savvy.diff_view.in_cached_mode", in_cached_mode)
+            settings.set("git_savvy.diff_view.in_cached_mode", bool(in_cached_mode))
             settings.set("git_savvy.diff_view.ignore_whitespace", ignore_whitespace)
             settings.set("git_savvy.diff_view.show_word_diff", show_word_diff)
             settings.set("git_savvy.diff_view.context_lines", context_lines)

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -552,13 +552,20 @@ class GsStatusDiffCommand(TextCommand, GitCommand):
         cached_files = get_selected_files(self.view, repo_path, 'staged')
 
         sublime.set_timeout_async(
-            lambda: self.load_diff_windows(window, non_cached_files, cached_files)
+            lambda: self.load_diff_windows(
+                window,  # type: ignore  # https://github.com/python/mypy/issues/4297
+                non_cached_files,
+                cached_files
+            )
         )
 
     def load_diff_windows(self, window, non_cached_files, cached_files):
         # type: (sublime.Window, List[str], List[str]) -> None
         for fpath in non_cached_files:
-            window.run_command("gs_diff", {"file_path": fpath})
+            window.run_command("gs_diff", {
+                "file_path": fpath,
+                "in_cached_mode": False,
+            })
 
         for fpath in cached_files:
             window.run_command("gs_diff", {


### PR DESCRIPTION
When reusing diff views it is often desired to not force a specific
"cached" mode but just switch to the view. For example, a user might
have a key binding to diff the current file. Here it is better to
just have *one* binding to open or focus the diff, and switch the
"cached" mode via `<TAB>`.

We thus make `in_cached_mode` a three-state toggle, t.i. not setting it
(`None`) becomes also meaningful in that it only focuses the view.

Fixes regression introduced by c74159fef38729bb2c179b74b6831991a31ce70f
("Update "cached" mode when reusing diff views"), thus related to #1299.