### PR TITLE
Do not cache reading the HEAD commit

### DIFF
--- a/core/commands/show_commit.py
+++ b/core/commands/show_commit.py
@@ -41,6 +41,9 @@ class gs_show_commit(WindowCommand, GitCommand):
     def run(self, commit_hash):
         # need to get repo_path before the new view is created.
         repo_path = self.repo_path
+        if commit_hash in {"", "HEAD"}:
+            commit_hash = self.git("rev-parse", "--short", "HEAD").strip()
+
         this_id = (
             self.repo_path,
             commit_hash

--- a/core/git_mixins/history.py
+++ b/core/git_mixins/history.py
@@ -306,6 +306,15 @@ class HistoryMixin():
         ignore_whitespace=False
     ):
         # type: (str, Optional[str], bool, bool, bool) -> str
+        if not commit_hash or commit_hash == "HEAD":
+            return self._read_commit(
+                commit_hash,
+                file_path,
+                show_diffstat,
+                show_patch,
+                ignore_whitespace
+            )
+
         key = (
             "read_commit",
             self.repo_path,


### PR DESCRIPTION
Fixes #1368

Do not cache reading the HEAD commit. Everywhere else, we already checked if the `commit_hash` is `""` or `"HEAD"` to skip caching, so this one was missing here.

We go one step further, special case "HEAD", and dynamically update and thus follow HEAD.

The use case is a user binding to `gs_show_commit` with `commit_hash`
set to `HEAD`.  For example:

```
  {
      "caption": "git: show HEAD commit",
      "command": "gs_show_commit",
      "args": {
          "commit_hash": "HEAD"
      }
  },
```

However, arbitrary references, like for example tags or branch names, are not supported. 