### PR TITLE
Fix `row_offset` if the view has some folded content

### DIFF
--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -209,11 +209,10 @@ class gs_inline_diff(WindowCommand, GitCommand):
         file_path = os.path.normpath(os.path.join(repo_path, jump_position.filename))
         syntax_file = util.file.guess_syntax_for_file(self.window, file_path)
 
-        row_in_view = view.rowcol(cursor)[0]
         cur_pos = Position(
             jump_position.line - 1,
             jump_position.col - 1,
-            row_offset(row_in_view, view)
+            row_offset(view, cursor)
         )
         if cached:
             row, col, offset = cur_pos

--- a/core/view.py
+++ b/core/view.py
@@ -26,13 +26,14 @@ def capture_cur_position(view):
         return None
 
     row, col = view.rowcol(sel.begin())
-    return Position(row, col, row_offset(row, view))
+    return Position(row, col, row_offset(view, sel.begin()))
 
 
-def row_offset(row, view):
-    # type: (Row, sublime.View) -> float
-    vx, vy = view.viewport_position()
-    return row - (vy / view.line_height())
+def row_offset(view, cursor):
+    # type: (sublime.View, int) -> float
+    _, cy = view.text_to_layout(cursor)
+    _, vy = view.viewport_position()
+    return (cy - vy) / view.line_height()
 
 
 # `replace_view_content` is a wrapper for `_replace_region` to get some


### PR DESCRIPTION
`row_offset` tells you for example that a given row is the 20th
in the viewport.  The algorithm didn't count for hidden rows which
happens if the user folds the code.

We switch to comparing the y values of two vectors.  `viewport_position`
return the top `y`, and `text_to_layout` returns the current `y` the
cursor is on.