### PR TITLE
Hotfix reverse tab cycling

### DIFF
--- a/core/git_command.py
+++ b/core/git_command.py
@@ -154,12 +154,10 @@ class GitCommand(StatusMixin,
         command = (self.git_binary_path, ) + tuple(arg for arg in args if arg)
         command_str = " ".join(["git"] + list(filter(None, args)))
 
-        show_panel_overrides = self.savvy_settings.get("show_panel_for")
         if show_panel is None:
-            show_panel = args[0] in show_panel_overrides
+            show_panel = args[0] in self.savvy_settings.get("show_panel_for")
 
-        close_panel_for = self.savvy_settings.get("close_panel_for") or []
-        if args[0] in close_panel_for:
+        if args[0] in self.savvy_settings.get("close_panel_for"):
             sublime.active_window().run_command("hide_panel", {"cancel": True})
 
         live_panel_output = self.savvy_settings.get("live_panel_output", False)

--- a/core/interfaces/__init__.py
+++ b/core/interfaces/__init__.py
@@ -43,8 +43,8 @@ class GsTabCycleCommand(TextCommand, GitCommand):
     def get_next(self, source, reverse=False):
         tab_order = self.savvy_settings.get("tab_order")
 
-        if reverse is True:
-            tab_order.reverse()
+        if reverse:
+            tab_order = list(reversed(tab_order))
 
         if source not in tab_order:
             return None

--- a/github/github.py
+++ b/github/github.py
@@ -70,10 +70,7 @@ def parse_remote(remote):
         return None
 
     fqdn, owner, repo = match.groups()
-
-    api_tokens = GitSavvySettings().get("api_tokens")
-    token = api_tokens and api_tokens.get(fqdn, None) or None
-
+    token = GitSavvySettings().get("api_tokens", {}).get(fqdn)
     return GitHubRepo(url, fqdn, owner, repo, token)
 
 

--- a/gitlab/gitlab.py
+++ b/gitlab/gitlab.py
@@ -72,10 +72,7 @@ def parse_remote(remote):
         return None
 
     fqdn, owner, repo = match.groups()
-
-    api_tokens = GitSavvySettings().get("api_tokens")
-    token = api_tokens and api_tokens.get(fqdn, None) or None
-
+    token = GitSavvySettings().get("api_tokens", {}).get(fqdn)
     return GitLabRepo(url, fqdn, owner, repo, token)
 
 


### PR DESCRIPTION
Since b9e9928 (Rewrite settings abstraction for performance and
reliability) settings are cached and MUST NOT be mutated.

The code base is small here so instead of sending a copy of a setting
on access it is sufficient to make this small change here. We already
do not mutate settings anywhere else.