### PR TITLE
Small graph iteration

### DIFF
--- a/core/commands/__init__.py
+++ b/core/commands/__init__.py
@@ -16,6 +16,7 @@ from .init import *
 from .inline_diff import *
 from .log import *
 from .log_graph import *
+from .log_graph_smart_copy import *
 from .merge import *
 from .mv import *
 from .navigate import *

--- a/core/commands/fetch.py
+++ b/core/commands/fetch.py
@@ -34,9 +34,9 @@ class gs_fetch(WindowCommand, GitCommand):
 
     def do_fetch(self, remote=None):
         if remote is None:
-            self.window.status_message("Starting fetch all remotes...")
+            self.window.status_message("Start fetching all remotes...")
         else:
-            self.window.status_message("Starting fetch {}...".format(remote))
+            self.window.status_message("Start fetching {}...".format(remote))
 
         self.fetch(remote)
         self.window.status_message("Fetch complete.")

--- a/core/commands/fetch.py
+++ b/core/commands/fetch.py
@@ -1,4 +1,3 @@
-import sublime
 from sublime_plugin import WindowCommand
 
 from ..git_command import GitCommand
@@ -29,9 +28,9 @@ class gs_fetch(WindowCommand, GitCommand):
         if not remote:
             return
         if remote is True:
-            sublime.set_timeout_async(lambda: self.do_fetch())
+            enqueue_on_worker(self.do_fetch)
         else:
-            sublime.set_timeout_async(lambda: self.do_fetch(remote))
+            enqueue_on_worker(self.do_fetch, remote)
 
     def do_fetch(self, remote=None):
         if remote is None:

--- a/core/commands/fetch.py
+++ b/core/commands/fetch.py
@@ -2,6 +2,7 @@ import sublime
 from sublime_plugin import WindowCommand
 
 from ..git_command import GitCommand
+from ..runtime import enqueue_on_worker
 from ...common import util
 from ..ui_mixins.quick_panel import show_remote_panel
 
@@ -20,7 +21,7 @@ class gs_fetch(WindowCommand, GitCommand):
 
     def run(self, remote=None):
         if remote:
-            return self.do_fetch(remote)
+            return enqueue_on_worker(self.do_fetch, remote)
 
         show_remote_panel(self.on_remote_selection, show_option_all=True, allow_direct=True)
 

--- a/core/commands/fetch.py
+++ b/core/commands/fetch.py
@@ -6,7 +6,12 @@ from ...common import util
 from ..ui_mixins.quick_panel import show_remote_panel
 
 
