### PR TITLE
Do not render dashboards twice on resurrect

### DIFF
--- a/common/ui.py
+++ b/common/ui.py
@@ -72,7 +72,6 @@ class Interface():
 
         if view:
             self.view = view
-            self.render(nuke_cursors=False)
         else:
             self.create_view(repo_path)
             sublime.set_timeout_async(self.on_new_dashboard, 0)


### PR DESCRIPTION
On resurrect, for example starting up Sublime with the status dashboard
open, we first `focus_view` in `__new__` which will run `render`
`on_activated`, then we `render` a second time in `__init__`.

This patch removes the (imperative) call in `__init__`.