### PR TITLE
Small refactor inside inline diff

### DIFF
--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -915,6 +915,7 @@ class gs_inline_diff_undo(TextCommand, GitCommand):
     def run_async(self):
         history = self.view.settings().get("git_savvy.inline_diff.history") or []
         if not history:
+            flash(self.view, "Undo stack is empty")
             return
 
         last_args, last_stdin, encoding = history.pop()

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -648,11 +648,14 @@ class gs_inline_diff_stage_or_reset_base(TextCommand, GitCommand):
         self.git(*args, stdin=full_diff, stdin_encoding=encoding)
         self.save_to_history(args, full_diff, encoding)
 
-        cur_pos = capture_cur_position(self.view) if not (reset or in_cached_mode) else None
-        if cur_pos is not None:
-            row, col, offset = cur_pos
-            line_no, col_no = translate_pos_from_diff_view_to_file(self.view, row + 1, col + 1)
-            cur_pos = Position(line_no - 1, col_no - 1, offset)
+        if reset or in_cached_mode or self.name() == "gs_inline_diff_stage_or_reset_line":
+            cur_pos = None
+        else:
+            cur_pos = capture_cur_position(self.view)
+            if cur_pos:
+                row, col, offset = cur_pos
+                line_no, col_no = translate_pos_from_diff_view_to_file(self.view, row + 1, col + 1)
+                cur_pos = Position(line_no - 1, col_no - 1, offset)
 
         self.view.run_command("gs_inline_diff_refresh", {
             "match_position": cur_pos,

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -9,7 +9,7 @@ from . import diff
 from .navigate import GsNavigate
 from ..git_command import GitCommand
 from ..parse_diff import SplittedDiff, UnsupportedCombinedDiff
-from ..runtime import enqueue_on_ui
+from ..runtime import enqueue_on_ui, enqueue_on_worker
 from ..utils import flash, focus_view
 from ..view import capture_cur_position, replace_view_content, row_offset, Position
 from ...common import util
@@ -589,7 +589,7 @@ class gs_inline_diff_stage_or_reset_base(TextCommand, GitCommand):
         return is_interactive_diff(self.view)
 
     def run(self, edit, **kwargs):
-        sublime.set_timeout_async(lambda: self.run_async(**kwargs), 0)
+        enqueue_on_worker(self.run_async, **kwargs)
 
     def run_async(self, reset=False):
         in_cached_mode = self.view.settings().get("git_savvy.inline_diff_view.in_cached_mode")


### PR DESCRIPTION
As a follow up from #1327.  Already being in that "inline_diff.py" apply some basic refactorings.  Among others, again make a better distinction between "line" and "row". 


User facing changes:

- Flash a status message if the undo stack is empty.
- Maybe slightly better cursor movement after staging a single line.

