### PR TITLE
Implement jumping from "diff" to "inline-diff"

### DIFF
--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -160,7 +160,7 @@ class gs_inline_diff(WindowCommand, GitCommand):
             cur_pos = capture_cur_position(active_view)
             if cur_pos and cached:
                 row, col, offset = cur_pos
-                new_row = self.find_matching_lineno(None, None, row + 1, self.file_path) - 1
+                new_row = self.find_matching_lineno(None, None, row + 1, file_path) - 1
                 cur_pos = Position(new_row, col, offset)
         else:
             syntax_file = util.file.guess_syntax_for_file(self.window, file_path)

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -512,26 +512,20 @@ class GsStatusDiffInlineCommand(TextCommand, GitCommand):
         # type: (sublime.Window, List[str], List[str]) -> None
         for fpath in non_cached_files:
             syntax = util.file.guess_syntax_for_file(window, fpath)
-            settings = {
-                "file_path": fpath,
+            window.run_command("gs_inline_diff_open", {
                 "repo_path": self.repo_path,
-                "syntax": syntax
-            }
-            window.run_command("gs_inline_diff", {
-                "settings": settings,
-                "cached": False
+                "file_path": fpath,
+                "syntax": syntax,
+                "cached": False,
             })
 
         for fpath in cached_files:
             syntax = util.file.guess_syntax_for_file(window, fpath)
-            settings = {
-                "file_path": fpath,
+            window.run_command("gs_inline_diff_open", {
                 "repo_path": self.repo_path,
-                "syntax": syntax
-            }
-            window.run_command("gs_inline_diff", {
-                "settings": settings,
-                "cached": True
+                "file_path": fpath,
+                "syntax": syntax,
+                "cached": True,
             })
 
 


### PR DESCRIPTION
There is no new binding attached here.  Assuming you have these already setup, you can now jump from a diff view mildly accurate to the inline diff.  This basically shows the whole context of the hunk, and allows small line by line operations. 

Howerer, this is only "mildly" accurate.  I wanted to make this easy and just reuse existing functionality.  For the "diff" view, we have `jump_position_to_file` which computes the correct position in the workspace file.  Since the workspace file is on the `b` part of the diff, the function interpolates locations on the red `a` side by jumping to next available context or `b` line. 

The same is true for the inline diff. Here we only have code to jump from the workspace file *to* the diff, again `b` (workspace) to green `b` (diff). 

Still, I maybe merge this rather quickly, this is better than not having it, and doing it correctly needs some refactoring. 

Adds some refactorings as well:

- Extract `gs_inline_diff_open` from `gs_inline_diff`.  The former is internal only, and used for example in the status dashboard.  `gs_inline_diff` is the main command for the end-user which should be bound without any arguments ideally to a key binding.  It acts as a factory if you will, and basically reads the state from the originating view for example the cursor position, and then delegates opening the actual inline diff view to `gs_inline_diff_open`. 