### PR TITLE
Let `g` in the status view not forcefully jump to "HEAD"

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -417,7 +417,7 @@
     {
         "keys": ["g"],
         "command": "gs_graph",
-        "args": { "all": true, "follow": "HEAD" },
+        "args": { "all": true },
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.status_view", "operator": "equal", "operand": true }


### PR DESCRIPTION
We always jumped to HEAD using `g` from the status dashboard.  This is not helpful when reusing the graph view and the user actually did a research some pages down.

Switch that off.  Now `g` will just *focus* the graph view. (And technically follow whatever it followed before.)  

If *not* reusing the view, the first commit will be marked.  Often the HEAD but if not `h` to jump to the HEAD is maybe good enough.