### PR TITLE
Rewrite settings abstraction for performance and reliability

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -1,30 +1,87 @@
+from functools import lru_cache
+
 import sublime
+import sublime_plugin
+
+
+__all__ = (
+    "ProjectFileChanges",
+)
+
+MYPY = False
+if MYPY:
+    from typing import Callable, Dict, Optional, TypeVar
+    T = TypeVar("T")
 
 
 class GitSavvySettings:
-    def __init__(self, parent=None):
-        self.parent = parent
-        self.global_settings = sublime.load_settings("GitSavvy.sublime-settings")
+    def __init__(self, window=None):
+        # type: (sublime.Window) -> None
+        self._window = window or sublime.active_window()
+        self._global_settings = get_global_settings()
 
     def get(self, key, default=None):
-        window = sublime.active_window()
-        view = window.active_view()
-        project_savvy_settings = view.settings().get("GitSavvy", {}) or {}
-
-        if key in project_savvy_settings:
-            return project_savvy_settings[key]
-
-        # fall back to old style project setting
-        project_data = window.project_data()
-        if project_data and "GitSavvy" in project_data:
-            project_savvy_settings = project_data["GitSavvy"]
-            if key in project_savvy_settings:
-                return project_savvy_settings.get(key)
-
-        return self.global_settings.get(key, default)
+        try:
+            return get_project_settings(self._window)[key]
+        except KeyError:
+            return self._global_settings.get(key, default)
 
     def set(self, key, value):
-        self.global_settings.set(key, value)
+        self._global_settings.set(key, value)
+
+
+CHANGE_COUNT = 0
+
+
+class ProjectFileChanges(sublime_plugin.EventListener):
+    def on_post_save(self, view):
+        # type: (sublime.View) -> None
+        global CHANGE_COUNT
+        file_path = view.file_name()
+        if file_path and file_path.endswith(".sublime-project"):
+            CHANGE_COUNT += 1
+
+
+def get_project_settings(window):
+    # type: (sublime.Window) -> Dict
+    global CHANGE_COUNT
+    return _get_project_settings(window.id(), CHANGE_COUNT)
+
+
+@lru_cache(maxsize=16)
+def _get_project_settings(wid, _counter):
+    # type: (sublime.WindowId, int) -> Dict
+    window = sublime.Window(wid)
+    project_data = window.project_data()
+    if not project_data:
+        return {}
+    return project_data.get("settings", {}).get("GitSavvy", {})
+
+
+@lru_cache(maxsize=1)
+def get_global_settings():
+    return GlobalSettings("GitSavvy.sublime-settings")
+
+
+class GlobalSettings:
+    def __init__(self, name):
+        self._settings = s = sublime.load_settings(name)
+        s.clear_on_change(name)
+        s.add_on_change(name, self._on_update)
+        self._cache = {}
+
+    def get(self, name, default=None):
+        try:
+            return self._cache[name]
+        except KeyError:
+            self._cache[name] = current_value = self._settings.get(name, default)
+            return current_value
+
+    def set(self, name, value):
+        self._settings.set(name, value)
+
+    def _on_update(self):
+        self._cache.clear()
 
 
 class SettingsMixin:
@@ -33,5 +90,18 @@ class SettingsMixin:
     @property
     def savvy_settings(self):
         if not self._savvy_settings:
-            self._savvy_settings = GitSavvySettings(self)
+            window = (
+                maybe(lambda: self.window)  # type: ignore[attr-defined]
+                or maybe(lambda: self.view.window())  # type: ignore[attr-defined]
+                or sublime.active_window()
+            )
+            self._savvy_settings = GitSavvySettings(window)
         return self._savvy_settings
+
+
+def maybe(fn):
+    # type: (Callable[[], T]) -> Optional[T]
+    try:
+        return fn()
+    except Exception:
+        return None

--- a/git_savvy.py
+++ b/git_savvy.py
@@ -4,6 +4,7 @@ from .common.commands import *
 from .common.ui import *
 from .common.global_events import *
 from .core.commands import *
+from .core.settings import *
 from .core.interfaces import *
 from .core.runtime import *
 from .github.commands import *


### PR DESCRIPTION
Fixes #1201
Fixes #1341
Based on but rewrites rejected #1209

Generally, we want to support project wide overrides for the settings.
We could access these settings using `view.settings()`. However, for
`WindowCommand`s we don't necessarily have an `active_view()` for
example if the "view" is actually a `Sheet` showing an image or (in
ST4) a HTML page.  (Note that `sublime.active_window()` always yields
but `window.active_view()` can return `None`.)

For simplicity, we switch to depend solely on a `Window` and read the
project settings directly using `window.project_data()`.  We implement
caches for both the project settings and the global app settings. (The
caches make a difference if we run commands *not* on the main thread
because we avoid the synchronization.)