### PR TITLE
Improve syntax parsing

### DIFF
--- a/common/commands/help.py
+++ b/common/commands/help.py
@@ -61,7 +61,9 @@ class GsHelp(WindowCommand):
         view = util.view.get_scratch_view(self, "help", read_only=True)
         view.set_name("GITSAVVY HELP")
 
-        syntax_file = util.file.get_syntax_for_file("*.md")
+        syntax_file = util.file.get_syntax_for_file(
+            "*.md", default="Packages/Markdown/Markdown.sublime-syntax"
+        )
         view.set_syntax_file(syntax_file)
 
         view.run_command("gs_help_browse", {"page": page, "anchor": anchor})

--- a/common/commands/help.py
+++ b/common/commands/help.py
@@ -81,7 +81,11 @@ class GsHelpBrowse(TextCommand):
 
         if not page == previous_page:
             settings.set("git_savvy.help.page", page)
-            content = sublime.load_resource("Packages/GitSavvy/docs/" + page)
+            content = (
+                sublime.load_resource("Packages/GitSavvy/docs/" + page)
+                .replace('\r\n', '\n')
+                .replace('\r', '\n')
+            )
 
             is_read_only = self.view.is_read_only()
             self.view.set_read_only(False)

--- a/common/util/file.py
+++ b/common/util/file.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 from contextlib import contextmanager
 import os
+import plistlib
 import re
 import threading
 import yaml
@@ -46,6 +47,26 @@ def _try_yaml_parse(text):
 
 
 def _determine_syntax_files():
+    # type: () -> None
+    handle_tm_language_files()
+    handle_sublime_syntax_files()
+
+
+def handle_tm_language_files():
+    # type: () -> None
+    syntax_files = sublime.find_resources("*.tmLanguage")
+    for syntax_file in syntax_files:
+        try:
+            resource = sublime.load_binary_resource(syntax_file)
+        except Exception:
+            print("GitSavvy: could not load {}".format(syntax_file))
+            continue
+
+        for extension in plistlib.readPlistFromBytes(resource).get("fileTypes", []):
+            syntax_file_map[extension].append(syntax_file)
+
+
+def handle_sublime_syntax_files():
     # type: () -> None
     syntax_files = sublime.find_resources("*.sublime-syntax")
     for syntax_file in syntax_files:

--- a/common/util/file.py
+++ b/common/util/file.py
@@ -1,23 +1,27 @@
-import sublime
+from collections import defaultdict
+from contextlib import contextmanager
+import os
+import re
 import threading
 import yaml
-import os
-from contextlib import contextmanager
+
+import sublime
 
 
 MYPY = False
 if MYPY:
-    from typing import Dict, List
+    from typing import DefaultDict, List, Optional
 
 
 if 'syntax_file_map' not in globals():
-    syntax_file_map = {}  # type: Dict[str, List[str]]
+    syntax_file_map = defaultdict(list)  # type: DefaultDict[str, List[str]]
 
 if 'determine_syntax_thread' not in globals():
     determine_syntax_thread = None
 
 
 def determine_syntax_files():
