### PR TITLE
Implement "wide" first parent navigation in the graph view

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1492,6 +1492,24 @@
         ]
     },
     {
+        "keys": ["alt+down"],
+        "command": "gs_log_graph_navigate_first_parent",
+        "args": { "forward": true },
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.log_graph_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["alt+up"],
+        "command": "gs_log_graph_navigate_first_parent",
+        "args": { "forward": false },
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.log_graph_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
         "keys": ["j"],
         "command": "gs_log_graph_navigate",
         "args": {"forward": true},

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1477,7 +1477,6 @@
         "args": { "forward": true },
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
-            { "key": "setting.git_savvy.arrow_keys_navigation", "operator": "equal", "operand": true },
             { "key": "setting.git_savvy.log_graph_view", "operator": "equal", "operand": true }
         ]
     },
@@ -1487,7 +1486,6 @@
         "args": { "forward": false },
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
-            { "key": "setting.git_savvy.arrow_keys_navigation", "operator": "equal", "operand": true },
             { "key": "setting.git_savvy.log_graph_view", "operator": "equal", "operand": true }
         ]
     },

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1491,7 +1491,7 @@
     },
     {
         "keys": ["alt+down"],
-        "command": "gs_log_graph_navigate_first_parent",
+        "command": "gs_log_graph_navigate_wide",
         "args": { "forward": true },
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
@@ -1500,7 +1500,7 @@
     },
     {
         "keys": ["alt+up"],
-        "command": "gs_log_graph_navigate_first_parent",
+        "command": "gs_log_graph_navigate_wide",
         "args": { "forward": false },
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },

--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -85,6 +85,10 @@
             "commit_dot_background": "#991",
             "path_foreground": "#991",
             "path_background": "#99991109",
+            "commit_dot_above_foreground": "#f91d",
+            "commit_dot_above_background": "#99991109",
+            "path_above_foreground": "#19d",
+            "path_above_background": "#99991109",
             "matching_commit_foreground": "#1991",
             "matching_commit_background": "#199"
         }

