### PR TITLE
Only re-paint commit message view if diff has changed

### DIFF
--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -182,6 +182,9 @@ class gs_prepare_commit_refresh_diff(TextCommand, GitCommand):
         except IndexError:
             region = sublime.Region(view.size())
 
+        if view.substr(region) == final_text:
+            return
+
         replace_view_content(view, final_text, region)
         if shows_diff:
             intra_line_colorizer.annotate_intra_line_differences(view, final_text, region.begin())


### PR DESCRIPTION
The commit view is now a hybrid, in the top you can write the message,
in the diff we make the view read only.  Unfortunately, replacing the
diff *always* creates an undo entry which can get in the way (a bit)
when writing the message.

This is not huge because we only refresh on focus. But we do it async
so from time to time the refresh can end after the user typed again.
We reduce this effect by just not drawing when the view is already
up-to-date.

This helps especially *if* the diff was up-to-date because in that
case `ctrl+z` is a no-op for the user.  (T.i. hitting `ctrl+z` gives
no visual feedback because both states were the same.)