+    # type: () -> None
     global determine_syntax_thread
     if not syntax_file_map:
         determine_syntax_thread = threading.Thread(
@@ -25,27 +29,46 @@ def determine_syntax_files():
         determine_syntax_thread.start()
 
 
+def try_parse_for_file_extensions(text):
+    # type: (str) -> Optional[List[str]]
+    match = re.search(r"^file_extensions:\n((.*\n)+?)^(?=\w)", text, re.M)
+    if match:
+        return _try_yaml_parse(match.group(0))
+    return _try_yaml_parse(text)
+
+
+def _try_yaml_parse(text):
+    # type: (str) -> Optional[List[str]]
+    try:
+        return yaml.safe_load(text)["file_extensions"]
+    except Exception:
+        return None
+
+
 def _determine_syntax_files():
+    # type: () -> None
     syntax_files = sublime.find_resources("*.sublime-syntax")
     for syntax_file in syntax_files:
         try:
-            # Use `sublime.load_resource`, in case Package is `*.sublime-package`.
             resource = sublime.load_resource(syntax_file)
-            for extension in yaml.safe_load(resource)["file_extensions"]:
-                if extension not in syntax_file_map:
-                    syntax_file_map[extension] = []
-                extension_list = syntax_file_map[extension]
-                extension_list.append(syntax_file)
         except Exception:
+            print("GitSavvy: could not load {}".format(syntax_file))
             continue
 
+        for extension in try_parse_for_file_extensions(resource) or []:
+            syntax_file_map[extension].append(syntax_file)
 
-def get_syntax_for_file(filename):
+
+def get_syntax_for_file(filename, default="Packages/Text/Plain text.tmLanguage"):
+    # type: (str, str) -> str
     if not determine_syntax_thread or determine_syntax_thread.is_alive():
-        return "Packages/Text/Plain text.tmLanguage"
-    extension = get_file_extension(filename)
-    syntaxes = syntax_file_map.get(filename, None) or syntax_file_map.get(extension, None)
-    return syntaxes[-1] if syntaxes else "Packages/Text/Plain text.tmLanguage"
+        return default
+    syntaxes = (
+        syntax_file_map.get(filename, [])
+        or syntax_file_map.get(get_file_extension(filename), [])
+        or [default]
+    )
+    return syntaxes[-1]
 
 
 def get_file_extension(filename):

--- a/common/util/file.py
+++ b/common/util/file.py
@@ -80,6 +80,27 @@ def handle_sublime_syntax_files():
             syntax_file_map[extension].append(syntax_file)
 
 
+def guess_syntax_for_file(window, filename):
+    # type: (sublime.Window, str) -> str
+    view = window.find_open_file(filename)
+    if view:
+        syntax = view.settings().get("syntax")
+        remember_syntax_choice(filename, syntax)
+        return syntax
+    return get_syntax_for_file(filename)
+
+
+def remember_syntax_choice(filename, syntax):
+    # type: (str, str) -> None
+    registered_syntaxes = (
+        syntax_file_map.get(filename, [])
+        or syntax_file_map.get(get_file_extension(filename), [])
+    )
+    if syntax in registered_syntaxes:
+        registered_syntaxes.remove(syntax)
+    registered_syntaxes.append(syntax)
+
+
 def get_syntax_for_file(filename, default="Packages/Text/Plain text.tmLanguage"):
     # type: (str, str) -> str
     if not determine_syntax_thread or determine_syntax_thread.is_alive():

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -153,7 +153,7 @@ class gs_inline_diff(WindowCommand, GitCommand):
                     new_row = self.find_matching_lineno(None, None, row + 1, self.file_path) - 1
                     cur_pos = (new_row, col, offset)
             else:
-                syntax_file = util.file.get_syntax_for_file(file_path)
+                syntax_file = util.file.guess_syntax_for_file(self.window, file_path)
                 cur_pos = None
 
         else:

--- a/core/commands/show_file_at_commit.py
+++ b/core/commands/show_file_at_commit.py
@@ -43,7 +43,7 @@ class gs_show_file_at_commit(WindowCommand, GitCommand):
         settings.set("git_savvy.file_path", file_path)
         settings.set("git_savvy.repo_path", repo_path)
         if not lang:
-            lang = util.file.get_syntax_for_file(file_path)
+            lang = util.file.guess_syntax_for_file(self.window, file_path)
         nice_hash = self.get_short_hash(commit_hash) if len(commit_hash) >= 40 else commit_hash
         title = SHOW_COMMIT_TITLE.format(
             os.path.basename(file_path),

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -443,7 +443,7 @@ def get_selected_files(view, base_path, *sections):
 
     make_abs_path = partial(os.path.join, base_path)
     return [
-        make_abs_path(filename)
+        os.path.normpath(make_abs_path(filename))
         for filename in get_selected_subjects(view, *sections)
     ]
 

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -511,7 +511,7 @@ class GsStatusDiffInlineCommand(TextCommand, GitCommand):
     def load_inline_diff_views(self, window, non_cached_files, cached_files):
         # type: (sublime.Window, List[str], List[str]) -> None
         for fpath in non_cached_files:
-            syntax = util.file.get_syntax_for_file(fpath)
+            syntax = util.file.guess_syntax_for_file(window, fpath)
             settings = {
                 "file_path": fpath,
                 "repo_path": self.repo_path,
@@ -523,7 +523,7 @@ class GsStatusDiffInlineCommand(TextCommand, GitCommand):
             })
 
         for fpath in cached_files:
-            syntax = util.file.get_syntax_for_file(fpath)
+            syntax = util.file.guess_syntax_for_file(window, fpath)
             settings = {
                 "file_path": fpath,
                 "repo_path": self.repo_path,


### PR DESCRIPTION
Fixes #1028 
Fixes #666 

- Avoid yaml parse errors by extracting the wanted key "file_extensions" via an ordinary regex.  This is actually faster as well. By a lot.

- Additionally, parse "tmLanguage" syntaxes because why not. 

- For a better "guess" for which syntax to use look at actual views currently open.  Remember these used syntaxes.

Side fix:

- Normalize line endings in the help files
- Normalize abs paths coming from the status view