### PR TITLE
Modernize syntax settings

### DIFF
--- a/common/global_events.py
+++ b/common/global_events.py
@@ -111,6 +111,7 @@ class GsEditSettingsCommand(WindowCommand):
     For some reasons, the command palette doesn't trigger `on_post_window_command` for
     dev version of Sublime Text. The command palette would call `gs_edit_settings` and
     subsequently trigger `on_post_window_command`.
+    Ref: https://github.com/sublimehq/sublime_text/issues/2234
     """
     def run(self, **kwargs):
         self.window.run_command("edit_settings", kwargs)
@@ -121,6 +122,7 @@ class GsEditProjectSettingsCommand(WindowCommand):
     For some reasons, the command palette doesn't trigger `on_post_window_command` for
     dev version of Sublime Text. The command palette would call `gs_edit_settings` and
     subsequently trigger `on_post_window_command`.
+    Ref: https://github.com/sublimehq/sublime_text/issues/2234
     """
     def run(self):
         project_file_name = self.window.project_file_name()

--- a/common/global_events.py
+++ b/common/global_events.py
@@ -131,7 +131,7 @@ class GsEditProjectSettingsCommand(WindowCommand):
             sublime.error_message("No project data found.")
             return
 
-        sublime.set_timeout(lambda: self.window.run_command("edit_settings", {
+        self.window.run_command("edit_settings", {
             "user_file": project_file_name,
             "base_file": "${packages}/GitSavvy/GitSavvy.sublime-settings"
-        }), 100)
+        })

--- a/common/global_events.py
+++ b/common/global_events.py
@@ -89,6 +89,21 @@ class KeyboardSettingsListener(EventListener):
                     sublime.set_timeout_async(
                         lambda: view.show_popup(PROJECT_MSG, max_width=550)  # type: ignore
                     )
+            else:
+                w = sublime.active_window()
+                w.focus_group(1)
+                right_view = w.active_view()
+                if not right_view:
+                    return
+                filename = os.path.basename(right_view.file_name() or "")
+                if not filename:
+                    return
+
+                w.focus_group(0)
+                for r in sublime.find_resources(filename):
+                    if r.startswith("Packages/") and "/GitSavvy/syntax/" in r:
+                        w.run_command("open_file", {"file": "${packages}/" + r[9:]})
+                w.focus_group(1)
 
 
 class GsEditSettingsCommand(WindowCommand):

--- a/syntax/branch.sublime-settings
+++ b/syntax/branch.sublime-settings
@@ -10,7 +10,13 @@
     "rulers": [],
     "translate_tabs_to_spaces": false,
     "word_wrap": false,
+
     // syntax specific
+    "gutter": true,
+    "margin": -8,
+    "highlight_line": true,
+    "fold_buttons": false,
+    "fade_fold_buttons": false,
     "match_brackets": false,
     "match_tags": false
 }

--- a/syntax/diff.sublime-settings
+++ b/syntax/diff.sublime-settings
@@ -10,7 +10,12 @@
     "rulers": [],
     "translate_tabs_to_spaces": false,
     "word_wrap": false,
+
     // syntax specific
+    "gutter": true,
+    "margin": -8,
+    "fold_buttons": false,
+    "fade_fold_buttons": false,
     "match_brackets": false,
     "match_tags": false
 }

--- a/syntax/diff_view.sublime-settings
+++ b/syntax/diff_view.sublime-settings
@@ -10,7 +10,12 @@
     "rulers": [],
     "translate_tabs_to_spaces": false,
     "word_wrap": false,
+
     // syntax specific
+    "gutter": true,
+    "margin": -8,
+    "fold_buttons": false,
+    "fade_fold_buttons": false,
     "match_brackets": false,
     "match_tags": false
 }

--- a/syntax/graph.sublime-settings
+++ b/syntax/graph.sublime-settings
@@ -10,7 +10,13 @@
     "rulers": [],
     "translate_tabs_to_spaces": false,
     "word_wrap": false,
+
     // syntax specific
+    "gutter": true,
+    "margin": -20,
+    "highlight_line": true,
+    "fold_buttons": true,
+    "fade_fold_buttons": false,
     "match_brackets": false,
     "match_tags": false
 }

--- a/syntax/make_commit.sublime-settings
+++ b/syntax/make_commit.sublime-settings
@@ -12,6 +12,5 @@
     "word_wrap": false,
     // syntax specific
     "gutter": true,
-    "line_numbers": true,
-    "word_wrap": true
+    "line_numbers": true
 }

--- a/syntax/rebase.sublime-settings
+++ b/syntax/rebase.sublime-settings
@@ -10,7 +10,13 @@
     "rulers": [],
     "translate_tabs_to_spaces": false,
     "word_wrap": false,
+
     // syntax specific
+    "gutter": true,
+    "margin": -20,
+    "highlight_line": true,
+    "fold_buttons": true,
+    "fade_fold_buttons": false,
     "match_brackets": false,
     "match_tags": false
 }

--- a/syntax/show_commit.sublime-settings
+++ b/syntax/show_commit.sublime-settings
@@ -12,6 +12,5 @@
     "word_wrap": false,
     // syntax specific
     "match_brackets": false,
-    "match_tags": false,
-    "word_wrap": true
+    "match_tags": false
 }

--- a/syntax/status.sublime-settings
+++ b/syntax/status.sublime-settings
@@ -10,7 +10,13 @@
     "rulers": [],
     "translate_tabs_to_spaces": false,
     "word_wrap": false,
+
     // syntax specific
+    "gutter": true,
+    "margin": -20,
+    "highlight_line": true,
+    "fold_buttons": true,
+    "fade_fold_buttons": false,
     "match_brackets": false,
     "match_tags": false
 }

--- a/syntax/tags.sublime-settings
+++ b/syntax/tags.sublime-settings
@@ -10,7 +10,13 @@
     "rulers": [],
     "translate_tabs_to_spaces": false,
     "word_wrap": false,
+
     // syntax specific
+    "gutter": true,
+    "margin": -20,
+    "highlight_line": true,
+    "fold_buttons": true,
+    "fade_fold_buttons": false,
     "match_brackets": false,
     "match_tags": false
 }


### PR DESCRIPTION
The general move here is to turn the "gutter" on because otherwise
Sublime will never highlight the current line.  But because we don't
show line numbers in our dashboards we shift the view content to the
left (with a negative margin) to reduce the empty whitespace area.

For some dashboards it looks nice to have the fold buttons on.  This
really just adds some visual guidance, although you can fold out for
example the stashes section using these.  Note that we must turn off
"fade_fold_buttons", because the negative margin shifts the hover area
of the buttons away from them.

Also: Intercept the native "Settings - Syntax Specific" command, as run 
by the "Preferences" menu, and show *our* settings.  This works towards
a replacement for our `ctrl+,` binding because `ctrl+,` is now used for 
next/prev modification by Sublime Text.  For consistency and ease of use,
we might make that switch too.  