### PR TITLE
Fix: Take the `b` filename as a goto symbol

### DIFF
--- a/syntax/diff.sublime-syntax
+++ b/syntax/diff.sublime-syntax
@@ -81,14 +81,14 @@ contexts:
       captures:
         1: punctuation.definition.from-file.diff
         2: punctuation.definition.from-file.file-alias.diff
-        3: meta.filename.diff gitsavvy.gotosymbol
+        3: meta.filename.diff
 
     - match: ^(\+{3}) (b/)?(.+)$\n?
       scope: meta.diff.header.to-file
       captures:
         1: punctuation.definition.to-file.diff
         2: punctuation.definition.to-file.file-alias.diff
-        3: meta.filename.diff dont.need.gitsavvy.gotosymbol
+        3: meta.filename.diff gitsavvy.gotosymbol
 
     - match: ^(@@)\s*(.+?)\s*(@@)\s(.*)$\n?
       scope: meta.diff.range.unified

--- a/syntax/test/syntax_test_diff.txt
+++ b/syntax/test/syntax_test_diff.txt
@@ -36,24 +36,24 @@ similarity index 59%
 --- /dev/null
 # <- punctuation.definition.from-file.diff
 # ^ punctuation.definition.from-file.diff
-#   ^^^^^^^^^ meta.filename.diff gitsavvy.gotosymbol
+#   ^^^^^^^^^ meta.filename.diff
 
 +++ /dev/null
 # <- punctuation.definition.to-file.diff
 # ^ punctuation.definition.to-file.diff
-#   ^^^^^^^^^ meta.filename.diff dont.need.gitsavvy.gotosymbol
+#   ^^^^^^^^^ meta.filename.diff gitsavvy.gotosymbol
 
 --- a/syntax/rebase.sublime-syntax
 # <- punctuation.definition.from-file.diff
 # ^ punctuation.definition.from-file.diff
 #   ^^ punctuation.definition.from-file.file-alias.diff
-#     ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.filename.diff gitsavvy.gotosymbol
+#     ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.filename.diff
 
 +++ b/syntax/rebase.sublime-syntax
 # <- punctuation.definition.to-file.diff
 # ^ punctuation.definition.to-file.diff
 #   ^^ punctuation.definition.to-file.file-alias.diff
-#          ^ meta.filename.diff dont.need.gitsavvy.gotosymbol
+#          ^ meta.filename.diff gitsavvy.gotosymbol
 
 @@ -6,34 +6,39 @@ hidden: true
 # <- punctuation.definition.range.diff


### PR DESCRIPTION
We switch here, and mark `b` instead of `a` as the filename for the
Goto funtionality.  This is (more) correct here because we generally
have the current workstate on the b-side.

Imagine you check in a new file or you renamed a file.  In the first
case, `a` doesn't point to any file, in the latter `a` points to the
old file.