### PR TITLE
Remove "word-diff" feature

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -643,17 +643,9 @@
         ]
     },
     {
-        "keys": ["s"],
+        "keys": ["w"],
         "command": "gs_diff_toggle_setting",
         "args": { "setting": "ignore_whitespace" },
-        "context": [
-            { "key": "setting.command_mode", "operator": "equal", "operand": false },
-            { "key": "setting.git_savvy.diff_view", "operator": "equal", "operand": true }
-        ]
-    },
-    {
-        "keys": ["w"],
-        "command": "gs_diff_cycle_word_diff",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.diff_view", "operator": "equal", "operand": true }
@@ -755,18 +747,9 @@
         ]
     },
     {
-        "keys": ["s"],
-        "command": "gs_show_commit_toggle_setting",
-        "args": { "setting": "ignore_whitespace" },
-        "context": [
-            { "key": "setting.command_mode", "operator": "equal", "operand": false },
-            { "key": "setting.git_savvy.show_commit_view", "operator": "equal", "operand": true }
-        ]
-    },
-    {
         "keys": ["w"],
         "command": "gs_show_commit_toggle_setting",
-        "args": { "setting": "show_word_diff" },
+        "args": { "setting": "ignore_whitespace" },
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.show_commit_view", "operator": "equal", "operand": true }

--- a/core/commands/show_commit.py
+++ b/core/commands/show_commit.py
@@ -56,7 +56,6 @@ class gs_show_commit(WindowCommand, GitCommand):
             settings.set("git_savvy.show_commit_view.commit", commit_hash)
             settings.set("git_savvy.repo_path", repo_path)
             settings.set("git_savvy.show_commit_view.ignore_whitespace", False)
-            settings.set("git_savvy.show_commit_view.show_word_diff", False)
             settings.set("git_savvy.show_commit_view.show_diffstat", self.savvy_settings.get("show_diffstat", True))
             view.set_syntax_file("Packages/GitSavvy/syntax/show_commit.sublime-syntax")
             view.set_name(SHOW_COMMIT_TITLE.format(self.get_short_hash(commit_hash)))
@@ -72,12 +71,10 @@ class gs_show_commit_refresh(TextCommand, GitCommand):
         settings = self.view.settings()
         commit_hash = settings.get("git_savvy.show_commit_view.commit")
         ignore_whitespace = settings.get("git_savvy.show_commit_view.ignore_whitespace")
-        show_word_diff = settings.get("git_savvy.show_commit_view.show_word_diff")
         show_diffstat = settings.get("git_savvy.show_commit_view.show_diffstat")
         content = self.git(
             "show",
             "--ignore-all-space" if ignore_whitespace else None,
-            "--word-diff" if show_word_diff else None,
             "--stat" if show_diffstat else None,
             "--patch",
             "--format=fuller",
@@ -90,7 +87,7 @@ class gs_show_commit_refresh(TextCommand, GitCommand):
 class gs_show_commit_toggle_setting(TextCommand):
 
     """
-    Toggle view settings: `ignore_whitespace` or `show_word_diff`.
+    Toggle view settings: `ignore_whitespace`.
     """
 
     def run(self, edit, setting):

--- a/docs/staging.md
+++ b/docs/staging.md
@@ -43,7 +43,7 @@ You also have the option of staging all unstaged files (excluding untracked file
 
 This command will open a special diff view.  Output from `git diff` will be displayed.  If you position your cursor over a hunk and press `SUPER-Enter` (`CTRL-Enter` in Windows/Linux), that hunk will be staged.
 
-Use `o` to open the file at the beginning of the hunk.  Pressing `s` will toggle whether the diff ignores whitespice changes.  Pressing `w` will toggle whether the `--word-diff` mode is used.  And remember that you can not stage anything if either of these modes are enabled.
+Use `o` to open the file at the beginning of the hunk.  Pressing `w` will toggle whether the diff ignores whitespace changes.  Note that you can not stage anything in this mode.
 
 
 ## `git: diff cached`

--- a/tests/test_diff_view.py
+++ b/tests/test_diff_view.py
@@ -496,14 +496,13 @@ class TestZooming(DeferrableTestCase):
         self.addCleanup(view.close)
         view.set_scratch(True)
         view.settings().set("git_savvy.repo_path", "fake_repo_path")
-        view.settings().set("git_savvy.diff_view.show_word_diff", False)
 
         view.settings().set('git_savvy.diff_view.context_lines', CONTEXT_LINES)
         cmd = module.gs_diff_refresh(view)
         when(cmd).git(...).thenReturn('NEW CONTENT')
 
         cmd.run({'unused_edit'})
-        verify(cmd).git('diff', None, None, FLAG, ...)
+        verify(cmd).git('diff', None, FLAG, ...)
 
     @p.expand([
         (0, 2, 2),
@@ -551,7 +550,6 @@ class TestDiffView(DeferrableTestCase):
     @p.expand([
         ('in_cached_mode', False),
         ('ignore_whitespace', False),
-        ('show_word_diff', False),
         ('base_commit', None),
         ('target_commit', None),
         ('show_diffstat', True),


### PR DESCRIPTION
Fixes #1322

Removes the "word-diff" feature completely. Remaps `s` to `w` in the diff and commit view. 

As of now, no deprecation policy, no warnings.