### PR TITLE
Optimize "show commit" caching

### DIFF
--- a/core/commands/show_commit.py
+++ b/core/commands/show_commit.py
@@ -72,14 +72,11 @@ class gs_show_commit_refresh(TextCommand, GitCommand):
         commit_hash = settings.get("git_savvy.show_commit_view.commit")
         ignore_whitespace = settings.get("git_savvy.show_commit_view.ignore_whitespace")
         show_diffstat = settings.get("git_savvy.show_commit_view.show_diffstat")
-        content = self.git(
-            "show",
-            "--ignore-all-space" if ignore_whitespace else None,
-            "--stat" if show_diffstat else None,
-            "--patch",
-            "--format=fuller",
-            "--no-color",
-            commit_hash)
+        content = self.read_commit(
+            commit_hash,
+            show_diffstat=show_diffstat,
+            ignore_whitespace=ignore_whitespace
+        )
         replace_view_content(self.view, content)
         intra_line_colorizer.annotate_intra_line_differences(self.view)
 

--- a/core/commands/show_commit_info.py
+++ b/core/commands/show_commit_info.py
@@ -1,5 +1,4 @@
 from contextlib import contextmanager
-from functools import lru_cache
 
 import sublime
 from sublime_plugin import WindowCommand
@@ -73,26 +72,13 @@ class gs_show_commit_info(WindowCommand, GitCommand):
         output_view.settings().set("git_savvy.repo_path", self.repo_path)
 
         if commit_hash:
-            show_full = self.savvy_settings.get("show_full_commit_info")
+            show_patch = self.savvy_settings.get("show_full_commit_info")
             show_diffstat = self.savvy_settings.get("show_diffstat")
-            text = self.show_commit(commit_hash, file_path, show_diffstat, show_full)
+            text = self.read_commit(commit_hash, file_path, show_diffstat, show_patch)
         else:
             text = ''
 
         enqueue_on_ui(_draw, self.window, output_view, text, commit_hash)
-
-    @lru_cache(maxsize=64)
-    def show_commit(self, commit_hash, file_path, show_diffstat, show_full):
-        return self.git(
-            "show",
-            "--no-color",
-            "--format=fuller",
-            "--stat" if show_diffstat else None,
-            "--patch" if show_full else None,
-            commit_hash,
-            "--" if file_path else None,
-            file_path if file_path else None
-        )
 
 
 def _draw(window, view, text, commit):

--- a/core/git_mixins/history.py
+++ b/core/git_mixins/history.py
@@ -297,6 +297,50 @@ class HistoryMixin():
         # fails to find matching
         return line
 
+    def read_commit(
+        self,
+        commit_hash,
+        file_path=None,
+        show_diffstat=True,
+        show_patch=True,
+        ignore_whitespace=False
+    ):
+        # type: (str, Optional[str], bool, bool, bool) -> str
+        key = (
+            "read_commit",
+            self.repo_path,
+            commit_hash,
+            file_path,
+            show_diffstat,
+            show_patch,
+            ignore_whitespace
+        )
+        try:
+            return store.cache[key]
+        except KeyError:
+            rv = store.cache[key] = self._read_commit(
+                commit_hash,
+                file_path,
+                show_diffstat,
+                show_patch,
+                ignore_whitespace
+            )
+            return rv
+
+    def _read_commit(self, commit_hash, file_path, show_diffstat, show_patch, ignore_whitespace):
+        # type: (str, Optional[str], bool, bool, bool) -> str
+        return self.git(
+            "show",
+            "--no-color",
+            "--format=fuller",
+            "--stat" if show_diffstat else None,
+            "--ignore-all-space" if ignore_whitespace else None,
+            "--patch" if show_patch else None,
+            commit_hash,
+            "--" if file_path else None,
+            file_path if file_path else None
+        )
+
     def previous_commit(self, current_commit, file_path, follow=False):
         # type: (str, str, bool) -> Optional[str]
         if not current_commit or current_commit == "HEAD":

--- a/tests/test_graph_view.py
+++ b/tests/test_graph_view.py
@@ -162,7 +162,7 @@ class TestDiffViewInteractionWithCommitInfoPanel(DeferrableTestCase):
 
     def register_commit_info(self, info):
         for sha1, info in info.items():
-            when(gs_show_commit_info).show_commit(sha1, ...).thenReturn(info)
+            when(gs_show_commit_info).read_commit(sha1, ...).thenReturn(info)
 
     def create_graph_view_async(self, repo_path, log, wait_for):
         when(gs_log_graph_refresh).read_graph(...).thenReturn(log.splitlines(keepends=True))


### PR DESCRIPTION
We already cached `git show <commit>` for the commit info panel.  We
now add this to the ordinary commit view.

We use the global app cache `store.cache` to share the cache between
both.