### PR TITLE
Implement "Line History View"

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -89,9 +89,13 @@
         "args": { "all": false }
     },
     {
-        "caption": "git: File history",
+        "caption": "git: File History",
         "command": "gs_graph_current_file",
         "args": { "all": false }
+    },
+    {
+        "caption": "git: Line History",
+        "command": "gs_line_history"
     },
     {
         "caption": "github: open file on remote",

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1530,6 +1530,82 @@
         ]
     },
 
+    //////////////////
+    // LINE HISTORY //
+    //////////////////
+
+    {
+        "keys": ["o"],
+        "command": "gs_line_history_open_commit",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.line_history_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["O"],
+        "command": "gs_diff_open_file_at_hunk",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.line_history_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["g"],
+        "command": "gs_line_history_open_graph_context",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.line_history_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["."],
+        "command": "gs_diff_navigate",
+        "args": { "forward": true },
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.line_history_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": [","],
+        "command": "gs_diff_navigate",
+        "args": { "forward": false },
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.line_history_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["j"],
+        "command": "gs_diff_navigate",
+        "args": { "forward": true },
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.vintageous_friendly", "operator": "equal", "operand": true },
+            { "key": "setting.git_savvy.line_history_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["k"],
+        "command": "gs_diff_navigate",
+        "args": { "forward": false },
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.vintageous_friendly", "operator": "equal", "operand": true },
+            { "key": "setting.git_savvy.line_history_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["?"],
+        "command": "gs_interface_toggle_popup_help",
+        "args": { "view_name": "line_history" },
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.line_history_view", "operator": "equal", "operand": true }
+        ]
+    },
+
     //////////////////////
     // REBASE DASHBOARD //
     //////////////////////

--- a/core/commands/__init__.py
+++ b/core/commands/__init__.py
@@ -14,6 +14,7 @@ from .flow import *
 from .ignore import *
 from .init import *
 from .inline_diff import *
+from .line_history import *
 from .log import *
 from .log_graph import *
 from .log_graph_smart_copy import *

--- a/core/commands/line_history.py
+++ b/core/commands/line_history.py
@@ -42,6 +42,9 @@ class gs_line_history(TextCommand, GitCommand):
             flash(view, "Not available for unsaved files.")
             return
 
+        if view.is_dirty():
+            flash(view, "Hint: For unsaved files the line selection is probably not correct.")
+
         ranges = [
             (line_on_point(view, s.begin()), line_on_point(view, s.end()))
             for s in view.sel()

--- a/core/commands/line_history.py
+++ b/core/commands/line_history.py
@@ -1,0 +1,144 @@
+import os
+
+import sublime
+from sublime_plugin import TextCommand, WindowCommand
+
+from ..fns import filter_
+from ..git_command import GitCommand
+from ..parse_diff import SplittedDiff
+from ..runtime import enqueue_on_worker
+from ..utils import flash
+from ..view import replace_view_content
+from ...common import util
+
+
+__all__ = (
+    "gs_line_history",
+    "gs_open_line_history",
+    "gs_line_history_open_commit",
+    "gs_line_history_open_graph_context",
+)
+
+
+MYPY = False
+if MYPY:
+    from typing import List, Optional, Tuple
+    from ..types import LineNo
+
+    LineRange = Tuple[LineNo, LineNo]
+
+
+class gs_line_history(TextCommand, GitCommand):
+    def run(self, edit):
+        # type: (sublime.Edit) -> None
+        view = self.view
+        window = view.window()
+        if not window:
+            return
+
+        repo_path = self.repo_path
+        file_path = view.file_name()
+        if not file_path:
+            flash(view, "Not available for unsaved files.")
+            return
+
+        ranges = [
+            (line_on_point(view, s.begin()), line_on_point(view, s.end()))
+            for s in view.sel()
+        ]
+        if not ranges:
+            flash(view, "No cursor to compute a line range from.")
+            return
+
+        window.run_command("gs_open_line_history", {
+            "repo_path": repo_path,
+            "file_path": file_path,
+            "ranges": ranges,
+        })
+
+
+def line_on_point(view, pt):
+    # type: (sublime.View, int) -> LineNo
+    row, _ = view.rowcol(pt)
+    return row + 1
+
+
+class gs_open_line_history(WindowCommand, GitCommand):
+    def run(self, repo_path, file_path, ranges, commit=None):
+        # type: (str, str, List[LineRange], str) -> None
+        view = util.view.get_scratch_view(self, "line_history")
+        settings = view.settings()
+        settings.set("git_savvy.repo_path", repo_path)
+        settings.set("git_savvy.file_path", file_path)
+
+        rel_file_path = os.path.relpath(file_path, repo_path)
+        title = ''.join(
+            [
+                'LOG: {}'.format(
+                    rel_file_path
+                    + ('@{}'.format(commit) if commit else '')
+                )
+            ]
+            + [' L{}-{}'.format(lr[0], lr[1]) for lr in ranges]
+        )
+        view.set_name(title)
+        view.set_syntax_file("Packages/GitSavvy/syntax/show_commit.sublime-syntax")
+
+        def render():
+            normalized_short_filename = rel_file_path.replace('\\', '/')
+            cmd = (
+                [
+                    'log',
+                    '--decorate',
+                    "--format=fuller",
+                ]
+                + [
+                    '-L{},{}:{}'.format(lr[0], lr[1], normalized_short_filename)
+                    for lr in ranges
+                ]
+                + [commit]  # type: ignore[list-item]  # mypy bug
+            )
+            output = self.git(*cmd)
+            replace_view_content(view, output)
+
+        enqueue_on_worker(render)
+
+
+class gs_line_history_open_commit(TextCommand, GitCommand):
+    def run(self, edit):
+        # type: (sublime.Edit) -> None
+        view = self.view
+        window = view.window()
+        if not window:
+            return
+
+        diff = SplittedDiff.from_view(view)
+        commits = filter_(commit_hash_before_pt(diff, s.begin()) for s in view.sel())
+        for c in commits:
+            window.run_command('gs_show_commit', {'commit_hash': c})
+
+
+class gs_line_history_open_graph_context(TextCommand, GitCommand):
+    def run(self, edit):
+        # type: (sublime.Edit) -> None
+        view = self.view
+        window = view.window()
+        if not window:
+            return
+
+        diff = SplittedDiff.from_view(view)
+        commit_hash = commit_hash_before_pt(diff, view.sel()[0].begin())
+        if commit_hash:
+            window.run_command("gs_graph", {
+                "all": True,
+                "follow": self.get_short_hash(commit_hash)
+            })
+
+
+def commit_hash_before_pt(diff, pt):
+    # type: (SplittedDiff, int) -> Optional[str]
+    for commit_header in reversed(diff.commits):
+        if commit_header.a <= pt:
+            return commit_header.commit_hash()
+    else:
+        return None

--- a/core/commands/line_history.py
+++ b/core/commands/line_history.py
@@ -50,6 +50,15 @@ class gs_line_history(TextCommand, GitCommand):
             flash(view, "No cursor to compute a line range from.")
             return
 
+        diff = self.no_context_diff(None, "HEAD", file_path)
+        ranges = [
+            (
+                self.adjust_line_according_to_diff(diff, a),
+                self.adjust_line_according_to_diff(diff, b)
+            )
+            for a, b in ranges
+        ]
+
         window.run_command("gs_open_line_history", {
             "repo_path": repo_path,
             "file_path": file_path,

--- a/popups/line_history.html
+++ b/popups/line_history.html
@@ -1,0 +1,29 @@
+<html>
+<style>
+{css}
+</style>
+<body>
+<div class="header-wrapper"><h2>Keyboard Shortcuts</h2></div>
+
+<h3>Actions</h3>
+<ul>
+  <li><code><span class="shortcut-key">o&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>open commit</code></li>
+  <li><code><span class="shortcut-key">O&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>open file revision at hunk</code></li>
+  <li><code><span class="shortcut-key">g&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>show in graph</code></li>
+  <li><code><span class="shortcut-key">.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>go to next hunk</code></li>
+  <li><code><span class="shortcut-key">,&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>go to previous hunk</code></li>
+</ul>
+
+<h3>Other</h3>
+<ul>
+  <li><code><span class="shortcut-key">?&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>show this help popup</code></li>
+</ul>
+
+<h3>Vintageous friendly mode</h3>
+<ul>
+  <li><code><span class="shortcut-key">j&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>go to next hunk</code></li>
+  <li><code><span class="shortcut-key">k&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>go to previous hunk</code></li>
+</ul>
+
+</body>
+</html>

--- a/syntax/show_commit.sublime-syntax
+++ b/syntax/show_commit.sublime-syntax
@@ -44,12 +44,17 @@ contexts:
     - match: ^
       push:
         - meta_scope: meta.commit_message
+        - match: (?=^commit \h{7,})
+          set: main
         - match: (?=^diff\s)
-          set: "scope:git-savvy.diff"
+          embed: "scope:git-savvy.diff"
+          escape: (?=^commit \h{7,})
         # Merge commits "just" start the diffstat without the "---" line
         - match: (?=^ \S)
-          set: "scope:git-savvy.diff"
+          embed: "scope:git-savvy.diff"
+          escape: (?=^commit \h{7,})
         - match: ^---$\n?
           scope: meta.commit-header-and-stat-splitter
-          set: "scope:git-savvy.diff"
+          embed: "scope:git-savvy.diff"
+          escape: (?=^commit \h{7,})
         - include: make_commit.sublime-syntax#references


### PR DESCRIPTION
A "Line History" (aka "log wtf" or "log why") basically calls
"git log -L<some_file>,1:3".  Rarely used on the command line because of
its syntax, it is a super easy to write and then very useful tool in
the editor.  It is usually the faster (in terms of you get the info
you're looking for faster) "blame" and also the faster "File History"
because often you're only interested in some part of a file. Really
answering "Why is this line or section of code here?".

Comes with `[o]` to open the complete commit under the cursor;
`[O]` to open the file revision;
`[g]` to open the graph context.