-class GsFetchCommand(WindowCommand, GitCommand):
+__all__ = (
+    "gs_fetch",
+)
+
+
+class gs_fetch(WindowCommand, GitCommand):
 
     """
     Display a panel of all git remotes for active repository and

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -1730,7 +1730,7 @@ class gs_log_graph_action(WindowCommand, GitCommand):
             ]
 
         if head_info and head_info["commit"] != info["commit"]:
-            get = partial(get_list, head_info)  # type: Callable[[ListItems], List[str]]  # type: ignore
+            get = partial(get_list, head_info)  # type: Callable[[ListItems], List[str]]  # type: ignore[no-redef]
             good_move_target = (
                 head_info["HEAD"]
                 if head_is_on_a_branch

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -1803,7 +1803,7 @@ class gs_log_graph_action(WindowCommand, GitCommand):
 
     def delete_tag(self, tag_name):
         self.git("tag", "-d", tag_name)
-        util.view.refresh_gitsavvy_interfaces(self.window, refresh_sidebar=True)
+        util.view.refresh_gitsavvy_interfaces(self.window)
 
     def reset_to(self, commitish):
         self.window.run_command("gs_reset", {"commit_hash": commitish})
@@ -1853,4 +1853,4 @@ class gs_log_graph_action(WindowCommand, GitCommand):
 
     def checkout_file_at_commit(self, commit_hash, file_path):
         self.checkout_ref(commit_hash, fpath=file_path)
-        util.view.refresh_gitsavvy_interfaces(self.window, refresh_sidebar=True)
+        util.view.refresh_gitsavvy_interfaces(self.window)

--- a/core/commands/log_graph_smart_copy.py
+++ b/core/commands/log_graph_smart_copy.py
@@ -1,0 +1,108 @@
+import sublime
+import sublime_plugin
+
+from . import log_graph
+from ..parse_diff import TextRange
+from ..runtime import throttled
+from ..utils import flash
+
+
+__all__ = (
+    "CopyIntercepterForGraph",
+)
+
+
+MYPY = False
+if MYPY:
+    from typing import Dict, List, Optional, Union
+
+
+HIGHLIGHT_REGION_KEY = "GS.flashs.{}"
+DURATION = 0.4
+STYLE = {"scope": "git_savvy.graph.dot", "flags": 0}
+
+
+class CopyIntercepterForGraph(sublime_plugin.EventListener):
+    def on_text_command(self, view, command_name, args):
+        # type: (sublime.View, str, Dict) -> Union[None, str]
+        if command_name != "copy":
+            return None
+
+        if not view.settings().get("git_savvy.log_graph_view"):
+            return None
+
+        frozen_sel = [r for r in view.sel()]
+        if len(frozen_sel) != 1:
+            return None
+
+        if not frozen_sel[0].empty():
+            return None
+
+        cursor = frozen_sel[0].a
+        line_span = view.line(cursor)
+
+        commit_hash = read_commit_hash(view, line_span)
+        if not commit_hash:
+            return None
+
+        clip_content = sublime.get_clipboard(128)
+        if not clip_content:
+            set_clipboard_and_flash(view, commit_hash.text, [commit_hash.region()])
+            return "noop"
+
+        commit_msg = read_commit_message(view, line_span)
+        if not commit_msg:
+            return None
+
+        if clip_content == commit_hash.text:
+            set_clipboard_and_flash(view, commit_msg.text, [commit_msg.region()])
+        elif clip_content == commit_msg.text:
+            set_clipboard_and_flash(
+                view,
+                "{} ({})".format(commit_hash.text, commit_msg.text),
+                [commit_hash.region(), commit_msg.region()]
+            )
+        else:
+            set_clipboard_and_flash(view, commit_hash.text, [commit_hash.region()])
+        return "noop"
+
+
+def set_clipboard_and_flash(view, text, regions):
+    # type: (sublime.View, str, List[sublime.Region]) -> None
+    sublime.set_clipboard(text)
+    flash_copied_regions(view, regions)
+    flash(view, "Copied '{}' to the clipboard".format(text))
+
+
+def read_commit_hash(view, line_span):
+    # type: (sublime.View, sublime.Region) -> Optional[TextRange]
+    commit_region = log_graph.extract_comit_hash_span(view, line_span)
+    if not commit_region:
+        return None
+
+    return TextRange(view.substr(commit_region), commit_region.a, commit_region.b)
+
+
+def read_commit_message(view, line_span):
+    # type: (sublime.View, sublime.Region) -> Optional[TextRange]
+    for r in view.find_by_selector("meta.graph.message.git-savvy"):
+        if line_span.contains(r):
+            return TextRange(view.substr(r), r.a, r.b)
+    else:
+        return None
+
+
+def flash_copied_regions(view, regions):
+    # type: (sublime.View, List[sublime.Region]) -> None
+    region_key = HIGHLIGHT_REGION_KEY.format("flash_copied_regions")
+    view.add_regions(region_key, regions, **STYLE)  # type: ignore[arg-type]
+
+    sublime.set_timeout(
+        throttled(erase_regions, view, region_key),
+        int(DURATION * 1000)
+    )
+
+
+def erase_regions(view, region_key):
+    # type: (sublime.View, str) -> None
+    view.erase_regions(region_key)

--- a/core/commands/pull.py
+++ b/core/commands/pull.py
@@ -6,8 +6,13 @@ from ...common import util
 from ..ui_mixins.quick_panel import show_branch_panel
 
 
-class GsPullBase(GitCommand):
+__all__ = (
+    "gs_pull",
+    "gs_pull_from_branch",
+)
 
+
+class GsPullBase(WindowCommand, GitCommand):
     def do_pull(self, remote, remote_branch, rebase):
         """
         Perform `git pull remote branch`.
