### PR TITLE
Show the whole hunk when using `gs_next_hunk`/`gs_prev_hunk`

### DIFF
--- a/core/commands/next_hunk.py
+++ b/core/commands/next_hunk.py
@@ -8,6 +8,7 @@ import sublime_plugin
 
 from GitSavvy.core.fns import pairwise
 from GitSavvy.core.utils import flash
+from GitSavvy.core.view import show_region
 
 
 __all__ = (
@@ -141,18 +142,6 @@ def restore_sel_and_viewport(view):
     finally:
         set_sel(view, frozen_sel)
         view.set_viewport_position(vp, animate=False)
-
-
-def show_region(view, region, context=5):
-    # type: (sublime.View, sublime.Region, int) -> None
-    row_a, _ = view.rowcol(region.begin())
-    row_b, _ = view.rowcol(region.end())
-    adjusted_section = sublime.Region(
-        # `text_point` is permissive and normalizes negative rows
-        view.text_point(row_a - context, 0),
-        view.text_point(row_b + context, 0)
-    )
-    view.show(adjusted_section, False)
 
 
 def cur_pos(view):

--- a/core/view.py
+++ b/core/view.py
@@ -18,6 +18,18 @@ else:
     Position = namedtuple("Position", "row col offset")
 
 
+def show_region(view, region, context=5):
+    # type: (sublime.View, sublime.Region, int) -> None
+    row_a, _ = view.rowcol(region.begin())
+    row_b, _ = view.rowcol(region.end())
+    adjusted_section = sublime.Region(
+        # `text_point` is permissive and normalizes negative rows
+        view.text_point(row_a - context, 0),
+        view.text_point(row_b + context, 0)
+    )
+    view.show(adjusted_section, False)
+
+
 def capture_cur_position(view):
     # type: (sublime.View) -> Optional[Position]
     try:

--- a/core/view.py
+++ b/core/view.py
@@ -20,14 +20,48 @@ else:
 
 def show_region(view, region, context=5):
     # type: (sublime.View, sublime.Region, int) -> None
-    row_a, _ = view.rowcol(region.begin())
-    row_b, _ = view.rowcol(region.end())
-    adjusted_section = sublime.Region(
-        # `text_point` is permissive and normalizes negative rows
-        view.text_point(row_a - context, 0),
-        view.text_point(row_b + context, 0)
-    )
-    view.show(adjusted_section, False)
+    # Differentiate between wide and short jumps. For
+    # short jumps minimize the scrolling.
+    if touching_regions(view.visible_region(), region):
+        row_a, _ = view.rowcol(region.begin())
+        row_b, _ = view.rowcol(region.end())
+        adjusted_section = sublime.Region(
+            # `text_point` is permissive and normalizes negative rows
+            # If the region is wider than the viewport, Sublime prefers
+            # showing the `b` position; naturally since the cursor is
+            # at `b` by definition.  We flip a and b here because we
+            # prefer the region start.
+            view.text_point(row_b + context, 0),
+            view.text_point(row_a - context, 0),
+        )
+        view.show(adjusted_section, False)
+
+    else:
+        # For long jumps, usually keep the target, `region.begin()`, around
+        # center (`vh / 2`).  But try to always show the whole region if it fits.
+        lh = view.line_height()
+        _, vh = view.viewport_extent()
+        _, rt = view.text_to_layout(region.begin())
+        _, rb = view.text_to_layout(region.end())
+        rh = rb - rt + lh
+        ch = context * lh
+        offset = clamp(
+            clamp(lh, ch, vh - rh),
+            vh / 2,
+            vh - (rh + ch)
+        )
+        new_top = max(0, rt - offset)
+        view.set_viewport_position((0.0, new_top))
+
+
+def touching_regions(a, b):
+    # type: (sublime.Region, sublime.Region) -> bool
+    return a.intersects(b) or a.contains(b)
+
+
+def clamp(lo, hi, v):
+    # type: (float, float, float) -> float
+    return max(lo, min(hi, v))
 
 
 def capture_cur_position(view):


### PR DESCRIPTION
We used to just show the first line of the hunk which is a mistake.  Instead show the full hunk (if it fits).  

Differentiate between wide and short jumps.  Short jump being jumps to a region already within the viewport (or parts of it).  For that, try to minimize the scrolling.  

Wide jumps on the other hand are jumps to locations *not* currently in the viewport.  In that case, try to bring the first line of the region *around* the center of the viewport. 

a1f27b8 (Extract `show_region` to `core/view.py`) is cherry picked from dev to reduce merge conflicts. 