### PR TITLE
Iterate inline diff

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -41,6 +41,32 @@
         ]
     },
     {
+        "keys": ["c"],
+        "command": "gs_commit",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.inline_diff_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["C"],
+        "command": "gs_commit",
+        "args": {"include_unstaged": true},
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.inline_diff_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["m"],
+        "command": "gs_commit",
+        "args": {"amend": true},
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.inline_diff_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
         "keys": ["."],
         "command": "gs_inline_diff_navigate_hunk",
         "args": { "forward": true },

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -41,14 +41,6 @@
         ]
     },
     {
-        "keys": ["r"],
-        "command": "gs_inline_diff_refresh",
-        "context": [
-            { "key": "setting.command_mode", "operator": "equal", "operand": false },
-            { "key": "setting.git_savvy.inline_diff_view", "operator": "equal", "operand": true }
-        ]
-    },
-    {
         "keys": ["."],
         "command": "gs_inline_diff_navigate_hunk",
         "args": { "forward": true },

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -571,6 +571,15 @@
         ]
     },
     {
+        "keys": ["m"],
+        "command": "gs_commit",
+        "args": {"amend": true},
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.diff_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
         "keys": ["."],
         "command": "gs_diff_navigate",
         "args": { "forward": true },

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -113,6 +113,15 @@
         ]
     },
     {
+        "keys": ["tab"],
+        "command": "gs_inline_diff_toggle_cached_mode",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.inline_diff_view", "operator": "equal", "operand": true }
+        ]
+    },
+
+    {
         "keys": ["?"],
         "command": "gs_interface_toggle_popup_help",
         "args": { "view_name": "inline_diff_view" },

--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -80,19 +80,6 @@
     "inline_diff_auto_scroll": false,
 
     "colors": {
-        /*
-            Colors used by the inline-diff view to display changes.
-         */
-        "inline_diff": {
-            "add_foreground": "#F9F9F4",
-            "add_background": "#37A832",
-            "add_foreground_bold": "#F9F9F4",
-            "add_background_bold": "#287020",
-            "remove_foreground": "#F9F9F4",
-            "remove_background": "#A83732",
-            "remove_foreground_bold": "#F9F9F4",
-            "remove_background_bold": "#702820"
-        },
         "log_graph": {
             "commit_dot_foreground": "#9911",
             "commit_dot_background": "#991",

--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -342,12 +342,6 @@
     "load_additional_codecs": false,
 
     /*
-        Set this value to true if you'd like GitSavvy to automatically attempt
-        to decode using the `fallback_encoding` value, without prompting.
-     */
-    "silent_fallback": false,
-
-    /*
         GitSavvy allows you to press `Tab` to cycle from one dashboard interface
         to the next.  This setting defines the order of that cycle.  The following
         are valid entries, and can be included in your preferred order:

--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -74,10 +74,10 @@
     "show_commit_diff": "stat",
 
     /*
-        Change this to `true` to scroll to the first hunk automatically when
-        you open the inline-diff view.
+        Change this to `false` to not scroll to the first hunk automatically when
+        you open the inline-diff view from the status dashboard.
      */
-    "inline_diff_auto_scroll": false,
+    "inline_diff_auto_scroll": true,
 
     "colors": {
         "log_graph": {

--- a/common/util/__init__.py
+++ b/common/util/__init__.py
@@ -1,6 +1,6 @@
 import sys
 
-from .parse_diff import parse_diff
+from .parse_diff import parse_diff, UnsupportedDiffMode
 from . import dates
 from . import view
 from . import file

--- a/common/util/diff_string.py
+++ b/common/util/diff_string.py
@@ -42,7 +42,7 @@ def get_changes(old, new):
 
     matcher = SequenceMatcher(a=old_chunks, b=new_chunks, autojunk=False)
 
-    if matcher.quick_ratio() < 0.85:
+    if matcher.quick_ratio() < 0.75 or matcher.ratio() < 0.75:
         return []
 
     return [Change(change_type, old_indices[os], old_indices[oe], new_indices[ns], new_indices[ne])

--- a/common/util/file.py
+++ b/common/util/file.py
@@ -5,8 +5,13 @@ import os
 from contextlib import contextmanager
 
 
+MYPY = False
+if MYPY:
+    from typing import Dict, List
+
+
 if 'syntax_file_map' not in globals():
-    syntax_file_map = {}
+    syntax_file_map = {}  # type: Dict[str, List[str]]
 
 if 'determine_syntax_thread' not in globals():
     determine_syntax_thread = None

--- a/common/util/file.py
+++ b/common/util/file.py
@@ -44,8 +44,8 @@ def get_syntax_for_file(filename):
 
 
 def get_file_extension(filename):
-    period_delimited_segments = filename.split(".")
-    return "" if len(period_delimited_segments) < 2 else period_delimited_segments[-1]
+    # type: (str) -> str
+    return os.path.splitext(filename)[1][1:]
 
 
 def get_file_contents_binary(repo_path, file_path):

--- a/common/util/parse_diff.py
+++ b/common/util/parse_diff.py
@@ -12,6 +12,10 @@ Change = namedtuple("Change", ("raw", "type", "head_pos", "saved_pos", "text"))
 re_metadata = re.compile(r"^@@ -(\d+)(,(\d+))? \+(\d+)(,(\d+))? @@")
 
 
+class UnsupportedDiffMode(RuntimeError):
+    pass
+
+
 def parse_diff(diff_str):
     """
     Given the string output from a `git diff` command, parse the string into
@@ -65,6 +69,9 @@ def _get_metadata(meta_str):
     the start and length values from that header.
     """
     match = re_metadata.match(meta_str)
+    if match is None:
+        raise UnsupportedDiffMode(meta_str)
+
     head_start, _, head_length, saved_start, _, saved_length = match.groups()
     return (int(head_start),
             int(head_length or "1"),

--- a/common/util/parse_diff.py
+++ b/common/util/parse_diff.py
@@ -24,7 +24,7 @@ def parse_diff(diff_str):
     """
     hunks = []
 
-    raw_hunks = _split_into_hunks(diff_str.splitlines())
+    raw_hunks = _split_into_hunks(diff_str.splitlines(keepends=True))
 
     for raw_hunk in raw_hunks:
         hunk_lines = list(raw_hunk)

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -297,8 +297,8 @@ class gs_inline_diff_refresh(TextCommand, GitCommand):
                 section_start, section_end, hunk, line_types, raw_lines
             ))
 
-            # Discard the first character of every diff-line (`+`, `-`).
-            lines = lines[:section_start] + raw_lines + lines[head_end + adjustment:]
+            tail = lines[head_end + adjustment + (1 if line_types[-1] == "\\" else 0):]
+            lines = lines[:section_start] + raw_lines + tail
             replaced_lines.append((section_start, section_end, line_types, raw_lines))
 
             adjustment += len(diff_lines) - hunk.head_length

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -485,6 +485,9 @@ class gs_inline_diff_stage_or_reset_base(TextCommand, GitCommand):
         # Git lines are 1-indexed; Sublime rows are 0-indexed.
         line_number = self.view.rowcol(region.begin())[0] + 1
         diff_lines = self.get_diff_from_line(line_number, reset)
+        if not diff_lines:
+            flash(self.view, "Not on a hunk.")
+            return
 
         rel_path = self.get_rel_path()
         if os.name == "nt":

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -462,7 +462,7 @@ class gs_inline_diff_stage_or_reset_base(TextCommand, GitCommand):
         #    apply the patch in reverse, but only apply it against the cached/
         #    indexed file.
         #
-        # NOTE: When in cached mode, the action taken will always be to apply
+        # Note: When in cached mode, the action taken will always be to apply
         #       the patch in reverse only to the index.
 
         args = [

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -27,7 +27,7 @@ __all__ = (
 
 MYPY = False
 if MYPY:
-    from typing import Iterable, Optional, Tuple
+    from typing import Dict, Iterable, List, Optional, Tuple
 
 
 HunkReference = namedtuple("HunkReference", ("section_start", "section_end", "hunk", "line_types", "lines"))
@@ -41,7 +41,7 @@ DIFF_HEADER = """diff --git a/{path} b/{path}
 +++ b/{path}
 """
 
-diff_view_hunks = {}
+diff_view_hunks = {}  # type: Dict[sublime.ViewId, List[HunkReference]]
 
 
 def capture_cur_position(view):
@@ -279,7 +279,7 @@ class gs_inline_diff_refresh(TextCommand, GitCommand):
         in `diff_view_hunks` to be used when the user takes an
         action in the view.
         """
-        hunks = []
+        hunks = []  # type: List[HunkReference]
         diff_view_hunks[self.view.id()] = hunks
 
         lines = original_contents.split("\n")
@@ -323,9 +323,9 @@ class gs_inline_diff_refresh(TextCommand, GitCommand):
         for the lines in that hunk, highlight the added regions in green and
         the removed regions in red.
         """
-        add_regions = []
+        add_regions = []  # type: List[sublime.Region]
         add_bold_regions = []
-        remove_regions = []
+        remove_regions = []  # type: List[sublime.Region]
         remove_bold_regions = []
 
         for section_start, section_end, line_types, raw_lines in replaced_lines:

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -92,6 +92,11 @@ def compute_identifier_for_view(view):
     ) if settings.get('git_savvy.inline_diff_view') else None
 
 
+def is_inline_diff_view(view):
+    # type: (sublime.View) -> bool
+    return view.settings().get('git_savvy.inline_diff_view')
+
+
 class gs_inline_diff(WindowCommand, GitCommand):
 
     """
@@ -104,6 +109,10 @@ class gs_inline_diff(WindowCommand, GitCommand):
         if settings is None:
             active_view = self.window.active_view()
             assert active_view
+            # Let this command act like a toggle
+            if is_inline_diff_view(active_view):
+                active_view.close()
+                return
 
             repo_path = self.repo_path
             file_path = self.file_path

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -345,9 +345,8 @@ class gs_inline_diff_refresh(TextCommand, GitCommand):
                 container = add_regions if line_type == "+" else remove_regions
                 container.append(region)
 
-            # If there are both additions and removals in the hunk, display additional
-            # highlighting for the in-line changes (if similarity is above threshold).
-            if "+" in line_types and "-" in line_types:
+            # For symmetric modifications show highlighting for the in-line changes
+            if sum(1 if t == "+" else -1 for t in line_types) == 0:
                 # Determine start of hunk/section.
                 section_start_idx = self.view.text_point(section_start, 0)
 

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -478,7 +478,7 @@ class gs_inline_diff_stage_or_reset_base(TextCommand, GitCommand):
         self.git(*args, stdin=full_diff, stdin_encoding=encoding)
         self.save_to_history(args, full_diff, encoding)
 
-        cur_pos = capture_cur_position(self.view) if not reset else None
+        cur_pos = capture_cur_position(self.view) if not (reset or in_cached_mode) else None
         if cur_pos is not None:
             row, col, offset = cur_pos
             line_no, col_no = translate_pos_from_diff_view_to_file(self.view, row + 1, col + 1)

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -657,10 +657,7 @@ class gs_inline_diff_open_file(TextCommand):
         # The selected line is after the hunk.
         else:
             lines_after_hunk_end = line_no - hunk_ref.section_end - 1
-            # Adjust line position for remove-only hunks.
-            if all(change.type == "-" for change in hunk_ref.hunk.changes):
-                lines_after_hunk_end += 1
-            hunk_end_in_saved = hunk_ref.hunk.saved_start + hunk_ref.hunk.saved_length
+            hunk_end_in_saved = real_saved_start(hunk_ref.hunk) + hunk_ref.hunk.saved_length
             return hunk_end_in_saved + lines_after_hunk_end, col_no
 
     def get_closest_hunk_ref_before(self, line_no):

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -105,7 +105,7 @@ class gs_inline_diff(WindowCommand, GitCommand):
     hunks or individual lines, and to navigate between hunks.
     """
 
-    def run(self, settings=None, cached=False, match_current_position=False):
+    def run(self, settings=None, cached=False, match_current_position=True):
         if settings is None:
             active_view = self.window.active_view()
             assert active_view

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -258,7 +258,7 @@ class gs_inline_diff_refresh(TextCommand, GitCommand):
         replace_view_content(view, inline_diff_contents)
 
         if match_position is None:
-            if cur_pos == (0, 0, 0) and self.savvy_settings.get("inline_diff_auto_scroll"):
+            if cur_pos == (0, 0, 0) and self.savvy_settings.get("inline_diff_auto_scroll", True):
                 view.run_command("gs_inline_diff_navigate_hunk")
         else:
             row, col, row_offset = match_position

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -140,6 +140,9 @@ class gs_inline_diff(WindowCommand, GitCommand):
 
             repo_path = self.repo_path
             file_path = self.file_path
+            if not file_path:
+                flash(active_view, "Cannot show diff for unnamed buffers.")
+                return
 
             is_ordinary_view = bool(active_view.file_name())
             if is_ordinary_view:

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -142,6 +142,10 @@ class gs_inline_diff(WindowCommand, GitCommand):
             if is_ordinary_view:
                 syntax_file = active_view.settings().get("syntax")
                 cur_pos = capture_cur_position(active_view) if match_current_position else None
+                if cur_pos is not None and cached:
+                    row, col, offset = cur_pos
+                    new_row = self.find_matching_lineno(None, None, row + 1, self.file_path) - 1
+                    cur_pos = (new_row, col, offset)
             else:
                 syntax_file = util.file.get_syntax_for_file(file_path)
                 cur_pos = None

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -131,7 +131,10 @@ class gs_inline_diff(WindowCommand, GitCommand):
             active_view = self.window.active_view()
             assert active_view
             # Let this command act like a toggle
-            if is_inline_diff_view(active_view):
+            if (
+                is_inline_diff_view(active_view) and
+                active_view.settings().get('git_savvy.inline_diff_view.in_cached_mode') == cached
+            ):
                 active_view.close()
                 return
 

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -228,16 +228,11 @@ class gs_inline_diff_refresh(TextCommand, GitCommand):
             return
 
         hunks_count = len(diff)
-        if hunks_count == 0:
-            flash(self.view, "The file is clean.")
-            self.view.close()
-            return
-        else:
-            flash(self.view, "File has {} {} {}".format(
-                hunks_count,
-                "staged" if in_cached_mode else "unstaged",
-                "hunk" if hunks_count == 1 else "hunks"
-            ))
+        flash(self.view, "File has {} {} {}".format(
+            hunks_count,
+            "staged" if in_cached_mode else "unstaged",
+            "hunk" if hunks_count == 1 else "hunks"
+        ))
 
         rel_file_path = self.get_rel_path(file_path).replace('\\', '/')
         if in_cached_mode:

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -11,6 +11,19 @@ from ..view import replace_view_content
 from ...common import util
 from ...common.theme_generator import XMLThemeGenerator, JSONThemeGenerator
 
+
+__all__ = (
+    "gs_inline_diff",
+    "gs_inline_diff_refresh",
+    "gs_inline_diff_stage_or_reset_line",
+    "gs_inline_diff_stage_or_reset_hunk",
+    "gs_inline_diff_open_file",
+    "gs_inline_diff_navigate_hunk",
+    "gs_inline_diff_undo",
+    "GsInlineDiffFocusEventListener",
+)
+
+
 HunkReference = namedtuple("HunkReference", ("section_start", "section_end", "hunk", "line_types", "lines"))
 
 
@@ -61,7 +74,7 @@ def translate_row_to_inline_diff(diff_view, row):
     return row + deleted_lines_before_row
 
 
-class GsInlineDiffCommand(WindowCommand, GitCommand):
+class gs_inline_diff(WindowCommand, GitCommand):
 
     """
     Given an open file in a git-tracked directory, show a new view with the
@@ -161,7 +174,7 @@ class GsInlineDiffCommand(WindowCommand, GitCommand):
         themeGenerator.apply_new_theme("active-diff-view." + file_ext, target_view)
 
 
-class GsInlineDiffRefreshCommand(TextCommand, GitCommand):
+class gs_inline_diff_refresh(TextCommand, GitCommand):
 
     """
     Diff one version of a file (the base) against another, and display the
@@ -372,7 +385,7 @@ class GsInlineDiffFocusEventListener(EventListener):
             view.run_command("gs_inline_diff_refresh", {"sync": False})
 
 
-class GsInlineDiffStageOrResetBase(TextCommand, GitCommand):
+class gs_inline_diff_stage_or_reset_base(TextCommand, GitCommand):
 
     """
     Base class for any stage or reset operation in the inline-diff view.
@@ -448,7 +461,7 @@ class GsInlineDiffStageOrResetBase(TextCommand, GitCommand):
         self.view.settings().set("git_savvy.inline_diff.history", history)
 
 
-class GsInlineDiffStageOrResetLineCommand(GsInlineDiffStageOrResetBase):
+class gs_inline_diff_stage_or_reset_line(gs_inline_diff_stage_or_reset_base):
 
     """
     Given a line number, generate a diff of that single line in the active
@@ -540,7 +553,7 @@ class GsInlineDiffStageOrResetLineCommand(GsInlineDiffStageOrResetBase):
             )
 
 
-class GsInlineDiffStageOrResetHunkCommand(GsInlineDiffStageOrResetBase):
+class gs_inline_diff_stage_or_reset_hunk(gs_inline_diff_stage_or_reset_base):
 
     """
     Given a line number, generate a diff of the hunk containing that line,
@@ -587,7 +600,7 @@ class GsInlineDiffStageOrResetHunkCommand(GsInlineDiffStageOrResetBase):
         return "\n".join([stand_alone_header] + hunk_ref.hunk.raw_lines[1:])
 
 
-class GsInlineDiffOpenFile(TextCommand):
+class gs_inline_diff_open_file(TextCommand):
 
     """
     Opens an editable view of the file being diff'd.
@@ -646,7 +659,7 @@ class GsInlineDiffOpenFile(TextCommand):
                 return hunk_ref
 
 
-class GsInlineDiffNavigateHunkCommand(GsNavigate):
+class gs_inline_diff_navigate_hunk(GsNavigate):
 
     """
     Navigate to the next/previous hunk that appears after the current cursor
@@ -662,7 +675,7 @@ class GsInlineDiffNavigateHunkCommand(GsNavigate):
             for hunk in diff_view_hunks[self.view.id()]]
 
 
-class GsInlineDiffUndo(TextCommand, GitCommand):
+class gs_inline_diff_undo(TextCommand, GitCommand):
 
     """
     Undo the last action taken in the inline-diff view, if possible.

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -6,6 +6,7 @@ from sublime_plugin import WindowCommand, TextCommand, EventListener
 
 from .navigate import GsNavigate
 from ..git_command import GitCommand
+from ..utils import flash
 from ..runtime import enqueue_on_ui
 from ..view import replace_view_content
 from ...common import util
@@ -198,6 +199,18 @@ class gs_inline_diff_refresh(TextCommand, GitCommand):
                                   "it has a merge conflict.")
             self.view.close()
             return
+
+        hunks_count = len(diff)
+        if hunks_count == 0:
+            flash(self.view, "The file is clean.")
+            self.view.close()
+            return
+        else:
+            flash(self.view, "File has {} {} {}".format(
+                hunks_count,
+                "staged" if in_cached_mode else "unstaged",
+                "hunk" if hunks_count == 1 else "hunks"
+            ))
 
         rel_file_path = self.get_rel_path(file_path).replace('\\', '/')
         if in_cached_mode:

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -282,7 +282,7 @@ class gs_inline_diff_refresh(TextCommand, GitCommand):
         hunks = []  # type: List[HunkReference]
         diff_view_hunks[self.view.id()] = hunks
 
-        lines = original_contents.split("\n")
+        lines = original_contents.splitlines(keepends=True)
         replaced_lines = []
 
         adjustment = 0
@@ -314,7 +314,7 @@ class gs_inline_diff_refresh(TextCommand, GitCommand):
 
             adjustment += len(diff_lines) - hunk.head_length
 
-        return "\n".join(lines), replaced_lines
+        return "".join(lines), replaced_lines
 
     def highlight_regions(self, replaced_lines):
         """
@@ -353,10 +353,10 @@ class gs_inline_diff_refresh(TextCommand, GitCommand):
                 # Removed lines come first in a hunk.
                 remove_start = section_start_idx
                 first_added_line = line_types.index("+")
-                add_start = section_start_idx + len("\n".join(raw_lines[:first_added_line])) + 1
+                add_start = section_start_idx + len("".join(raw_lines[:first_added_line]))
 
-                removed_part = "\n".join(raw_lines[:first_added_line])
-                added_part = "\n".join(raw_lines[first_added_line:])
+                removed_part = "".join(raw_lines[:first_added_line])
+                added_part = "".join(raw_lines[first_added_line:])
                 changes = util.diff_string.get_changes(removed_part, added_part)
 
                 for change in changes:
@@ -598,7 +598,7 @@ class gs_inline_diff_stage_or_reset_hunk(gs_inline_diff_stage_or_reset_base):
             return
 
         stand_alone_header = \
-            "@@ -{head_start},{head_length} +{new_start},{new_length} @@".format(
+            "@@ -{head_start},{head_length} +{new_start},{new_length} @@\n".format(
                 head_start=hunk_ref.hunk.head_start + (add_length_earlier_in_diff if reset else 0),
                 head_length=hunk_ref.hunk.head_length,
                 # If head_length is zero, diff will report original start position
@@ -608,7 +608,7 @@ class gs_inline_diff_stage_or_reset_hunk(gs_inline_diff_stage_or_reset_base):
                 new_length=hunk_ref.hunk.saved_length
             )
 
-        return "\n".join([stand_alone_header] + hunk_ref.hunk.raw_lines[1:])
+        return "".join([stand_alone_header] + hunk_ref.hunk.raw_lines[1:])
 
 
 class gs_inline_diff_open_file(TextCommand):

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -102,13 +102,19 @@ class gs_inline_diff(WindowCommand, GitCommand):
 
     def run(self, settings=None, cached=False, match_current_position=False):
         if settings is None:
-            file_view = self.window.active_view()
-            assert file_view
+            active_view = self.window.active_view()
+            assert active_view
 
             repo_path = self.repo_path
             file_path = self.file_path
-            syntax_file = file_view.settings().get("syntax")
-            cur_pos = capture_cur_position(file_view) if match_current_position else None
+
+            is_ordinary_view = bool(active_view.file_name())
+            if is_ordinary_view:
+                syntax_file = active_view.settings().get("syntax")
+                cur_pos = capture_cur_position(active_view) if match_current_position else None
+            else:
+                syntax_file = util.file.get_syntax_for_file(file_path)
+                cur_pos = None
 
         else:
             repo_path = settings["repo_path"]

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -163,12 +163,11 @@ class gs_inline_diff_refresh(TextCommand, GitCommand):
 
     def run(self, edit, sync=True, match_position=None):
         if sync:
-            self._run(match_position=match_position)
+            self._run(sync, match_position)
         else:
-            sublime.set_timeout_async(lambda: self._run(match_position=match_position))
+            sublime.set_timeout_async(lambda: self._run(sync, match_position))
 
-    def _run(self, match_position=None):
-
+    def _run(self, runs_on_ui_thread, match_position):
         file_path = self.file_path
         rel_file_path = self.get_rel_path(file_path).replace('\\', '/')
         in_cached_mode = self.view.settings().get("git_savvy.inline_diff_view.in_cached_mode")
@@ -219,7 +218,10 @@ class gs_inline_diff_refresh(TextCommand, GitCommand):
 
             self.highlight_regions(replaced_lines)
 
-        enqueue_on_ui(draw, self.view)
+        if runs_on_ui_thread:
+            draw(self.view)
+        else:
+            enqueue_on_ui(draw, self.view)
 
     def abort_for_conflicted_file(self):
         # type: () -> None

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -492,7 +492,7 @@ class gs_inline_diff_stage_or_reset_line(gs_inline_diff_stage_or_reset_base):
 
         # Find the correct hunk.
         for hunk_ref in hunks:
-            if hunk_ref.section_start <= line_no and hunk_ref.section_end >= line_no:
+            if hunk_ref.section_start < line_no <= hunk_ref.section_end:
                 break
             else:
                 # we loop through all hooks before selected hunk.
@@ -515,6 +515,7 @@ class gs_inline_diff_stage_or_reset_line(gs_inline_diff_stage_or_reset_base):
 
         # Determine head/staged starting line.
         index_in_hunk = line_no - section_start
+        assert index_in_hunk >= 0
         line = hunk_ref.lines[index_in_hunk]
         line_type = hunk_ref.line_types[index_in_hunk]
 
@@ -581,7 +582,7 @@ class gs_inline_diff_stage_or_reset_hunk(gs_inline_diff_stage_or_reset_base):
 
         # Find the correct hunk.
         for hunk_ref in hunks:
-            if hunk_ref.section_start <= line_no and hunk_ref.section_end >= line_no:
+            if hunk_ref.section_start < line_no <= hunk_ref.section_end:
                 break
             else:
                 # we loop through all hooks before selected hunk.

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -503,11 +503,6 @@ class gs_inline_diff_stage_or_reset_line(gs_inline_diff_stage_or_reset_base):
                         add_length_earlier_in_diff += 1
                     elif type == "-":
                         add_length_earlier_in_diff -= 1
-                    else:
-                        # should never happen that it will raise.
-                        raise ValueError('type have to be eather "+" or "-"')
-
-        # Correct hunk not found.
         else:
             return
 
@@ -524,8 +519,7 @@ class gs_inline_diff_stage_or_reset_line(gs_inline_diff_stage_or_reset_base):
         for type in hunk_ref.line_types[:index_in_hunk]:
             if type == "-":
                 cur_hunk_begin_on_minus += 1
-            else:
-                # type will be +
+            elif type == "+":
                 cur_hunk_begin_on_plus += 1
 
         # Removed lines are always first with `git diff -U0 ...`. Therefore, the
@@ -593,11 +587,6 @@ class gs_inline_diff_stage_or_reset_hunk(gs_inline_diff_stage_or_reset_base):
                         add_length_earlier_in_diff += 1
                     elif type == "-":
                         add_length_earlier_in_diff -= 1
-                    else:
-                        # should never happen that it will raise.
-                        raise ValueError('type have to be eather "+" or "-"')
-
-        # Correct hunk not found.
         else:
             return
 

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -498,6 +498,10 @@ class gs_inline_diff_stage_or_reset_base(TextCommand, GitCommand):
         history.append((args, full_diff, encoding))
         self.view.settings().set("git_savvy.inline_diff.history", history)
 
+    def get_diff_from_line(self, line_no, reset):
+        # type: (LineNo, bool) -> str
+        raise NotImplementedError
+
 
 class gs_inline_diff_stage_or_reset_line(gs_inline_diff_stage_or_reset_base):
 

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -6,10 +6,12 @@ Define a base command class that:
      for Git operations.
 """
 
+import locale
 import os
 import subprocess
 import shutil
 import re
+import time
 import threading
 import traceback
 
@@ -30,21 +32,21 @@ from .git_mixins.rewrite import RewriteMixin
 from .git_mixins.merge import MergeMixin
 from .exceptions import GitSavvyError
 from .settings import SettingsMixin
-import time
+
+
+MYPY = False
+if MYPY:
+    from typing import Sequence, Tuple
+
 
 git_path = None
 error_message_displayed = False
 
-UTF8_PARSE_ERROR_MSG = (
-    "GitSavvy was unable to parse Git output as UTF-8. Would "
-    "you like to use the fallback encoding specified in GitSavvy "
-    "settings? Text may not appear as expected."
-)
-
 FALLBACK_PARSE_ERROR_MSG = (
-    "The Git command returned data that unparsable.  This may happen "
-    "if you have checked binary data into your repository.  The current "
-    "operation has been aborted."
+    "The Git command returned data that is unparsable.  This may happen "
+    "if you have checked binary data into your repository, or not UTF-8 "
+    "encoded files.  In the latter case use the 'fallback_encoding' setting.  "
+    "The current operation has been aborted."
 )
 
 MIN_GIT_VERSION = (2, 16, 0)
@@ -285,22 +287,30 @@ class GitCommand(StatusMixin,
 
         return stdout
 
+    def get_encoding_candidates(self):
+        # type: () -> Sequence[str]
+        return [
+            'utf-8',
+            locale.getpreferredencoding(),
+            self.savvy_settings.get("fallback_encoding")
+        ]
+
     def decode_stdout(self, stdout):
-        fallback_encoding = self.savvy_settings.get("fallback_encoding")
-        silent_fallback = self.savvy_settings.get("silent_fallback")
-        try:
-            return stdout.decode()
-        except UnicodeDecodeError:
+        # type: (bytes) -> str
+        encodings = self.get_encoding_candidates()
+        decoded, _ = self.try_decode(stdout, encodings)
+        return decoded
+
+    def try_decode(self, input, encodings):  # type: ignore  # missing return statement
+        # type: (bytes, Sequence[str]) -> Tuple[str, str]
+        assert encodings
+        for n, encoding in enumerate(encodings, start=1):
             try:
-                return stdout.decode("latin-1")
-            except UnicodeDecodeError as unicode_err:
-                if silent_fallback or sublime.ok_cancel_dialog(UTF8_PARSE_ERROR_MSG, "Fallback?"):
-                    try:
-                        return stdout.decode(fallback_encoding)
-                    except UnicodeDecodeError as fallback_err:
-                        sublime.error_message(FALLBACK_PARSE_ERROR_MSG)
-                        raise fallback_err
-                raise unicode_err
+                return input.decode(encoding), encoding
+            except UnicodeDecodeError as err:
+                if n == len(encodings):
+                    sublime.error_message(FALLBACK_PARSE_ERROR_MSG)
+                    raise err
 
     @property
     def encoding(self):

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -513,8 +513,8 @@ class GsStatusDiffInlineCommand(TextCommand, GitCommand):
         for fpath in non_cached_files:
             syntax = util.file.get_syntax_for_file(fpath)
             settings = {
-                "git_savvy.file_path": fpath,
-                "git_savvy.repo_path": self.repo_path,
+                "file_path": fpath,
+                "repo_path": self.repo_path,
                 "syntax": syntax
             }
             window.run_command("gs_inline_diff", {"settings": settings})
@@ -522,8 +522,8 @@ class GsStatusDiffInlineCommand(TextCommand, GitCommand):
         for fpath in cached_files:
             syntax = util.file.get_syntax_for_file(fpath)
             settings = {
-                "git_savvy.file_path": fpath,
-                "git_savvy.repo_path": self.repo_path,
+                "file_path": fpath,
+                "repo_path": self.repo_path,
                 "syntax": syntax
             }
             window.run_command("gs_inline_diff", {

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -517,7 +517,10 @@ class GsStatusDiffInlineCommand(TextCommand, GitCommand):
                 "repo_path": self.repo_path,
                 "syntax": syntax
             }
-            window.run_command("gs_inline_diff", {"settings": settings})
+            window.run_command("gs_inline_diff", {
+                "settings": settings,
+                "cached": False
+            })
 
         for fpath in cached_files:
             syntax = util.file.get_syntax_for_file(fpath)

--- a/core/utils.py
+++ b/core/utils.py
@@ -76,6 +76,17 @@ def flash(view, message):
         window.status_message(message)
 
 
+def focus_view(view):
+    # type: (sublime.View) -> None
+    window = view.window()
+    if not window:
+        return
+
+    group, _ = window.get_view_index(view)
+    window.focus_group(group)
+    window.focus_view(view)
+
+
 def line_indentation(line):
     # type: (str) -> int
     return len(line) - len(line.lstrip())

--- a/core/utils.py
+++ b/core/utils.py
@@ -11,6 +11,7 @@ import traceback
 MYPY = False
 if MYPY:
     from typing import Callable, Iterator, Type
+    import sublime
 
 
 @contextmanager
@@ -66,6 +67,13 @@ def hprint(msg):
     # We later might find better ways to show these help
     # messages to the user.
     print(msg)
+
+
+def flash(view, message):
+    # type: (sublime.View, str) -> None
+    window = view.window()
+    if window:
+        window.status_message(message)
 
 
 def line_indentation(line):

--- a/popups/diff_view.html
+++ b/popups/diff_view.html
@@ -21,6 +21,7 @@
   <li><code><span class="shortcut-key">H / {super_key}-backspace&nbsp;&nbsp;</span>reset hunk</code></li>
   <li><code><span class="shortcut-key">c&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>commit</code></li>
   <li><code><span class="shortcut-key">C&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>commit, including unstaged</code></li>
+  <li><code><span class="shortcut-key">m&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>amend previous commit</code></li>
 </ul>
 
 <h3>Other</h3>

--- a/popups/diff_view.html
+++ b/popups/diff_view.html
@@ -16,7 +16,7 @@
 
 <h3>When Diffing Working Tree</h3>
 <ul>
-  <li><code><span class="shortcut-key">tab&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>switch between staged/unstaged area</code></li>
+  <li><code><span class="shortcut-key">TAB&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>switch between staged/unstaged area</code></li>
   <li><code><span class="shortcut-key">h / {super_key}-enter&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>stage hunk / unstage hunk (in cached mode)</code></li>
   <li><code><span class="shortcut-key">H / {super_key}-backspace&nbsp;&nbsp;</span>reset hunk</code></li>
   <li><code><span class="shortcut-key">c&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>commit</code></li>

--- a/popups/inline_diff_view.html
+++ b/popups/inline_diff_view.html
@@ -20,7 +20,6 @@
 <h3>Other</h3>
 <ul>
   <li><code><span class="shortcut-key">?&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>show this help popup</code></li>
-  <li><code><span class="shortcut-key">r&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>refresh the page</code></li>
   <li><code><span class="shortcut-key">{super_key}-z&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>undo last action</code></li>
 </ul>
 

--- a/popups/inline_diff_view.html
+++ b/popups/inline_diff_view.html
@@ -13,6 +13,10 @@
   <li><code><span class="shortcut-key">h&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>stage hunk / unstage line (in cached mode)</code></li>
   <li><code><span class="shortcut-key">L&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>reset line</code></li>
   <li><code><span class="shortcut-key">H&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>reset hunk</code></li>
+  <li><code><span class="shortcut-key">c&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>commit</code></li>
+  <li><code><span class="shortcut-key">C&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>commit, including unstaged</code></li>
+  <li><code><span class="shortcut-key">m&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>amend previous commit</code></li>
+
   <li><code><span class="shortcut-key">.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>go to next hunk</code></li>
   <li><code><span class="shortcut-key">,&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>go to previous hunk</code></li>
 </ul>

--- a/popups/inline_diff_view.html
+++ b/popups/inline_diff_view.html
@@ -9,6 +9,7 @@
 <ul>
   <li><code><span class="shortcut-key">o&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>open file at hunk</code></li>
 
+  <li><code><span class="shortcut-key">TAB&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>switch between staged/unstaged area</code></li>
   <li><code><span class="shortcut-key">l&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>stage line / unstage line (in cached mode)</code></li>
   <li><code><span class="shortcut-key">h&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>stage hunk / unstage line (in cached mode)</code></li>
   <li><code><span class="shortcut-key">L&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>reset line</code></li>


### PR DESCRIPTION
~~On top of #1305 for testing convenience.~~

It is recommended to bind `gs_inline_diff` to a key combo so it becomes a main entry point into the GitSavvy world. E.g.

```
  {
      "keys": ["ctrl+shift+["],
      "command": "gs_inline_diff",
  },
```

Now, this key acts like a toggle. You press it to switch to the inline view. Press it again to close it. Extra care has been taken that the viewport doesn't jump around while doing that. 

Being in that view, you can stage, undo staging, or discard changes. Use `[TAB]` to switch between the staged and unstaged mode. 

Use `[c]`, `[C]` or `[m]` to enter the commit message view.

Notable changes:

- Uses the builtin color scheme (just like the intra line colorization for the normal diff views).  You can compare toggling the built in "Show modifications" feat, (iirc `ctrl+shift+.` by default) with calling `gs_inline_diff` and notice that both look very similar, coherent now. 

- Fix: Show error for conflicting files
- Fix: Don't select a hunk if exactly on the line above a hunk
- Simplify how we find the right encoding being used. Remove "silent_fallback" setting by doing so.
- Fix: Respect original line endings. 
- Fix: Open file at cursor when in cached mode
- Fix: Don't throw when user "[h]unks" not being on a hunk
- Adds `[m]` to the normal diff view for consistency