@@ -18,7 +23,7 @@ class GsPullBase(GitCommand):
         util.view.refresh_gitsavvy(self.window.active_view())
 
 
-class GsPull(WindowCommand, GsPullBase):
+class gs_pull(GsPullBase):
     """
     Pull from remote tracking branch if it is found. Otherwise, use GsPullFromBranchCommand.
     """
@@ -42,8 +47,7 @@ class GsPull(WindowCommand, GsPullBase):
             self.window.run_command("gs_pull_from_branch", {"rebase": rebase})
 
 
-class GsPullFromBranchCommand(WindowCommand, GsPullBase):
-
+class gs_pull_from_branch(GsPullBase):
     """
     Through a series of panels, allow the user to pull from a remote branch.
     """

--- a/core/commands/pull.py
+++ b/core/commands/pull.py
@@ -18,8 +18,10 @@ class GsPullBase(WindowCommand, GitCommand):
         Perform `git pull remote branch`.
         """
         self.window.status_message("Starting pull...")
-        self.pull(remote=remote, remote_branch=remote_branch, rebase=rebase)
-        self.window.status_message("Pull complete.")
+        output = self.pull(remote=remote, remote_branch=remote_branch, rebase=rebase).strip()
+        self.window.status_message(
+            output if output == "Already up to date." else "Pull complete."
+        )
         util.view.refresh_gitsavvy(self.window.active_view())
 
 

--- a/core/commands/push.py
+++ b/core/commands/push.py
@@ -7,6 +7,13 @@ from ..ui_mixins.quick_panel import show_remote_panel, show_branch_panel
 from ..ui_mixins.input_panel import show_single_line_input_panel
 
 
+__all__ = (
+    "gs_push",
+    "gs_push_to_branch",
+    "gs_push_to_branch_name",
+)
+
+
 START_PUSH_MESSAGE = "Starting push..."
 END_PUSH_MESSAGE = "Push complete."
 PUSH_TO_BRANCH_NAME_PROMPT = "Enter remote branch name:"
@@ -16,7 +23,7 @@ CONFIRM_FORCE_PUSH = ("You are about to `git push {}`. Would you  "
                       "like to proceed?")
 
 
-class PushBase(GitCommand):
+class PushBase(WindowCommand, GitCommand):
     set_upstream = False
 
     def do_push(self, remote, branch, force=False, force_with_lease=False, remote_branch=None):
@@ -44,8 +51,7 @@ class PushBase(GitCommand):
         util.view.refresh_gitsavvy(self.window.active_view())
 
 
-class GsPushCommand(WindowCommand, PushBase):
-
+class gs_push(PushBase):
     """
     Push current branch.
     """
@@ -90,8 +96,7 @@ class GsPushCommand(WindowCommand, PushBase):
             })
 
 
-class GsPushToBranchCommand(WindowCommand, PushBase):
-
+class gs_push_to_branch(PushBase):
     """
     Through a series of panels, allow the user to push to a specific remote branch.
     """
@@ -112,8 +117,7 @@ class GsPushToBranchCommand(WindowCommand, PushBase):
                 selected_remote, current_local_branch, remote_branch=selected_branch))
 
 
-class GsPushToBranchNameCommand(WindowCommand, PushBase):
-
+class gs_push_to_branch_name(PushBase):
     """
     Prompt for remote and remote branch name, then push.
     """

--- a/core/git_mixins/active_branch.py
+++ b/core/git_mixins/active_branch.py
@@ -166,6 +166,10 @@ class ActiveBranchMixin():
         return self.git("rev-parse", "--abbrev-ref", "--symbolic-full-name",
                         "@{u}", throw_on_stderr=False).strip()
 
+    def get_remote_for_branch(self, branch_name):
+        # type: (str) -> str
+        return self.git("config", "--get", "branch.{}.remote".format(branch_name)).strip()
+
     def get_active_remote_branch(self):
         """
         Return named tuple of the upstream for active branch.

