### PR TITLE
Speedup navigation esp. in the graph view

### DIFF
--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -1430,12 +1430,9 @@ def colorize_fixups(view):
 def _colorize_fixups(vid, dots):
     # type: (sublime.ViewId, Tuple[colorizer.Char]) -> None
     view = sublime.View(vid)
-    message_regions = find_by_selector(view, 'meta.graph.message.git-savvy')
-    extract_message = partial(
-        message_from_fixup_squash_line, view.id(), message_regions=message_regions
-    )
+    extract_message = partial(message_from_fixup_squash_line, view.id())
     matching_dots = list(filter_(
-        find_matching_commit(view.id(), dot, message, message_regions)
+        find_matching_commit(view.id(), dot, message)
         for dot, message in zip(dots, map(extract_message, dots))
         if message
     ))
@@ -1446,20 +1443,29 @@ def _colorize_fixups(vid, dots):
     )
 
 
+def extract_message_regions(view):
+    # type: (sublime.View) -> List[sublime.Region]
+    return find_by_selector(view, "meta.graph.message.git-savvy")
+
+
 def find_by_selector(view, selector):
-    # type: (sublime.View, str) -> Tuple[Region, ...]
-    # Same as `view.find_by_selector` but the result is hashable.
-    return tuple(
-        Region(r.a, r.b)
-        for r in view.find_by_selector(selector)
-    )
+    # type: (sublime.View, str) -> List[sublime.Region]
+    # Same as `view.find_by_selector` but cached.
+    return _find_by_selector(view.id(), view.change_count(), selector)
+
+
+@lru_cache(maxsize=1)
+def _find_by_selector(vid, _cc, selector):
+    # type: (sublime.ViewId, int, str) -> List[sublime.Region]
+    view = sublime.View(vid)
+    return view.find_by_selector(selector)
 
 
 @lru_cache(maxsize=64)
-def message_from_fixup_squash_line(vid, dot, message_regions):
-    # type: (sublime.ViewId, colorizer.Char, Iterable[Region]) -> Optional[str]
+def message_from_fixup_squash_line(vid, dot):
+    # type: (sublime.ViewId, colorizer.Char) -> Optional[str]
     view = sublime.View(vid)
-    message = commit_message_from_point(view, dot.pt, message_regions)
+    message = commit_message_from_point(view, dot.pt)
     if not message:
         return None
     # Truncated messages end with one or multiple "." dots which we
@@ -1471,10 +1477,10 @@ def message_from_fixup_squash_line(vid, dot, message_regions):
     return None
 
 
-def commit_message_from_point(view, pt, message_regions):
-    # type: (sublime.View, int, Iterable[Region]) -> Optional[str]
+def commit_message_from_point(view, pt):
+    # type: (sublime.View, int) -> Optional[str]
     line_span = view.line(pt)
-    for r in message_regions:
+    for r in extract_message_regions(view):
         if line_span.contains(r):
             return view.substr(r)
     else:
@@ -1482,11 +1488,11 @@ def commit_message_from_point(view, pt, message_regions):
 
 
 @lru_cache(maxsize=64)
-def find_matching_commit(vid, dot, message, message_regions):
-    # type: (sublime.ViewId, colorizer.Char, str, Iterable[Region]) -> Optional[colorizer.Char]
+def find_matching_commit(vid, dot, message):
+    # type: (sublime.ViewId, colorizer.Char, str) -> Optional[colorizer.Char]
     view = sublime.View(vid)
     for dot in islice(follow_dots(dot), 0, 50):
-        this_message = commit_message_from_point(view, dot.pt, message_regions)
+        this_message = commit_message_from_point(view, dot.pt)
         if this_message and this_message.startswith(message):
             return dot
     else:

--- a/core/commands/log_graph_colorizer.py
+++ b/core/commands/log_graph_colorizer.py
@@ -1,3 +1,5 @@
+from functools import lru_cache
+
 import sublime
 
 MYPY = False
@@ -163,11 +165,13 @@ def follow(ch, direction):
     return decorator
 
 
+@lru_cache(maxsize=64)
 def follow_path_down(dot):
     # type: (Char) -> List[Char]
     return list(_follow_path(dot, "down"))
 
 
+@lru_cache(maxsize=64)
 def follow_path_up(dot):
     # type: (Char) -> List[Char]
     return list(_follow_path(dot, "up"))

--- a/core/commands/navigate.py
+++ b/core/commands/navigate.py
@@ -61,16 +61,48 @@ class GsNavigate(TextCommand, GitCommand):
 
     def forward(self, current_position, regions):
         # type: (sublime.Point, Sequence[sublime.Region]) -> Optional[sublime.Region]
-        for region in regions:
-            if region.a > current_position:
-                return region
-
-        return regions[0] if self.wrap else None
+        region = find_next(regions, current_position)
+        if region is not None:
+            return region
+        else:
+            return regions[0] if self.wrap else None
 
     def backward(self, current_position, regions):
         # type: (sublime.Point, Sequence[sublime.Region]) -> Optional[sublime.Region]
-        for region in reversed(regions):
-            if region.b < current_position:
-                return region
+        region = find_previous(regions, current_position)
+        if region is not None:
+            return region
+        else:
+            return regions[-1] if self.wrap else None
 
-        return regions[-1] if self.wrap else None
+
+def find_next(regions, pos):
+    # type: (Sequence[sublime.Region], sublime.Point) -> Optional[sublime.Region]
+    lo, hi = 0, len(regions)
+    found = None
+
+    while lo < hi:
+        middle = (lo + hi) // 2
+        middle_region = regions[middle]
+        if middle_region.a > pos:
+            found = middle_region
+            hi = middle
+        else:
+            lo = middle + 1
+    return found
+
+
+def find_previous(regions, pos):
+    # type: (Sequence[sublime.Region], sublime.Point) -> Optional[sublime.Region]
+    lo, hi = 0, len(regions)
+    found = None
+
+    while lo < hi:
+        middle = (lo + hi) // 2
+        middle_region = regions[middle]
+        if middle_region.b < pos:
+            found = middle_region
+            lo = middle + 1
+        else:
+            hi = middle
+    return found


### PR DESCRIPTION
Navigation using for example using `up|down` was a bit laggy esp. in the
graph view.  

1. We cache `get_available_regions` in `GsNavigate` and use `view.change_count()`as the
invalidator. 

2. We implement a binary search for these available regions.  This is needed esp.
for log graph view, and especially for going up.  For going up, we used a simple `reversed`linear search which is obviously slow if you have 5000 commits below the 
cursor.  For all other views there is no advantage, and a linear search would be maybe even faster but probably not measurable. 

3. In the log graph view, we implement a cached version of `view.find_by_selector` which speeds-up looking for fixup/squash commits.

4. We generally cache following a dot. 