### PR TITLE
Force no animation when setting the viewport

### DIFF
--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -59,7 +59,7 @@ def place_cursor_and_show(view, row, col, row_offset):
 
     vy = (row - row_offset) * view.line_height()
     vx, _ = view.viewport_position()
-    view.set_viewport_position((vx, vy))
+    view.set_viewport_position((vx, vy), animate=False)
 
 
 def translate_row_to_inline_diff(diff_view, row):

--- a/core/commands/next_hunk.py
+++ b/core/commands/next_hunk.py
@@ -140,7 +140,7 @@ def restore_sel_and_viewport(view):
         yield
     finally:
         set_sel(view, frozen_sel)
-        view.set_viewport_position(vp)
+        view.set_viewport_position(vp, animate=False)
 
 
 def show_region(view, region, context=5):

--- a/core/commands/show_commit_info.py
+++ b/core/commands/show_commit_info.py
@@ -117,4 +117,4 @@ def restore_viewport_position(view, next_commit):
 
     view.settings().set("git_savvy.show_commit_view.commit", next_commit)
     prev_position = storage.get(next_commit, (0, 0))
-    view.set_viewport_position(prev_position, False)
+    view.set_viewport_position(prev_position, animate=False)

--- a/core/commands/show_file_at_commit.py
+++ b/core/commands/show_file_at_commit.py
@@ -147,7 +147,7 @@ def move_cursor_to_line_col(view, position):
     else:
         vy = (row - row_offset) * view.line_height()
         vx, _ = view.viewport_position()
-        view.set_viewport_position((vx, vy))
+        view.set_viewport_position((vx, vy), animate=False)
 
 
 class gs_show_file_at_commit_open_previous_commit(TextCommand, GitCommand):

--- a/core/view.py
+++ b/core/view.py
@@ -111,5 +111,5 @@ def stable_viewport(view):
     try:
         yield
     finally:
-        view.set_viewport_position((0, 0))  # intentional!
-        view.set_viewport_position((vx, vy))
+        view.set_viewport_position((0, 0), animate=False)  # intentional!
+        view.set_viewport_position((vx, vy), animate=False)


### PR DESCRIPTION
Our usage of `set_viewport_position` always is to fully control the
viewport, often to prevent any scrolling.  I thought the default
here is `False` but actually the default is to follow the global
`animation_enabled` setting (which in turn is `true` by default).

We hence force `False` in all[*] calls.

This removes some flicker and glitches when the user has animation on.

Fixes #1349 

[*]  Not fixed in `GsNavigate` to avoid a merge conflict because this call has been removed already in *dev*