--- a/core/git_mixins/remotes.py
+++ b/core/git_mixins/remotes.py
@@ -47,7 +47,7 @@ class RemotesMixin():
         Pull from the specified remote and branch if provided, otherwise
         perform default `git pull`.
         """
-        self.git(
+        return self.git(
             "pull",
             "--rebase" if rebase else None,
             remote if remote else None,
@@ -66,7 +66,9 @@ class RemotesMixin():
         Push to the specified remote and branch if provided, otherwise
         perform default `git push`.
         """
-        return self.git(
+        # Do not return the output. It is always empty since the output
+        # of "git push" actually goes to stderr.
+        self.git(
             "push",
             "--force" if force else None,
             "--force-with-lease" if force_with_lease else None,

--- a/github/commands/pull_request.py
+++ b/github/commands/pull_request.py
@@ -7,7 +7,7 @@ from .. import github
 from .. import git_mixins
 from ...common import interwebs
 from ...common import util
-from ...core.commands.push import GsPushToBranchNameCommand
+from ...core.commands.push import gs_push_to_branch_name
 from ...core.git_command import GitCommand
 from ...core.ui_mixins.quick_panel import show_paginated_panel
 from ...core.ui_mixins.input_panel import show_single_line_input_panel
@@ -212,7 +212,7 @@ class GsGithubCreatePullRequestCommand(WindowCommand, GitCommand, git_mixins.Git
         open_in_browser(url)
 
 
-class GsGithubPushAndCreatePullRequestCommand(GsPushToBranchNameCommand):
+class GsGithubPushAndCreatePullRequestCommand(gs_push_to_branch_name):
 
     def do_push(self, *args, **kwargs):
         super().do_push(*args, **kwargs)

--- a/syntax/graph.sublime-syntax
+++ b/syntax/graph.sublime-syntax
@@ -76,6 +76,10 @@ contexts:
 
   message:
     - meta_scope: meta.graph.message.git-savvy
+    - match: (fixup|squash)(!)
+      captures:
+        1: string.other.rebase-hint.git-savvy
+        2: punctuation.string.end.git-savvy
     - match: (`[^`]*`)
       comment: by name
       scope: keyword.by-name.git-savvy.


### PR DESCRIPTION
- Add "pull"/"push"/"fetch" to the action menu only when on the HEAD

E.g.

![image](https://user-images.githubusercontent.com/8558/87425382-d29a6700-c5dd-11ea-9add-654d760c270b.png)

I think this will be convenient.

- Tweak syntax and mark "fixup!" and "squash!" prefixes as `string.other.rebase-hint.git-savvy`.  Just being "string" probably makes it yellow by default but you can fancy style as well

E.g.

![image](https://user-images.githubusercontent.com/8558/87425243-8f3ff880-c5dd-11ea-81e9-01b3eec4e210.png)

This is should make it easy to spot if you still need to rebase before pushing or merging.

- Fine-tune "diff against" action: When on the head, open the normal diff views where you can actually stage etc.  Otherwise usually open a diff "commit..HEAD" (t.i. **not** workdir) which is best suited for reviewing topic branches (PRs). 

- Implement a smart copy feature to copy the commit hash, commit message, or a combination of both to the clipboard. 

E.g.

![mUIMP2V6Fr](https://user-images.githubusercontent.com/8558/87545886-fbd3f980-c6a8-11ea-9553-95ebd3858fb3.gif)
