### PR TITLE
Fixups for initial revisions of a file

### DIFF
--- a/common/util/__init__.py
+++ b/common/util/__init__.py
@@ -1,6 +1,6 @@
 import sys
 
-from .parse_diff import parse_diff, UnsupportedDiffMode
+from .parse_diff import parse_diff
 from . import dates
 from . import view
 from . import file

--- a/common/util/parse_diff.py
+++ b/common/util/parse_diff.py
@@ -3,100 +3,76 @@ Parse and process output from `git diff` command.
 """
 
 from collections import namedtuple
-from itertools import islice
-import re
 
-Hunk = namedtuple("Hunk", ("raw_lines", "changes", "head_start", "head_length", "saved_start", "saved_length"))
-Change = namedtuple("Change", ("raw", "type", "head_pos", "saved_pos", "text"))
+from GitSavvy.core.parse_diff import HunkLine, SplittedDiff
 
-re_metadata = re.compile(r"^@@ -(\d+)(,(\d+))? \+(\d+)(,(\d+))? @@")
+MYPY = False
+if MYPY:
+    from typing import Iterator, List, NamedTuple
+    from GitSavvy.core.types import LineNo
 
+    Change = NamedTuple("Change", [
+        ("raw", str),
+        ("type", str),
+        ("head_pos", LineNo),
+        ("saved_pos", LineNo),
+        ("text", str)
+    ])
+    Hunk = NamedTuple("Hunk", [
+        ("raw_lines", List[str]),
+        ("changes", List[Change]),
+        ("head_start", LineNo),
+        ("head_length", int),
+        ("saved_start", LineNo),
+        ("saved_length", int)
+    ])
 
-class UnsupportedDiffMode(RuntimeError):
-    pass
+else:
+    Hunk = namedtuple("Hunk", "raw_lines changes head_start head_length saved_start saved_length")
+    Change = namedtuple("Change", "raw type head_pos saved_pos text")
 
 
 def parse_diff(diff_str):
+    # type: (str) -> List[Hunk]
     """
     Given the string output from a `git diff` command, parse the string into
     hunks and, more granularly, meta-data and change information for each of
     those hunks.
     """
     hunks = []
-
-    raw_hunks = _split_into_hunks(diff_str.splitlines(keepends=True))
-
-    for raw_hunk in raw_hunks:
-        hunk_lines = list(raw_hunk)
-        head_start, head_length, saved_start, saved_length = _get_metadata(hunk_lines[0])
-        changes = _get_changes(hunk_lines[1:], head_start, saved_start)
-        # Remove lines warning about "No newline at end of file"; change[1] will == `\`.
-        changes_filtered = tuple(change for change in changes if change[1] != "\\")
-        hunks.append(Hunk(hunk_lines, changes_filtered, head_start, head_length, saved_start, saved_length))
+    for hunk in SplittedDiff.from_string(diff_str).hunks:
+        head_start, head_length, saved_start, saved_length = hunk.header().parse()
+        changes = _get_changes(hunk.content().lines(), head_start, saved_start)
+        # Remove lines warning about "No newline at end of file"; change.type will == `\`.
+        changes_filtered = [change for change in changes if change.type != "\\"]
+        hunks.append(
+            Hunk(
+                hunk.text.splitlines(keepends=True),
+                changes_filtered,
+                head_start,
+                head_length,
+                saved_start,
+                saved_length
+            )
+        )
 
     return hunks
 
 
-def _split_into_hunks(lines):
-    """
-    Given an array of lines from the output of a `git-diff` command, yield
-    slices of the lines that correspond to the hunks in the diff.
-    """
-    # Throw away the first four lines of the git output.
-    #   diff --git a/c9d70aa928a3670bc2b879b4a596f10d3e81ba7c b/d95427d30480b29b99b407981c8e048b6e0c902d
-    #   index c9d70aa..d95427d 100644
-    #   --- a/c9d70aa928a3670bc2b879b4a596f10d3e81ba7c
-    #   +++ b/d95427d30480b29b99b407981c8e048b6e0c902d
-    lines = lines[4:]
-    lines_iter = enumerate(lines)
-    start = 0
-
-    if len(lines) < 1:
-        return
-
-    for line_number, line in lines_iter:
-        if not line.startswith(("+", "-", "\\")) and line_number != 0:
-            yield islice(lines, start, line_number)
-        if line.startswith("@@"):
-            start = line_number
-
-    yield islice(lines, start, line_number + 1)
-
-
-def _get_metadata(meta_str):
-    """
-    Given the `@@ ... @@` header from the beginning of a hunk, return
-    the start and length values from that header.
-    """
-    match = re_metadata.match(meta_str)
-    if match is None:
-        raise UnsupportedDiffMode(meta_str)
-
-    head_start, _, head_length, saved_start, _, saved_length = match.groups()
-    return (int(head_start),
-            int(head_length or "1"),
-            int(saved_start),
-            int(saved_length or "1"))
-
-
 def _get_changes(hunk_lines, head_start, saved_start):
+    # type: (List[HunkLine], LineNo, LineNo) -> Iterator[Change]
     """
     Transform a list of `+` or `-` lines from a `git diff` output
     into tuples with the original raw line, the type of the change,
     the position of the HEAD- and saved- versions at that line, and
     the text of the line with the `+` or `-` removed.
     """
-    changes = []
     head_pos = head_start
     saved_pos = saved_start
 
-    for raw_line in hunk_lines:
-        change_type = raw_line[0]
-        text = raw_line[1:]
-        changes.append(Change(raw_line, change_type, head_pos, saved_pos, text))
-        if change_type == "-":
+    for line in hunk_lines:
+        yield Change(line.text, line.mode, head_pos, saved_pos, line.content)
+        if line.is_from_line():
             head_pos += 1
-        elif change_type == "+":
+        elif line.is_to_line():
             saved_pos += 1
-
-    return changes

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -324,6 +324,8 @@ class gs_inline_diff_refresh(TextCommand, GitCommand):
         base_commit = settings.get("git_savvy.inline_diff_view.base_commit")
         target_commit = settings.get("git_savvy.inline_diff_view.target_commit")
         ignore_eol_ws = self.savvy_settings.get("inline_diff_ignore_eol_whitespaces", True)
+        if target_commit and not base_commit:
+            target_commit = "{}^".format(target_commit)
 
         if raw_diff is None:
             raw_diff_output = self.git(
@@ -360,6 +362,11 @@ class gs_inline_diff_refresh(TextCommand, GitCommand):
 
         if in_cached_mode:
             original_content = self.get_file_content_at_commit(file_path, "HEAD")
+        elif target_commit and not base_commit:
+            # For historical diffs, not having a `base_commit` means we
+            # have reached the initial revision of a file. The base content
+            # we're coming from is thus the empty "".
+            original_content = ""
         else:
             original_content = self.get_file_content_at_commit(file_path, base_commit)
         inline_diff_contents, replaced_lines = self.get_inline_diff_contents(original_content, diff)

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -8,7 +8,7 @@ from sublime_plugin import WindowCommand, TextCommand, EventListener
 from . import diff
 from .navigate import GsNavigate
 from ..git_command import GitCommand
-from ..parse_diff import SplittedDiff
+from ..parse_diff import SplittedDiff, UnsupportedCombinedDiff
 from ..runtime import enqueue_on_ui
 from ..utils import flash, focus_view
 from ..view import capture_cur_position, replace_view_content, row_offset, Position
@@ -344,7 +344,7 @@ class gs_inline_diff_refresh(TextCommand, GitCommand):
 
         try:
             diff = util.parse_diff(raw_diff)
-        except util.UnsupportedDiffMode:
+        except UnsupportedCombinedDiff:
             sublime.error_message("Inline-diff cannot be displayed for this file - "
                                   "it has a merge conflict.")
             self.view.close()

--- a/core/commands/show_file_at_commit.py
+++ b/core/commands/show_file_at_commit.py
@@ -119,7 +119,12 @@ class gs_show_file_at_commit_refresh(TextCommand, GitCommand):
     def previous_file_version(self, current_commit, file_path):
         # type: (str, str) -> str
         previous_commit = self.previous_commit(current_commit, file_path)
-        return self.get_file_content_at_commit(file_path, previous_commit)
+        if previous_commit:
+            return self.get_file_content_at_commit(file_path, previous_commit)
+        else:
+            # For intial revisions of a file, everything is new/added, and we
+            # just compare with the empty "".
+            return ""
 
 
 @text_command

--- a/core/commands/stage_hunk.py
+++ b/core/commands/stage_hunk.py
@@ -41,8 +41,8 @@ class UnsupportedCombinedDiff(RuntimeError):
 class gs_stage_hunk(TextCommand, GitCommand):
     def run(self, edit):
         view = self.view
-        fpath = view.file_name()
-        if not fpath:
+        file_path = view.file_name()
+        if not file_path:
             flash(view, "Cannot stage on unnnamed buffers.")
             return
 
@@ -50,11 +50,11 @@ class gs_stage_hunk(TextCommand, GitCommand):
             flash(view, "Cannot stage on unsaved files.")
             return
 
-        raw_diff = self.git("diff", "-U0", fpath)
+        raw_diff = self.git("diff", "-U0", file_path)
         if not raw_diff:
-            not_tracked_file = self.git("ls-files", fpath).strip() == ""
+            not_tracked_file = self.git("ls-files", file_path).strip() == ""
             if not_tracked_file:
-                self.git("add", fpath)
+                self.git("add", file_path)
                 flash(view, "Staged whole file.")
             else:
                 flash(view, "The file is clean.")

--- a/core/commands/stage_hunk.py
+++ b/core/commands/stage_hunk.py
@@ -41,6 +41,7 @@ class UnsupportedCombinedDiff(RuntimeError):
 
 class gs_stage_hunk(TextCommand, GitCommand):
     def run(self, edit):
+        # type: (sublime.Edit) -> None
         view = self.view
         file_path = view.file_name()
         if not file_path:

--- a/core/git_mixins/history.py
+++ b/core/git_mixins/history.py
@@ -298,7 +298,7 @@ class HistoryMixin():
         return line
 
     def previous_commit(self, current_commit, file_path, follow=False):
-        # type: (str, str, bool) -> str
+        # type: (str, str, bool) -> Optional[str]
         if not current_commit or current_commit == "HEAD":
             return self._previous_commit(current_commit, file_path, follow)
 
@@ -310,7 +310,7 @@ class HistoryMixin():
             return rv
 
     def _previous_commit(self, current_commit, file_path, follow):
-        # type: (str, str, bool) -> str
+        # type: (str, str, bool) -> Optional[str]
         return self.git(
             "log",
             "--format=%H",
@@ -320,9 +320,10 @@ class HistoryMixin():
             current_commit,
             "--",
             file_path
-        ).strip()
+        ).strip() or None
 
     def next_commit(self, current_commit, file_path, follow=False):
+        # type: (str, str, bool) -> Optional[str]
         try:
             return self.git(
                 "log",
@@ -333,7 +334,7 @@ class HistoryMixin():
                 file_path
             ).strip().splitlines()[-1]
         except IndexError:
-            return ""
+            return None
 
     def newest_commit_for_file(self, file_path, follow=False):
         """