--- a/common/theme_generator.py
+++ b/common/theme_generator.py
@@ -41,6 +41,17 @@ class ThemeGenerator():
     on the data, save it, and apply the transformed theme to a view.
     """
 
+    hidden_theme_extension = None  # type: str
+
+    @staticmethod
+    def for_view(view):
+        # type: (sublime.View) -> ThemeGenerator
+        color_scheme = view.settings().get('color_scheme')
+        if color_scheme.endswith(".tmTheme"):
+            return XMLThemeGenerator(color_scheme)
+        else:
+            return JSONThemeGenerator(color_scheme)
+
     def __init__(self, original_color_scheme):
         self._dirty = False
         try:
@@ -117,7 +128,9 @@ class XMLThemeGenerator(ThemeGenerator):
     def __init__(self, original_color_scheme):
         super().__init__(original_color_scheme)
         self.plist = ElementTree.XML(self.color_scheme_string)
-        self.styles = self.plist.find("./dict/array")
+        styles = self.plist.find("./dict/array")
+        assert styles
+        self.styles = styles
 
     def _add_scoped_style(self, name, scope, **kwargs):
         properties = "".join(PROPERTY_TEMPLATE.format(key=k, value=v) for k, v in kwargs.items())

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -1427,12 +1427,8 @@ def follow_dots(dot):
     # type: (colorizer.Char) -> Iterator[colorizer.Char]
     """Follow dot to dot omitting the path chars in between."""
     while True:
-        try:
-            dot = colorizer.follow_path_down(dot)[-1]
-        except IndexError:
-            break
-        else:
-            yield dot
+        dot = next(ch for ch in colorizer.follow_path_down(dot) if ch == COMMIT_NODE_CHAR)
+        yield dot
 
 
 def draw_info_panel(view):

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -1474,8 +1474,9 @@ def draw_info_panel_for_line(vid, line_text):
 
 
 def extract_commit_hash(line):
+    # type: (str) -> str
     match = COMMIT_LINE.search(line)
-    return match.groupdict()['commit_hash'] if match else ""
+    return match.group('commit_hash') if match else ""
 
 
 class gs_log_graph_toggle_more_info(WindowCommand, GitCommand):

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -31,7 +31,7 @@ from ..ui_mixins.input_panel import show_single_line_input_panel
 from ..ui_mixins.quick_panel import show_branch_panel
 from ..utils import focus_view
 from ...common import util
-from ...common.theme_generator import XMLThemeGenerator, JSONThemeGenerator
+from ...common.theme_generator import ThemeGenerator
 
 
 __all__ = (
@@ -190,11 +190,7 @@ def augment_color_scheme(view):
     if not colors:
         return
 
-    color_scheme = view.settings().get('color_scheme')
-    if color_scheme.endswith(".tmTheme"):
-        themeGenerator = XMLThemeGenerator(color_scheme)
-    else:
-        themeGenerator = JSONThemeGenerator(color_scheme)
+    themeGenerator = ThemeGenerator.for_view(view)
     themeGenerator.add_scoped_style(
         "GitSavvy Highlighted Commit Dot",
         DOT_SCOPE,

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -925,11 +925,8 @@ class gs_log_graph_by_branch(WindowCommand, GitCommand):
 
 
 class gs_log_graph_navigate(GsNavigate):
-
-    """
-    Travel between commits. It is also used by compare_commit_view.
-    """
     offset = 0
+    show_at_center = False
 
     def get_available_regions(self):
         return self.view.find_by_selector("constant.numeric.graph.commit-hash.git-savvy")

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -1287,7 +1287,10 @@ def _colorize_dots(vid, dots):
     view.add_regions('gs_log_graph_dot', [d.region() for d in dots], scope=DOT_SCOPE)
     paths = [
         c.region()
-        for path in map(colorizer.follow_path, dots)
+        for path in chain(
+            map(colorizer.follow_path_down, dots),
+            map(colorizer.follow_path_up, dots)
+        )
         if len(path) > 1
         for c in path
     ]
@@ -1372,7 +1375,7 @@ def follow_dots(dot):
     """Follow dot to dot omitting the path chars in between."""
     while True:
         try:
-            dot = colorizer.follow_path(dot)[-1]
+            dot = colorizer.follow_path_down(dot)[-1]
         except IndexError:
             break
         else:

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -45,7 +45,7 @@ __all__ = (
     "gs_log_graph_by_author",
     "gs_log_graph_by_branch",
     "gs_log_graph_navigate",
-    "gs_log_graph_navigate_first_parent",
+    "gs_log_graph_navigate_wide",
     "gs_log_graph_navigate_to_head",
     "gs_log_graph_edit_branches",
     "gs_log_graph_edit_filters",
@@ -932,7 +932,7 @@ class gs_log_graph_navigate(GsNavigate):
         return self.view.find_by_selector("constant.numeric.graph.commit-hash.git-savvy")
 
 
-class gs_log_graph_navigate_first_parent(TextCommand):
+class gs_log_graph_navigate_wide(TextCommand):
     def run(self, edit, forward=True):
         # type: (sublime.Edit, bool) -> None
         view = self.view

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -927,6 +927,7 @@ class gs_log_graph_by_branch(WindowCommand, GitCommand):
 class gs_log_graph_navigate(GsNavigate):
     offset = 0
     show_at_center = False
+    wrap = False
 
     def get_available_regions(self):
         return self.view.find_by_selector("constant.numeric.graph.commit-hash.git-savvy")

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -12,6 +12,7 @@ import threading
 
 import sublime
 from sublime_plugin import WindowCommand, TextCommand, EventListener
+from Default import history_list  # type: ignore[import]
 
 from . import log_graph_colorizer as colorizer, show_commit_info
 from .log import GsLogCommand
@@ -26,7 +27,7 @@ from ..runtime import (
     run_or_timeout, run_on_new_thread,
     text_command
 )
-from ..view import replace_view_content, show_region
+from ..view import line_distance, replace_view_content, show_region
 from ..ui_mixins.input_panel import show_single_line_input_panel
 from ..ui_mixins.quick_panel import show_branch_panel
 from ..utils import focus_view
@@ -949,6 +950,8 @@ class gs_log_graph_navigate_first_parent(TextCommand):
             line_span = view.line(next_dot.region())
             r = extract_comit_hash_span(view, line_span)
             if r:
+                if line_distance(view, dot.region(), r) > 1:
+                    history_list.get_jump_history_for_view(view).push_selection(view)
                 sel = view.sel()
                 sel.clear()
                 sel.add(r.a)

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -842,7 +842,7 @@ class gs_log_graph(GsLogCommand):
     ensures that each of the defined actions/commands in `default_actions` are finally
     called with `file_path` set.
     """
