### PR TITLE
Improve dynamic filtering the graph view

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1451,6 +1451,22 @@
         ]
     },
     {
+        "keys": ["up"],
+        "command": "gs_input_handler_go_history",
+        "args": { "forward": false },
+        "context": [
+            { "key": "setting.input_panel_with_history" }
+        ]
+    },
+    {
+        "keys": ["down"],
+        "command": "gs_input_handler_go_history",
+        "args": { "forward": true },
+        "context": [
+            { "key": "setting.input_panel_with_history" }
+        ]
+    },
+    {
         "keys": ["F"],
         "command": "gs_log_graph_reset_filters",
         "context": [

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1451,6 +1451,14 @@
         ]
     },
     {
+        "keys": ["F"],
+        "command": "gs_log_graph_reset_filters",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.log_graph_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
         "keys": ["up"],
         "command": "gs_input_handler_go_history",
         "args": { "forward": false },
@@ -1467,8 +1475,8 @@
         ]
     },
     {
-        "keys": ["F"],
-        "command": "gs_log_graph_reset_filters",
+        "keys": ["l"],
+        "command": "gs_log_graph_edit_files",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.log_graph_view", "operator": "equal", "operand": true }

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -28,7 +28,7 @@ from ..runtime import (
 from ..view import join_regions, line_distance, replace_view_content, show_region
 from ..ui_mixins.input_panel import show_single_line_input_panel
 from ..ui_mixins.quick_panel import show_branch_panel
-from ..utils import add_selection_to_jump_history, focus_view
+from ..utils import add_selection_to_jump_history, focus_view, show_toast
 from ...common import util
 from ...common.theme_generator import ThemeGenerator
 
@@ -1074,11 +1074,21 @@ class gs_log_graph_edit_filters(TextCommand):
 
         def on_done(text):
             # type: (str) -> None
+            hide_toast()  # type: ignore[has-type]
             settings.set("git_savvy.log_graph_view.filters", text)
             self.view.run_command("gs_log_graph_refresh")
 
         show_single_line_input_panel(
-            "additional args", filters, on_done, select_text=True
+            "additional args",
+            filters,
+            on_done,
+            on_cancel=lambda: enqueue_on_worker(hide_toast),  # type: ignore[has-type]
+            select_text=True
+        )
+        hide_toast = show_toast(
+            self.view,
+            "Examples: --reflog  |  -Ssearch_term  |  -Gsearch_term  |  --dense",
+            timeout=-1
         )
 
 

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -1198,13 +1198,7 @@ class gs_log_graph_edit_files(TextCommand, GitCommand):
         window = view.window()
         assert window
 
-        files = self.git(
-            "ls-tree",
-            "-r",
-            "--full-tree",
-            "--name-only",
-            "HEAD"
-        ).strip().splitlines()
+        files = self.list_controlled_files(view.change_count())
         apply_filters = settings.get("git_savvy.log_graph_view.apply_filters")
         paths = (
             settings.get("git_savvy.log_graph_view.paths", [])
@@ -1247,6 +1241,17 @@ class gs_log_graph_edit_files(TextCommand, GitCommand):
             on_done,
             flags=sublime.MONOSPACE_FONT,
         )
+
+    @lru_cache(1)
+    def list_controlled_files(self, __cc):
+        # type: (int) -> List[str]
+        return self.git(
+            "ls-tree",
+            "-r",
+            "--full-tree",
+            "--name-only",
+            "HEAD"
+        ).strip().splitlines()
 
 
 class gs_log_graph_toggle_all_setting(TextCommand, GitCommand):

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -1090,14 +1090,15 @@ class gs_log_graph_edit_filters(TextCommand):
         # type: (sublime.Edit) -> None
         view = self.view
         settings = view.settings()
-        filters = settings.get("git_savvy.log_graph_view.filters", "")
+        applying_filters = settings.get("git_savvy.log_graph_view.apply_filters")
+        filters = (
+            settings.get("git_savvy.log_graph_view.filters", "")
+            if applying_filters
+            else ""
+        )
         filter_history = settings.get("git_savvy.log_graph_view.filter_history")
         if not filter_history:
             filter_history = DEFAULT_HISTORY_ENTRIES + ([filters] if filters else [])
-        elif not filters:
-            filters = filter_history[-1]
-
-        apply_filters = settings.get("git_savvy.log_graph_view.apply_filters")
 
         def on_done(text):
             # type: (str) -> None
@@ -1109,7 +1110,7 @@ class gs_log_graph_edit_filters(TextCommand):
             settings.set("git_savvy.log_graph_view.apply_filters", True)
             settings.set("git_savvy.log_graph_view.filters", text)
             settings.set("git_savvy.log_graph_view.filter_history", new_filter_history)
-            if not apply_filters:
+            if not applying_filters:
                 settings.set("git_savvy.log_graph_view.paths", [])
                 settings.set("git_savvy.log_graph_view.filter_by_author", "")
 

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -1113,14 +1113,17 @@ class gs_log_graph_edit_filters(TextCommand):
                 settings.set("git_savvy.log_graph_view.paths", [])
                 settings.set("git_savvy.log_graph_view.filter_by_author", "")
 
-            hide_toast()  # type: ignore[has-type]
+            hide_toast()
             view.run_command("gs_log_graph_refresh")
+
+        def on_cancel():
+            enqueue_on_worker(hide_toast)
 
         input_panel = show_single_line_input_panel(
             "additional args",
             filters,
             on_done,
-            on_cancel=lambda: enqueue_on_worker(hide_toast),  # type: ignore[has-type]
+            on_cancel=on_cancel,
             select_text=True
         )
 

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -140,11 +140,12 @@ class gs_graph(WindowCommand, GitCommand):
         )
         for view in self.window.views():
             other_id = compute_identifier_for_view(view)
-            if other_id in (
-                this_id,
-                (repo_path, True, NO_FILTERS),
-                (repo_path, [], NO_FILTERS)
-            ):
+            standard_graph_views = (
+                []
+                if branches
+                else [(repo_path, True, NO_FILTERS), (repo_path, [], NO_FILTERS)]
+            )
+            if other_id in [this_id] + standard_graph_views:
                 settings = view.settings()
                 settings.set("git_savvy.log_graph_view.all_branches", all)
                 settings.set("git_savvy.log_graph_view.branches", branches)

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -168,7 +168,10 @@ class gs_graph(WindowCommand, GitCommand):
                         replace_view_content(panel, "")
                     navigate_to_symbol(view, follow)
 
-                focus_view(view)
+                if self.window.active_view() != view:
+                    focus_view(view)
+                else:
+                    view.run_command("gs_log_graph_refresh")
                 break
         else:
             view = util.view.get_scratch_view(self, "log_graph", read_only=True)

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -106,7 +106,8 @@ class gs_graph(WindowCommand, GitCommand):
         title='GRAPH',
         follow=None,
         decoration='sparse',
-        filters=''
+        filters='',
+        apply_filters=None
     ):
         if repo_path is None:
             repo_path = self.repo_path
