### PR TITLE
Performant and sane graph navigation

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1507,7 +1507,7 @@
         "args": { "forward": true },
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
-            { "key": "setting.git_savvy.log_graph_view", "operator": "equal", "operand": true }
+            { "key": "selector", "operand": "git-savvy.graph meta.content.git_savvy.graph" }
         ]
     },
     {
@@ -1516,7 +1516,7 @@
         "args": { "forward": false },
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
-            { "key": "setting.git_savvy.log_graph_view", "operator": "equal", "operand": true }
+            { "key": "selector", "operand": "git-savvy.graph meta.content.git_savvy.graph" }
         ]
     },
     {

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1504,7 +1504,7 @@
     {
         "keys": ["down"],
         "command": "gs_log_graph_navigate",
-        "args": { "forward": true },
+        "args": { "forward": true, "natural_movement": true },
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "selector", "operand": "git-savvy.graph meta.content.git_savvy.graph" }
@@ -1513,7 +1513,7 @@
     {
         "keys": ["up"],
         "command": "gs_log_graph_navigate",
-        "args": { "forward": false },
+        "args": { "forward": false, "natural_movement": true },
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "selector", "operand": "git-savvy.graph meta.content.git_savvy.graph" }

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -934,6 +934,7 @@ class gs_log_graph_navigate(TextCommand):
 
         wanted_section = self.search(current_position, forward)
         if wanted_section is None:
+            self.view.run_command("move", {"by": "lines", "forward": forward})
             return
 
         sel.clear()

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -1430,12 +1430,9 @@ def colorize_fixups(view):
 def _colorize_fixups(vid, dots):
     # type: (sublime.ViewId, Tuple[colorizer.Char]) -> None
     view = sublime.View(vid)
-    message_regions = find_by_selector(view, 'meta.graph.message.git-savvy')
-    extract_message = partial(
-        message_from_fixup_squash_line, view.id(), message_regions=message_regions
-    )
+    extract_message = partial(message_from_fixup_squash_line, view.id())
     matching_dots = list(filter_(
-        find_matching_commit(view.id(), dot, message, message_regions)
+        find_matching_commit(view.id(), dot, message)
         for dot, message in zip(dots, map(extract_message, dots))
         if message
     ))
@@ -1446,20 +1443,29 @@ def _colorize_fixups(vid, dots):
     )
 
 
+def extract_message_regions(view):
+    # type: (sublime.View) -> List[sublime.Region]
+    return find_by_selector(view, "meta.graph.message.git-savvy")
+
+
 def find_by_selector(view, selector):
-    # type: (sublime.View, str) -> Tuple[Region, ...]
-    # Same as `view.find_by_selector` but the result is hashable.
-    return tuple(
-        Region(r.a, r.b)
-        for r in view.find_by_selector(selector)
-    )
+    # type: (sublime.View, str) -> List[sublime.Region]
+    # Same as `view.find_by_selector` but cached.
+    return _find_by_selector(view.id(), view.change_count(), selector)
+
+
+@lru_cache(maxsize=16)
+def _find_by_selector(vid, _cc, selector):
+    # type: (sublime.ViewId, int, str) -> List[sublime.Region]
+    view = sublime.View(vid)
+    return view.find_by_selector(selector)
 
 
 @lru_cache(maxsize=64)
-def message_from_fixup_squash_line(vid, dot, message_regions):
-    # type: (sublime.ViewId, colorizer.Char, Iterable[Region]) -> Optional[str]
+def message_from_fixup_squash_line(vid, dot):
+    # type: (sublime.ViewId, colorizer.Char) -> Optional[str]
     view = sublime.View(vid)
-    message = commit_message_from_point(view, dot.pt, message_regions)
+    message = commit_message_from_point(view, dot.pt)
     if not message:
         return None
     # Truncated messages end with one or multiple "." dots which we
@@ -1471,10 +1477,10 @@ def message_from_fixup_squash_line(vid, dot, message_regions):
     return None
 
 
-def commit_message_from_point(view, pt, message_regions):
-    # type: (sublime.View, int, Iterable[Region]) -> Optional[str]
+def commit_message_from_point(view, pt):
+    # type: (sublime.View, int) -> Optional[str]
     line_span = view.line(pt)
-    for r in message_regions:
+    for r in extract_message_regions(view):
         if line_span.contains(r):
             return view.substr(r)
     else:
@@ -1482,11 +1488,11 @@ def commit_message_from_point(view, pt, message_regions):
 
 
 @lru_cache(maxsize=64)
-def find_matching_commit(vid, dot, message, message_regions):
-    # type: (sublime.ViewId, colorizer.Char, str, Iterable[Region]) -> Optional[colorizer.Char]
+def find_matching_commit(vid, dot, message):
+    # type: (sublime.ViewId, colorizer.Char, str) -> Optional[colorizer.Char]
     view = sublime.View(vid)
     for dot in islice(follow_dots(dot), 0, 50):
-        this_message = commit_message_from_point(view, dot.pt, message_regions)
+        this_message = commit_message_from_point(view, dot.pt)
         if this_message and this_message.startswith(message):
             return dot
     else:

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -930,7 +930,13 @@ class gs_log_graph_by_branch(WindowCommand, GitCommand):
 class gs_log_graph_navigate(TextCommand):
     def run(self, edit, forward=True):
         sel = self.view.sel()
-        current_position = sel[0].a
+        current_position = max(
+            sel[0].a,
+            # If inside the prelude section, jump to the *first*
+            # commit.  For `.b`, Sublime already returns the first
+            # row of the content section, thus `- 1` to compensate.
+            find_by_selector(self.view, "meta.prelude")[0].b - 1
+        )
 
         wanted_section = self.search(current_position, forward)
         if wanted_section is None:

--- a/core/commands/log_graph_colorizer.py
+++ b/core/commands/log_graph_colorizer.py
@@ -1,3 +1,5 @@
+from functools import lru_cache
+
 import sublime
 
 MYPY = False
@@ -163,11 +165,13 @@ def follow(ch, direction):
     return decorator
 
 
+@lru_cache(maxsize=64)
 def follow_path_down(dot):
     # type: (Char) -> List[Char]
     return list(_follow_path(dot, "down"))
 
 
+@lru_cache(maxsize=64)
 def follow_path_up(dot):
     # type: (Char) -> List[Char]
     return list(_follow_path(dot, "up"))

--- a/core/commands/navigate.py
+++ b/core/commands/navigate.py
@@ -31,7 +31,7 @@ class GsNavigate(TextCommand, GitCommand):
             if forward
             else self.backward(current_position, available_regions)
         )
-        if not wanted_section:
+        if wanted_section is None:
             return
 
         sel.clear()


### PR DESCRIPTION
Navigation using for example using `up|down` was a bit laggy and jumpy.  

1. We implement a cached version of `view.find_by_selector` which speeds-up looking for fixup/squash commits.

2. We generally cache following a dot. 

3. We implement a local `GsNavigate` variant with constant performance. 

4. We don't own the cursor and try to respect the column the user was on.

Successor of #1367 