-    default_actions = [
+    default_actions = [  # type: ignore[assignment]
         ["gs_log_graph_current_branch", "For current branch"],
         ["gs_log_graph_all_branches", "For all branches"],
         ["gs_log_graph_by_author", "Filtered by author"],

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -12,7 +12,6 @@ import threading
 
 import sublime
 from sublime_plugin import WindowCommand, TextCommand, EventListener
-from Default import history_list  # type: ignore[import]
 
 from . import log_graph_colorizer as colorizer, show_commit_info
 from .log import GsLogCommand
@@ -30,7 +29,7 @@ from ..runtime import (
 from ..view import line_distance, replace_view_content, show_region
 from ..ui_mixins.input_panel import show_single_line_input_panel
 from ..ui_mixins.quick_panel import show_branch_panel
-from ..utils import focus_view
+from ..utils import add_selection_to_jump_history, focus_view
 from ...common import util
 from ...common.theme_generator import ThemeGenerator
 
@@ -966,7 +965,7 @@ class gs_log_graph_navigate_wide(TextCommand):
         line_span = view.line(next_dot.region())
         r = extract_comit_hash_span(view, line_span)
         if r:
-            history_list.get_jump_history_for_view(view).push_selection(view)
+            add_selection_to_jump_history(view)
             sel = view.sel()
             sel.clear()
             sel.add(r.a)

--- a/core/commands/log_graph_colorizer.py
+++ b/core/commands/log_graph_colorizer.py
@@ -216,7 +216,7 @@ def before_dot(char):
 @follow('|', "down")
 def after_vertical_bar(char):
     # type: (Char) -> Iterator[Char]
-    yield from contains(char.s, '|' + COMMIT_NODE_CHAR)
+    yield from contains(char.s, '|/' + COMMIT_NODE_CHAR)
 
     # Check crossing line before following '/'
     # | |/ / /
@@ -283,7 +283,7 @@ def before_forwardslash(char):
     yield from contains(char.n.e.e, '/')
     if char.n.e.e != '_' and char.n.e.e != '/':
         yield from contains(char.n.e, '/|' + COMMIT_NODE_CHAR)
-    yield from contains(char.n, '\\')
+    yield from contains(char.n, '|\\')
 
 
 @follow('_', "down")

--- a/core/commands/log_graph_colorizer.py
+++ b/core/commands/log_graph_colorizer.py
@@ -191,7 +191,7 @@ def contains(next_char, test):
 
 
 @follow(COMMIT_NODE_CHAR, "down")
-def follow_dot(char):
+def after_dot(char):
     # type: (Char) -> Iterator[Char]
     yield from contains(char.e, '-')
     yield from contains(char.s, '|' + COMMIT_NODE_CHAR)
@@ -200,7 +200,7 @@ def follow_dot(char):
 
 
 @follow('|', "down")
-def follow_vertical_bar(char):
+def after_vertical_bar(char):
     # type: (Char) -> Iterator[Char]
     yield from contains(char.s, '|' + COMMIT_NODE_CHAR)
     if char.e != '/' and char.e != '_':
@@ -209,14 +209,14 @@ def follow_vertical_bar(char):
 
 
 @follow('\\', "down")
-def follow_backslash(char):
+def after_backslash(char):
     # type: (Char) -> Iterator[Char]
     yield from contains(char.s, '/')
     yield from contains(char.se, '\\|' + COMMIT_NODE_CHAR)
 
 
 @follow('/', "down")
-def follow_forwardslash(char):
+def after_forwardslash(char):
     # type: (Char) -> Iterator[Char]
     yield from contains(char.w, '_')
 
@@ -237,7 +237,7 @@ def follow_forwardslash(char):
 
 
 @follow('_', "down")
-def follow_underscore(char):
+def after_underscore(char):
     # type: (Char) -> Iterator[Char]
     yield from contains(char.w, '_')
     if char.w == '|':
@@ -260,7 +260,7 @@ def follow_underscore(char):
 
 
 @follow('-', "down")
-def follow_horizontal_bar(char):
+def after_horizontal_bar(char):
     # type: (Char) -> Iterator[Char]
     # Multi merge octopoi
     # *---.
@@ -270,7 +270,7 @@ def follow_horizontal_bar(char):
 
 
 @follow('.', "down")
-def follow_point(char):
+def after_point(char):
     # type: (Char) -> Iterator[Char]
     yield from contains(char.se, '\\')
 

--- a/core/commands/log_graph_colorizer.py
+++ b/core/commands/log_graph_colorizer.py
@@ -198,10 +198,10 @@ def contains(next_char, test):
 @follow(COMMIT_NODE_CHAR, "down")
 def after_dot(char):
     # type: (Char) -> Iterator[Char]
-    yield from contains(char.e, '-')
-    yield from contains(char.s, '|' + COMMIT_NODE_CHAR)
     yield from contains(char.sw, '/')
+    yield from contains(char.s, '|' + COMMIT_NODE_CHAR)
     yield from contains(char.se, '\\')
+    yield from contains(char.e, '-')
 
 
 @follow(COMMIT_NODE_CHAR, "up")

--- a/core/commands/navigate.py
+++ b/core/commands/navigate.py
@@ -7,7 +7,7 @@ from GitSavvy.core.view import show_region
 
 MYPY = False
 if MYPY:
-    from typing import Sequence
+    from typing import Optional, Sequence
 
 
 class GsNavigate(TextCommand, GitCommand):
@@ -17,6 +17,7 @@ class GsNavigate(TextCommand, GitCommand):
 
     offset = 4
     show_at_center = True
+    wrap = True
 
     def run(self, edit, forward=True):
         sel = self.view.sel()
@@ -30,6 +31,8 @@ class GsNavigate(TextCommand, GitCommand):
             if forward
             else self.backward(current_position, available_regions)
         )
+        if not wanted_section:
+            return
 
         sel.clear()
         # Position the cursor at the beginning of the section...
@@ -46,17 +49,17 @@ class GsNavigate(TextCommand, GitCommand):
         raise NotImplementedError()
 
     def forward(self, current_position, regions):
-        # type: (sublime.Point, Sequence[sublime.Region]) -> sublime.Region
+        # type: (sublime.Point, Sequence[sublime.Region]) -> Optional[sublime.Region]
         for region in regions:
             if region.a > current_position:
                 return region
-        # Wrap around to the first one
-        return regions[0]
+
+        return regions[0] if self.wrap else None
 
     def backward(self, current_position, regions):
-        # type: (sublime.Point, Sequence[sublime.Region]) -> sublime.Region
+        # type: (sublime.Point, Sequence[sublime.Region]) -> Optional[sublime.Region]
         for region in reversed(regions):
             if region.b < current_position:
                 return region
-        # Wrap around to the last one
-        return regions[-1]
+
+        return regions[-1] if self.wrap else None

--- a/core/commands/navigate.py
+++ b/core/commands/navigate.py
@@ -2,51 +2,61 @@ import sublime
 from sublime_plugin import TextCommand
 
 from ..git_command import GitCommand
+from GitSavvy.core.view import show_region
+
+
+MYPY = False
+if MYPY:
+    from typing import Sequence
 
 
 class GsNavigate(TextCommand, GitCommand):
-
     """
     Move cursor to the next (or previous).
     """
+
     offset = 4
+    show_at_center = True
 
     def run(self, edit, forward=True):
         sel = self.view.sel()
-        if not sel:
-            return
         current_position = sel[0].a
 
         available_regions = self.get_available_regions()
-
-        new_position = (self.forward(current_position, available_regions)
-                        if forward
-                        else self.backward(current_position, available_regions))
-
-        if new_position is None:
+        if not available_regions:
             return
+        wanted_section = (
+            self.forward(current_position, available_regions)
+            if forward
+            else self.backward(current_position, available_regions)
+        )
 
         sel.clear()
-        # Position the cursor at the beginning of the file name.
-        new_position += self.offset
-        sel.add(sublime.Region(new_position, new_position))
-        self.view.show_at_center(new_position)
+        # Position the cursor at the beginning of the section...
+        new_cursor_position = wanted_section.begin() + self.offset
+        sel.add(sublime.Region(new_cursor_position))
 
-        # The following shouldn't strictly be necessary, but Sublime sometimes
-        # jumps to the right when show_at_center for a column-zero-point occurs.
-        _, vp_y = self.view.viewport_position()
-        self.view.set_viewport_position((0, vp_y), False)
+        if self.show_at_center:
+            self.view.show_at_center(new_cursor_position)
+        else:
+            show_region(self.view, wanted_section)
 
-    def forward(self, current_position, file_regions):
-        for file_region in file_regions:
-            if file_region.a > current_position:
-                return file_region.a
-        # If we are after the last match, pick the first one
-        return file_regions[0].a if len(file_regions) != 0 else None
+    def get_available_regions(self):
+        # type: () -> Sequence[sublime.Region]
+        raise NotImplementedError()
 
-    def backward(self, current_position, file_regions):
-        for file_region in reversed(file_regions):
-            if file_region.b < current_position:
-                return file_region.a
-        # If we are after the last match, pick the last one
-        return file_regions[-1].a if len(file_regions) != 0 else None
+    def forward(self, current_position, regions):
+        # type: (sublime.Point, Sequence[sublime.Region]) -> sublime.Region
+        for region in regions:
+            if region.a > current_position:
+                return region
+        # Wrap around to the first one
+        return regions[0]
+
+    def backward(self, current_position, regions):
+        # type: (sublime.Point, Sequence[sublime.Region]) -> sublime.Region
+        for region in reversed(regions):
+            if region.b < current_position:
+                return region
+        # Wrap around to the last one
+        return regions[-1]

--- a/core/commands/next_hunk.py
+++ b/core/commands/next_hunk.py
@@ -8,6 +8,7 @@ import sublime_plugin
 
 from GitSavvy.core.fns import pairwise
 from GitSavvy.core.utils import flash
+from GitSavvy.core.view import show_region
 
 
 __all__ = (
@@ -141,18 +142,6 @@ def restore_sel_and_viewport(view):
     finally:
         set_sel(view, frozen_sel)
         view.set_viewport_position(vp)
-
-
-def show_region(view, region, context=5):
-    # type: (sublime.View, sublime.Region, int) -> None
-    row_a, _ = view.rowcol(region.begin())
-    row_b, _ = view.rowcol(region.end())
-    adjusted_section = sublime.Region(
-        # `text_point` is permissive and normalizes negative rows
-        view.text_point(row_a - context, 0),
-        view.text_point(row_b + context, 0)
-    )
-    view.show(adjusted_section, False)
 
 
 def cur_pos(view):

--- a/core/commands/next_hunk.py
+++ b/core/commands/next_hunk.py
@@ -8,7 +8,7 @@ import sublime_plugin
 
 from GitSavvy.core.fns import pairwise
 from GitSavvy.core.utils import flash
-from GitSavvy.core.view import show_region
+from GitSavvy.core.view import line_distance, show_region
 
 
 __all__ = (
@@ -21,9 +21,6 @@ MYPY = False
 if MYPY:
     from typing import Iterable, Iterator, List, TypeVar
     T = TypeVar("T")
-
-    Point = int
-    Row = int
 
 
 LINE_DISTANCE_BETWEEN_EDITS = 2
@@ -101,28 +98,6 @@ def jump(view, method):
     while True:
         view.run_command(method)
         yield cur_pos(view)
-
-
-def line_distance(view, a, b):
-    # type: (sublime.View, sublime.Region, sublime.Region) -> int
-    if a.contains(b) or b.contains(a):
-        return 0
-    a, b = sorted((a, b), key=lambda region: region.begin())
-
-    # If a region `a` already contains a trailing "\n" just using
-    # `view.line(a)` will not strip this newline character but
-    # `split_by_newlines` does.
-    # E.g. for a region `(1136, 1253)` `split_by_newlines` last region
-    # is                `(1214, 1252)`
-    #                              ^
-    a_end = view.split_by_newlines(a)[-1].end()
-    b_start = b.begin()
-    return abs(row_on_pt(view, a_end) - row_on_pt(view, b_start))
-
-
-def row_on_pt(view, pt):
-    # type: (sublime.View, Point) -> Row
-    return view.rowcol(pt)[0]
 
 
 def set_sel(view, selection):

--- a/core/fns.py
+++ b/core/fns.py
@@ -3,7 +3,7 @@ from itertools import accumulate as accumulate_, chain, islice, tee
 
 MYPY = False
 if MYPY:
-    from typing import Callable, Iterable, Iterator, Optional, Set, Tuple, TypeVar
+    from typing import Callable, Iterable, Iterator, List, Optional, Set, Tuple, TypeVar
     T = TypeVar('T')
 
 
@@ -42,6 +42,7 @@ def unique(iterable):
 
 
 def take(n, iterable):
+    # type: (int, Iterable[T]) -> List[T]
     """Return first *n* items of the iterable as a list.
         >>> take(3, range(10))
         [0, 1, 2]

--- a/core/fns.py
+++ b/core/fns.py
@@ -75,3 +75,35 @@ def chunked(iterable, n):
 
     """
     return iter(partial(take, n, iter(iterable)), [])
+
+
+def partition(pred, iterable):
+    # type: (Optional[Callable[[T], bool]], Iterable[T]) -> Tuple[Iterator[T], Iterator[T]]
+    """
+    Returns a 2-tuple of iterables derived from the input iterable.
+    The first yields the items that have ``pred(item) == False``.
+    The second yields the items that have ``pred(item) == True``.
+
+        >>> is_odd = lambda x: x % 2 != 0
+        >>> iterable = range(10)
+        >>> even_items, odd_items = partition(is_odd, iterable)
+        >>> list(even_items), list(odd_items)
+        ([0, 2, 4, 6, 8], [1, 3, 5, 7, 9])
+
+    If *pred* is None, :func:`bool` is used.
+
+        >>> iterable = [0, 1, False, True, '', ' ']
+        >>> false_items, true_items = partition(None, iterable)
+        >>> list(false_items), list(true_items)
+        ([0, False, ''], [1, True, ' '])
+
+    """
+    if pred is None:
+        pred = bool
+
+    evaluations = ((pred(x), x) for x in iterable)
+    t1, t2 = tee(evaluations)
+    return (
+        (x for (cond, x) in t1 if not cond),
+        (x for (cond, x) in t2 if cond),
+    )

--- a/core/utils.py
+++ b/core/utils.py
@@ -8,11 +8,12 @@ import time
 import threading
 import traceback
 
+import sublime
+
 
 MYPY = False
 if MYPY:
     from typing import Callable, Iterator, Type
-    import sublime
 
 
 @contextmanager
@@ -87,6 +88,19 @@ def focus_view(view):
     group, _ = window.get_view_index(view)
     window.focus_group(group)
     window.focus_view(view)
+
+
+if int(sublime.version()) < 4000:
+    from Default import history_list  # type: ignore[import]
+
+    def add_selection_to_jump_history(view):
+        history_list.get_jump_history_for_view(view).push_selection(view)
+
+else:
+    def add_selection_to_jump_history(view):
+        view.run_command("add_jump_record", {
+            "selection": [(r.a, r.b) for r in view.sel()]
+        })
 
 
 def line_indentation(line):

--- a/core/view.py
+++ b/core/view.py
@@ -18,6 +18,18 @@ else:
     Position = namedtuple("Position", "row col offset")
 
 
+def show_region(view, region, context=5):
+    # type: (sublime.View, sublime.Region, int) -> None
+    row_a, _ = view.rowcol(region.begin())
+    row_b, _ = view.rowcol(region.end())
+    adjusted_section = sublime.Region(
+        # `text_point` is permissive and normalizes negative rows
+        view.text_point(row_a - context, 0),
+        view.text_point(row_b + context, 0)
+    )
+    view.show(adjusted_section, False)
+
+
 def capture_cur_position(view):
     # type: (sublime.View) -> Optional[Position]
     try:

--- a/core/view.py
+++ b/core/view.py
@@ -30,6 +30,26 @@ def show_region(view, region, context=5):
     view.show(adjusted_section, False)
 
 
+def line_distance(view, a, b):
+    # type: (sublime.View, sublime.Region, sublime.Region) -> int
+    a, b = sorted((a, b), key=lambda region: region.begin())
+
+    # If a region `a` already contains a trailing "\n" just using
+    # `view.line(a)` will not strip this newline character but
+    # `split_by_newlines` does.
+    # E.g. for a region `(1136, 1253)` `split_by_newlines` last region
+    # is                `(1214, 1252)`
+    #                              ^
+    a_end = view.split_by_newlines(a)[-1].end()
+    b_start = b.begin()
+    return abs(row_on_pt(view, a_end) - row_on_pt(view, b_start))
+
+
+def row_on_pt(view, pt):
+    # type: (sublime.View, sublime.Point) -> Row
+    return view.rowcol(pt)[0]
+
+
 def capture_cur_position(view):
     # type: (sublime.View) -> Optional[Position]
     try:

--- a/popups/log_graph_view.html
+++ b/popups/log_graph_view.html
@@ -17,6 +17,8 @@
   <li><code><span class="shortcut-key">f&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>edit filters verbatim, e.g. try "--reflog" or "-Ssearch_term"</code></li>
   <li><code><span class="shortcut-key">.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>go to next commit</code></li>
   <li><code><span class="shortcut-key">,&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>go to previous commit</code></li>
+  <li><code><span class="shortcut-key">alt+up&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>go to previous commit</code></li>
+  <li><code><span class="shortcut-key">alt+down&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>go to next commit</code></li>
 </ul>
 
 <h3>Other</h3>

--- a/tests/test_graph_diff.py
+++ b/tests/test_graph_diff.py
@@ -4,7 +4,7 @@ from GitSavvy.tests.parameterized import parameterized as p
 
 
 from GitSavvy.core.commands.log_graph import (
-    diff, simplify, normalize_tokens, apply_diff, Ins, Del, Replace, Same
+    diff, simplify, normalize_tokens, apply_diff, Ins, Del, Replace, Flush
 )
 
 
@@ -26,7 +26,7 @@ def tx(tokens):
 
 
 def filter_same(it):
-    return filter(lambda t: t is not Same, it)
+    return filter(lambda t: t is not Flush, it)
 
 
 class TestGraphDiff(DeferrableTestCase):


### PR DESCRIPTION
First implement following the graph upwards and colorize the graph. 

![image](https://user-images.githubusercontent.com/8558/89807372-d23bb000-db38-11ea-8fc1-0d8c2ebe9081.png)

Use this walking to implement a new `gs_log_graph_navigate_wide` command which roughly follows the first parent and thus allows faster navigation. 

- Bind `alt+up` and `alt+down` for "wide" navigation.
- Bind `up` and `down` for normal per commit navigation.  (This was hidden behind the feature flag `arrow_keys_navigation`.)

Improve this jumping around by not showing the location we jump to "at center" position.  This, especially for the simple `up|down` movements, produces way to much viewport scrolling.  Instead show the location with some context using `show_region` introduced before.

When jumping "wide" inform Sublime's history machinery and save the previous location to enable the native `jump_back|jump_forward` bindings.

While being in `log_graph.py`fix all remaining mypy errors.   