### PR TITLE
Do not refresh inline diff twice when reusing the view

### DIFF
--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -1,6 +1,7 @@
 from itertools import groupby, takewhile
 import os
 from collections import namedtuple
+from contextlib import contextmanager
 
 import sublime
 from sublime_plugin import WindowCommand, TextCommand, EventListener
@@ -47,6 +48,7 @@ DIFF_HEADER = """diff --git a/{path} b/{path}
 """
 
 diff_view_hunks = {}  # type: Dict[sublime.ViewId, List[HunkReference]]
+active_on_activated = True
 
 
 def place_cursor_and_show(view, row, col, row_offset):
@@ -245,6 +247,16 @@ class gs_inline_diff(WindowCommand, GitCommand):
         })
 
 
+@contextmanager
+def disabled_on_activated():
+    global active_on_activated
+    active_on_activated = False
+    try:
+        yield
+    finally:
+        active_on_activated = True
+
+
 class gs_inline_diff_open(WindowCommand, GitCommand):
     def run(
         self,
@@ -263,7 +275,8 @@ class gs_inline_diff_open(WindowCommand, GitCommand):
                 diff_view = view
                 settings = diff_view.settings()
                 settings.set("git_savvy.inline_diff_view.in_cached_mode", cached)
-                focus_view(diff_view)
+                with disabled_on_activated():
+                    focus_view(diff_view)
                 break
 
         else:
@@ -565,7 +578,7 @@ class GsInlineDiffFocusEventListener(EventListener):
     """
 
     def on_activated(self, view):
-        if is_inline_diff_view(view) and is_interactive_diff(view):
+        if active_on_activated and is_inline_diff_view(view) and is_interactive_diff(view):
             view.run_command("gs_inline_diff_refresh", {"sync": False})
 
 


### PR DESCRIPTION
For the inline diff view, we actually call "refresh" at the end of the
`gs_inline_diff_open` command to update the scroll position and the
cursor immediately within one re-paint.  We thus need to prevent our
automatic refresh signal on focus.