### PR TITLE
Fix: "rebase --continue" command

### DIFF
--- a/core/interfaces/rebase.py
+++ b/core/interfaces/rebase.py
@@ -1022,19 +1022,10 @@ class GsRebaseAbortCommand(TextCommand, GitCommand):
 class GsRebaseContinueCommand(TextCommand, GitCommand):
 
     def run(self, edit):
-        sublime.set_timeout_async(self.run_async, 0)
+        sublime.set_timeout_async(self.run_async)
 
     def run_async(self):
         try:
-            if self.in_rebase_merge():
-                (staged_entries,
-                 unstaged_entries,
-                 untracked_entries,
-                 conflict_entries) = self.sort_status_entries(self.get_status())
-                if len(unstaged_entries) + len(untracked_entries) + len(conflict_entries) == 0 and \
-                        len(staged_entries) > 0:
-                    self.git("commit", "--no-edit")
-
             self.git("rebase", "--continue")
         finally:
             util.view.refresh_gitsavvy(self.view)


### PR DESCRIPTION
Here, our `GsRebaseContinueCommand` wants to be smart by commiting the
staged files, assumely so that the user doesn't need to edit the commit
message.

But this approach here leads to wrong commit messages because git added
comments in the prepared message, and `--no-edit` will not strip these.

Also, this will literally do a new commit, for example with a new date
and author et.al. which is not what we want.

Example:


![image](https://user-images.githubusercontent.com/8558/85955909-3720b980-b982-11ea-925b-43373013a9a7.png)