@@ -116,6 +117,8 @@ class gs_graph(WindowCommand, GitCommand):
             if file_path
             else []
         )
+        if apply_filters is None:
+            apply_filters = paths or filters or author
 
         this_id = (
             repo_path,
@@ -132,6 +135,7 @@ class gs_graph(WindowCommand, GitCommand):
                 settings.set('git_savvy.log_graph_view.follow', follow)
                 settings.set('git_savvy.log_graph_view.decoration', decoration)
                 settings.set('git_savvy.log_graph_view.filters', filters)
+                settings.set('git_savvy.log_graph_view.apply_filters', apply_filters)
 
                 if follow and follow != extract_symbol_to_follow(view):
                     if show_commit_info.panel_is_visible(self.window):
@@ -162,6 +166,7 @@ class gs_graph(WindowCommand, GitCommand):
             settings.set('git_savvy.log_graph_view.follow', follow)
             settings.set('git_savvy.log_graph_view.decoration', decoration)
             settings.set('git_savvy.log_graph_view.filters', filters)
+            settings.set('git_savvy.log_graph_view.apply_filters', apply_filters)
             show_commit_info_panel = bool(self.savvy_settings.get("graph_show_more_commit_info"))
             settings.set(
                 "git_savvy.log_graph_view.show_commit_info_panel",
@@ -772,6 +777,7 @@ class gs_log_graph_refresh(TextCommand, GitCommand):
         author = settings.get("git_savvy.log_graph_view.filter_by_author")
         all_branches = settings.get("git_savvy.log_graph_view.all_branches")
         paths = settings.get("git_savvy.log_graph_view.paths", [])  # type: List[str]
+        apply_filters = settings.get("git_savvy.log_graph_view.apply_filters")
         args = [
             'log',
             '--graph',
@@ -780,8 +786,8 @@ class gs_log_graph_refresh(TextCommand, GitCommand):
             '--pretty=format:%h%d %<|(80,trunc)%s | %ad, %an',
             # Git can only follow exactly one path.  Luckily, this can
             # be a file or a directory.
-            '--follow' if len(paths) == 1 and follow else None,
-            '--author={}'.format(author) if author else None,
+            '--follow' if len(paths) == 1 and follow and apply_filters else None,
+            '--author={}'.format(author) if author and apply_filters else None,
             '--decorate-refs-exclude=refs/remotes/origin/HEAD',  # cosmetics
             '--exclude=refs/stash',
             '--all' if all_branches else None,
@@ -795,10 +801,10 @@ class gs_log_graph_refresh(TextCommand, GitCommand):
             args += branches
 
         filters = settings.get("git_savvy.log_graph_view.filters")
-        if filters:
+        if filters and apply_filters:
             args += shlex.split(filters)
 
-        if paths:
+        if paths and apply_filters:
             args += ["--"] + paths
 
         return args
@@ -827,14 +833,15 @@ def prelude(view):
     settings = view.settings()
     repo_path = settings.get("git_savvy.repo_path")
     paths = settings.get("git_savvy.log_graph_view.paths")
-    if paths:
+    apply_filters = settings.get("git_savvy.log_graph_view.apply_filters")
+    if apply_filters and paths:
         prelude += "  FILE: {}\n".format(" ".join(paths))
     elif repo_path:
         prelude += "  REPO: {}\n".format(repo_path)
 
     all_ = settings.get("git_savvy.log_graph_view.all_branches") or False
     branches = settings.get("git_savvy.log_graph_view.branches") or []
-    filters = settings.get("git_savvy.log_graph_view.filters") or ""
+    filters = apply_filters and settings.get("git_savvy.log_graph_view.filters") or ""
     prelude += (
         "  "
         + "  ".join(filter(None, [
@@ -1089,6 +1096,8 @@ class gs_log_graph_edit_filters(TextCommand):
         elif not filters:
             filters = filter_history[-1]
 
+        apply_filters = settings.get("git_savvy.log_graph_view.apply_filters")
+
         def on_done(text):
             # type: (str) -> None
             new_filter_history = (
@@ -1096,8 +1105,12 @@ class gs_log_graph_edit_filters(TextCommand):
                 if text in filter_history or not text
                 else (filter_history + [text])
             )
+            settings.set("git_savvy.log_graph_view.apply_filters", True)
             settings.set("git_savvy.log_graph_view.filters", text)
             settings.set("git_savvy.log_graph_view.filter_history", new_filter_history)
+            if not apply_filters:
+                settings.set("git_savvy.log_graph_view.paths", [])
+                settings.set("git_savvy.log_graph_view.filter_by_author", "")
 
             hide_toast()  # type: ignore[has-type]
             self.view.run_command("gs_log_graph_refresh")
@@ -1172,7 +1185,9 @@ class gs_input_handler_go_history(TextCommand):
 class gs_log_graph_reset_filters(TextCommand):
     def run(self, edit):
         settings = self.view.settings()
-        settings.set("git_savvy.log_graph_view.filters", "")
+        current = settings.get("git_savvy.log_graph_view.apply_filters")
+        next_state = not current
+        settings.set("git_savvy.log_graph_view.apply_filters", next_state)
         self.view.run_command("gs_log_graph_refresh")
 
 
@@ -1190,7 +1205,12 @@ class gs_log_graph_edit_files(TextCommand, GitCommand):
             "--name-only",
             "HEAD"
         ).strip().splitlines()
-        paths = settings.get("git_savvy.log_graph_view.paths", [])  # type: List[str]
+        apply_filters = settings.get("git_savvy.log_graph_view.apply_filters")
+        paths = (
+            settings.get("git_savvy.log_graph_view.paths", [])
+            if apply_filters
+            else []
+        )  # type: List[str]
         items = (
             [
                 ">  {}".format(file)
@@ -1215,6 +1235,11 @@ class gs_log_graph_edit_files(TextCommand, GitCommand):
                 settings.set("git_savvy.log_graph_view.paths", [p for p in paths if p != path])
             else:
                 settings.set("git_savvy.log_graph_view.paths", paths + [path])
+
+            settings.set("git_savvy.log_graph_view.apply_filters", True)
+            if not apply_filters:
+                settings.set("git_savvy.log_graph_view.filters", "")
+                settings.set("git_savvy.log_graph_view.filter_by_author", "")
             view.run_command("gs_log_graph_refresh")
 
         window.show_quick_panel(

--- a/popups/log_graph_view.html
+++ b/popups/log_graph_view.html
@@ -12,7 +12,8 @@
   <div><code><span class="shortcut-key">m&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>toggle commit details panel on the bottom</code></div>
   <div><code><span class="shortcut-key">a&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>toggle "--all"</code></div>
   <div><code><span class="shortcut-key">f&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>edit filters verbatim</code></div>
-  <div><code><span class="shortcut-key">F&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>reset filters</code></div>
+  <div><code><span class="shortcut-key">l&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>list paths to add or remove</code></div>
+  <div><code><span class="shortcut-key">F&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>toggle filters</code></div>
   <div><code><span class="shortcut-key">{super_key}+C&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>copy commit's hash, subject or a combination to the clipboard</code></div>
 </div>
 

--- a/popups/log_graph_view.html
+++ b/popups/log_graph_view.html
@@ -11,7 +11,8 @@
   <div><code><span class="shortcut-key">o&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>open commit in a new view</code></div>
   <div><code><span class="shortcut-key">m&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>toggle commit details panel on the bottom</code></div>
   <div><code><span class="shortcut-key">a&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>toggle "--all"</code></div>
-  <div><code><span class="shortcut-key">f&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>edit filters verbatim, e.g. try "--reflog" or "-Ssearch_term"</code></div>
+  <div><code><span class="shortcut-key">f&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>edit filters verbatim</code></div>
+  <div><code><span class="shortcut-key">F&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>reset filters</code></div>
   <div><code><span class="shortcut-key">{super_key}+C&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>copy commit's hash, subject or a combination to the clipboard</code></div>
 </div>
 

--- a/stubs/sublime.pyi
+++ b/stubs/sublime.pyi
@@ -391,8 +391,8 @@ class View:
         content: str,
         flags: int = ...,
         location: int = ...,
-        max_width: int = ...,
-        max_height: int = ...,
+        max_width: Union[int, float] = ...,
+        max_height: Union[int, float] = ...,
         on_navigate: Optional[Any] = ...,
         on_hide: Optional[Any] = ...,
     ) -> None: ...


### PR DESCRIPTION
- For `f`, maintain a history of previous filters.  Use `up|down` while in the input panel to access them.  Pre-populate the history with some common good settings, for example "--reflog" is very useful.  Also compute  a "--author" arg based on the current commits author.  

- Add `l` (**ls**-tree), to add or remove paths to the command.  This is really a dynamic variant of our "File History".  You can also select paths, not just concrete files; and of course multiple ones.

- For `F`, document the binding in the `?` tooltip 🙄.  Make it a toggle which will toggle `filters` and the file paths.  (Also `filter_by_author`, which can probably be deprecated with the new helper for `f`.)  For example, looking at a "File History" `F` will show the commit with full context.  

![image](https://user-images.githubusercontent.com/8558/94946122-f6ce5b80-04db-11eb-8e2e-a6b0f24961e2.png)

![image](https://user-images.githubusercontent.com/8558/94946043-de5e4100-04db-11eb-83f7-c3f496e41ffa.png)
  