### PR TITLE
Remember commit info panel state per graph view

### DIFF
--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -264,7 +264,7 @@
         When set to `true,`, GitSavvy will display the full diff of the current
         commit in the output panel.
     */
-    "show_full_commit_info": false,
+    "show_full_commit_info": true,
 
     /*
         When set to `true`, GitSavvy will follow file renames when running git log/graph

--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -254,7 +254,7 @@
 
     /*
         When set to `true`, GitSavvy will automatically display more info about the
-        current commit in a output panel.  When set to `false`, this function must
+        current commit in an output panel.  When set to `false`, this function must
         be invoked manually.
      */
     "graph_show_more_commit_info": true,


### PR DESCRIPTION
We used to store the state of the commit info panel (t.i. for the graph view) only globally, which of course didn't work non-buggy if you have multiple graph views open, be it in one window or multiple.  (Basically hiding the panel in *one* graph, also closed the panel for other graph views.)

We make this state local to a graph view.  We still also store globally (but only in-memory) which is then the initial state for new graph views.

Flip the default of `show_full_commit_info=true` because that is the standard behavior of git UI's when walking the repo history. 