--- a/core/git_mixins/history.py
+++ b/core/git_mixins/history.py
@@ -182,7 +182,7 @@ class HistoryMixin():
         return filename
 
     def get_file_content_at_commit(self, filename, commit_hash):
-        # type: (str, str) -> str
+        # type: (str, Optional[str]) -> str
         if not commit_hash or commit_hash == "HEAD":
             return self._get_file_content_at_commit(filename, commit_hash)
 
@@ -194,7 +194,7 @@ class HistoryMixin():
             return rv
 
     def _get_file_content_at_commit(self, filename, commit_hash):
-        # type: (str, str) -> str
+        # type: (str, Optional[str]) -> str
         filename = self.get_rel_path(filename)
         filename = filename.replace('\\', '/')
         return self.git("show", "{}:{}".format(commit_hash or "", filename))

--- a/core/parse_diff.py
+++ b/core/parse_diff.py
@@ -158,6 +158,11 @@ class Hunk(TextRange):
 
 
 EXTRACT_B_START = re.compile(r'@@*.+\+(\d+)(?:,\d+)? ')
+PARSE_HUNK_HEADER = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
+
+
+class UnsupportedCombinedDiff(RuntimeError):
+    pass
 
 
 class HunkHeader(TextRange):
@@ -172,6 +177,14 @@ class HunkHeader(TextRange):
             return None
 
         return int(match.group(1))
