### PR TITLE
Inline stage hunks

### DIFF
--- a/core/commands/__init__.py
+++ b/core/commands/__init__.py
@@ -14,6 +14,7 @@ from .flow import *
 from .ignore import *
 from .init import *
 from .inline_diff import *
+from .inline_stage_hunk import *
 from .log import *
 from .log_graph import *
 from .merge import *

--- a/core/commands/__init__.py
+++ b/core/commands/__init__.py
@@ -14,7 +14,6 @@ from .flow import *
 from .ignore import *
 from .init import *
 from .inline_diff import *
-from .inline_stage_hunk import *
 from .log import *
 from .log_graph import *
 from .merge import *
@@ -32,6 +31,7 @@ from .show_commit import *
 from .show_commit_info import *
 from .show_file_at_commit import *
 from .stage_diff import *
+from .stage_hunk import *
 from .stash import *
 from .status_bar import *
 from .tag import *

--- a/core/commands/inline_stage_hunk.py
+++ b/core/commands/inline_stage_hunk.py
@@ -49,7 +49,7 @@ class gs_inline_stage_hunk(TextCommand, GitCommand):
         view = self.view
         fpath = view.file_name()
         if not fpath:
-            flash(view, "Cannot stage unnnamed files.")
+            flash(view, "Cannot stage on unnnamed buffers.")
             return
 
         if view.is_dirty():

--- a/core/commands/inline_stage_hunk.py
+++ b/core/commands/inline_stage_hunk.py
@@ -73,6 +73,7 @@ class gs_inline_stage_hunk(TextCommand, GitCommand):
             hunks = hunks_touching_selection(diff, view)
         except UnsupportedCombinedDiff:
             flash(view, "Files with merge conflicts are not supported.")
+            return
 
         if not hunks:
             flash(view, "Not on a hunk.")

