### PR TITLE
Lower case HTTP Response headers keys

### DIFF
--- a/github/github.py
+++ b/github/github.py
@@ -191,12 +191,12 @@ def iteratively_query_github(api_url_template, github_repo):
     while True:
         if response is not None:
             # it means this is not the first iter
-            if "Link" not in response.headers:
+            if "link" not in response.headers:
                 break
 
             # following next link
             # https://developer.github.com/v3/#pagination
-            match = re.match(r'.*<([^>]+)>; rel="next"', response.headers["Link"])
+            match = re.match(r'.*<([^>]+)>; rel="next"', response.headers["link"])
             if not match:
                 break
 

--- a/gitlab/gitlab.py
+++ b/gitlab/gitlab.py
@@ -209,12 +209,12 @@ def iteratively_query_gitlab(api_url_template, gitlab_repo, **url_params):
     while True:
         if response is not None:
             # it means this is not the first iter
-            if "Link" not in response.headers:
+            if "link" not in response.headers:
                 break
 
             # following next link
             # https://docs.gitlab.com/ee/api/README.html#pagination
-            match = re.match(r'<([^>]+)>; rel="next"', response.headers["Link"])
+            match = re.match(r'<([^>]+)>; rel="next"', response.headers["link"])
             if not match:
                 break
 


### PR DESCRIPTION
Fixes #1312

Generally header keys must be read case-insensitive because a specific
casing is not enforced by any spec.  We go the simple route as we don't
have many use-cases in the code base and just normalize to lower case
when reading the response headers.