+
+    def parse(self):
+        # type: () -> Tuple[LineNo, int, LineNo, int]
+        match = PARSE_HUNK_HEADER.match(self.text)
+        if match is None:
+            raise UnsupportedCombinedDiff(self.text)
+        a_start, a_length, b_start, b_length = match.groups()
+        return int(a_start), int(a_length or "1"), int(b_start), int(b_length or "1")
 
 
 class HunkLine(TextRange):

--- a/core/parse_diff.py
+++ b/core/parse_diff.py
@@ -78,7 +78,6 @@ class SplittedDiff(SplittedDiffBase):
 
 
 HEADER_TO_FILE_RE = re.compile(r'\+\+\+ b/(.+)$')
-HUNKS_LINES_RE = re.compile(r'@@*.+\+(\d+)(?:,\d+)? ')
 
 
 class TextRange:
@@ -158,6 +157,9 @@ class Hunk(TextRange):
         )
 
 
+EXTRACT_B_START = re.compile(r'@@*.+\+(\d+)(?:,\d+)? ')
+
+
 class HunkHeader(TextRange):
     def to_line_start(self):
         # type: () -> Optional[LineNo]
@@ -165,7 +167,7 @@ class HunkHeader(TextRange):
 
         T.i. for "@@ -685,8 +686,14 @@ ..." extract the "686".
         """
-        match = HUNKS_LINES_RE.search(self.text)
+        match = EXTRACT_B_START.search(self.text)
         if not match:
             return None
 

--- a/core/store.py
+++ b/core/store.py
@@ -6,7 +6,7 @@ from .utils import Cache
 
 MYPY = False
 if MYPY:
-    from typing import DefaultDict, Dict, Tuple, TypedDict
+    from typing import Any, DefaultDict, Dict, Tuple, TypedDict
 
     RepoPath = str
     RepoStore = TypedDict(
@@ -18,7 +18,7 @@ if MYPY:
     )
 
 state = defaultdict(lambda: {})  # type: DefaultDict[RepoPath, RepoStore]
-cache = Cache(maxsize=512)  # type: Dict[Tuple, str]
+cache = Cache(maxsize=512)  # type: Dict[Tuple, Any]
 
 
 lock = threading.Lock()


### PR DESCRIPTION
Teach the "inline_diff" and the "File Revision View" to recognize and handle initial revisions of a file correct. 

This includes a refactoring to the `util.parse_diff` code which now uses and follows the newer `core.parse_diff` code.  This is necessary here because the old parser could not parse diffs introducing/adding files at all.  (Basically it assumed a diff header length of 4 lines which breaks here.) 

The refactoring combines and touches `stage_hunk.py` as well because we now basically use functionality exposed there.  Within `stage_hunk` we again confused "row" with "line" so I fixed the types and names here in one go. 

The actual hotfix is after that rather smallish in c2f9148 and c4219e6.