--- a/core/commands/inline_stage_hunk.py
+++ b/core/commands/inline_stage_hunk.py
@@ -1,0 +1,157 @@
+from collections import namedtuple
+from itertools import chain
+import re
+
+import sublime
+from sublime_plugin import TextCommand
+
+from ..fns import accumulate, filter_, unique
+from ..git_command import GitCommand
+from ..parse_diff import SplittedDiff
+
+
+__all__ = (
+    "gs_inline_stage_hunk",
+)
+
+
+MYPY = False
+if MYPY:
+    from typing import Iterator, List, NamedTuple, Optional, Tuple
+    from ..parse_diff import Hunk as HunkText
+
+
+if MYPY:
+    Hunk = NamedTuple("Hunk", [
+        ("a_start", int),
+        ("a_length", int),
+        ("b_start", int),
+        ("b_length", int),
+        ("content", str)
+    ])
+else:
+    Hunk = namedtuple("Hunk", "a_start a_length b_start b_length content")
+
+
+class UnsupportedCombinedDiff(RuntimeError):
+    pass
+
+
+def flash(view, message):
+    # type: (sublime.View, str) -> None
+    window = view.window()
+    if window:
+        window.status_message(message)
+
+
+class gs_inline_stage_hunk(TextCommand, GitCommand):
+    def run(self, edit):
+        view = self.view
+        fpath = view.file_name()
+        if not fpath:
+            flash(view, "Cannot stage unnnamed files.")
+            return
+
+        if view.is_dirty():
+            flash(view, "Cannot stage on unsaved files.")
+            return
+
+        raw_diff = self.git("diff", "-U0", fpath)
+        if not raw_diff:
+            not_tracked_file = self.git("ls-files", fpath).strip() == ""
+            if not_tracked_file:
+                self.git("add", fpath)
+                flash(view, "Staged whole file.")
+            else:
+                flash(view, "The file is clean.")
+            return
+
+        diff = SplittedDiff.from_string(raw_diff)
+        assert len(diff.headers) == 1
+
+        try:
+            hunks = hunks_touching_selection(diff, view)
+        except UnsupportedCombinedDiff:
+            flash(view, "Files with merge conflicts are not supported.")
+
+        if not hunks:
+            flash(view, "Not on a hunk.")
+            return
+
+        patch = format_patch(diff.headers[0].text, hunks)
+        self.git("apply", "--cached", "--unidiff-zero", "-", stdin=patch)
+
+        hunk_count = len(hunks)
+        flash(view, "Staged {} {}.".format(hunk_count, pluralize("hunk", hunk_count)))
+
+
+def hunks_touching_selection(diff, view):
+    # type: (SplittedDiff, sublime.View) -> List[Hunk]
+    rows = unique(
+        view.rowcol(line.begin())[0] + 1
+        for region in view.sel()
+        for line in view.lines(region)
+    )
+    hunks = list(map(parse_hunk, diff.hunks))
+    return list(unique(filter_(hunk_containing_row(hunks, row) for row in rows)))
+
+
+def parse_hunk(hunk):
+    # type: (HunkText) -> Hunk
+    return Hunk(*parse_metadata(hunk.header().text), content=hunk.content().text)
+
+
+def hunk_containing_row(hunks, row):
+    # type: (List[Hunk], int) -> Optional[Hunk]
+    # Assumes `hunks` are sorted
+    for hunk in hunks:
+        if row < hunk.b_start:
+            break
+        if hunk.b_start <= row < (hunk.b_start + max(hunk.b_length, 1)):
+            return hunk
+    return None
+
+
+def format_patch(header, hunks):
+    # type: (str, List[Hunk]) -> str
+    return ''.join(chain(
+        [header],
+        map(format_hunk, rewrite_hunks(hunks))
+    ))
+
+
+def format_hunk(hunk):
+    # type: (Hunk) -> str
+    return "@@ -{},{} +{},{} @@\n{}".format(*hunk)
+
+
+def rewrite_hunks(hunks, zerodiff=True):
+    # type: (List[Hunk], bool) -> Iterator[Hunk]
+    # Assumes `hunks` are sorted, and from the same file
+    deltas = (hunk.b_length - hunk.a_length for hunk in hunks)
+    offsets = accumulate(deltas, initial=0)
+    for hunk, offset in zip(hunks, offsets):
+        new_start = hunk.a_start + offset
+        if zerodiff:
+            if hunk.a_length == 0:
+                new_start += 1
+            elif hunk.b_length == 0:
+                new_start -= 1
+        yield hunk._replace(b_start=new_start)
+
+
+LINE_METADATA = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
+
+
+def parse_metadata(line):
+    # type: (str) -> Tuple[int, int, int, int]
+    match = LINE_METADATA.match(line)
+    if match is None:
+        raise UnsupportedCombinedDiff(line)
+    a_start, a_length, b_start, b_length = match.groups()
+    return int(a_start), int(a_length or "1"), int(b_start), int(b_length or "1")
+
+
+def pluralize(word, count):
+    # type: (str, int) -> str
+    return word if count == 1 else word + "s"

--- a/core/commands/stage_hunk.py
+++ b/core/commands/stage_hunk.py
@@ -11,7 +11,7 @@ from ..parse_diff import SplittedDiff
 
 
 __all__ = (
-    "gs_inline_stage_hunk",
+    "gs_stage_hunk",
 )
 
 
@@ -44,7 +44,7 @@ def flash(view, message):
         window.status_message(message)
 
 
-class gs_inline_stage_hunk(TextCommand, GitCommand):
+class gs_stage_hunk(TextCommand, GitCommand):
     def run(self, edit):
         view = self.view
         fpath = view.file_name()

--- a/core/parse_diff.py
+++ b/core/parse_diff.py
@@ -95,7 +95,7 @@ class TextRange:
 
     def __hash__(self):
         # type: () -> int
-        return hash(self._as_tuple)
+        return hash(self._as_tuple())
 
     def __eq__(self, other):
         # type: (object) -> bool


### PR DESCRIPTION
Implements #1304 

Comes without any bindings.  Add a key binding, e.g.

```
	{ "keys": ["ctrl+alt+s"], "command": "gs_stage_hunk"},
```

or to command palette on your own.
