### PR TITLE
Implement "fixup" helper in the commit message view

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -9,7 +9,7 @@
         "command": "gs_commit_view_do_commit",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
-            { "key": "setting.git_savvy.get_long_text_view", "operator": "equal", "operand": true },
+            { "key": "setting.git_savvy.commit_view", "operator": "equal", "operand": true },
             { "key": "setting.git_savvy.commit_on_close", "operator": "equal", "operand": false }
         ]
     },
@@ -18,7 +18,7 @@
         "command": "gs_commit_view_sign",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
-            { "key": "setting.git_savvy.get_long_text_view", "operator": "equal", "operand": true }
+            { "key": "setting.git_savvy.commit_view", "operator": "equal", "operand": true }
         ]
     },
     {

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -9,7 +9,7 @@
         "command": "gs_commit_view_do_commit",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
-            { "key": "setting.git_savvy.get_long_text_view", "operator": "equal", "operand": true },
+            { "key": "setting.git_savvy.commit_view", "operator": "equal", "operand": true },
             { "key": "setting.git_savvy.commit_on_close", "operator": "equal", "operand": false }
         ]
     },
@@ -18,7 +18,7 @@
         "command": "gs_commit_view_sign",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
-            { "key": "setting.git_savvy.get_long_text_view", "operator": "equal", "operand": true }
+            { "key": "setting.git_savvy.commit_view", "operator": "equal", "operand": true }
         ]
     },
     {

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -9,7 +9,7 @@
         "command": "gs_commit_view_do_commit",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
-            { "key": "setting.git_savvy.get_long_text_view", "operator": "equal", "operand": true },
+            { "key": "setting.git_savvy.commit_view", "operator": "equal", "operand": true },
             { "key": "setting.git_savvy.commit_on_close", "operator": "equal", "operand": false }
         ]
     },
@@ -18,7 +18,7 @@
         "command": "gs_commit_view_sign",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
-            { "key": "setting.git_savvy.get_long_text_view", "operator": "equal", "operand": true }
+            { "key": "setting.git_savvy.commit_view", "operator": "equal", "operand": true }
         ]
     },
     {

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -504,14 +504,12 @@
     // COMMIT VIEW //
     /////////////////
 
-    // Per-platform key-mapping for: gs_commit_view_do_commit
-
     {
         "keys": ["tab"],
         "command": "gs_github_show_issues",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
-            { "key": "setting.git_savvy.get_long_text_view", "operator": "equal", "operand": true },
+            { "key": "setting.git_savvy.commit_view", "operator": "equal", "operand": true },
             { "key": "preceding_text", "operator": "regex_match", "operand": ".*[\\n ]#$" }
         ]
     },
@@ -521,7 +519,7 @@
         "args": { "default_repo": false },
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
-            { "key": "setting.git_savvy.get_long_text_view", "operator": "equal", "operand": true },
+            { "key": "setting.git_savvy.commit_view", "operator": "equal", "operand": true },
             { "key": "preceding_text", "operator": "regex_match", "operand": ".*[\\n ][a-zA-Z\\-_0-9\\.]+/[a-zA-Z\\-_0-9\\.]+#$" }
         ]
     },
@@ -530,7 +528,7 @@
         "command": "gs_github_show_contributors",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
-            { "key": "setting.git_savvy.get_long_text_view", "operator": "equal", "operand": true },
+            { "key": "setting.git_savvy.commit_view", "operator": "equal", "operand": true },
             { "key": "preceding_text", "operator": "regex_match", "operand": ".*[\\n ]@$" }
         ]
     },

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -510,7 +510,9 @@
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.commit_view", "operator": "equal", "operand": true },
-            { "key": "preceding_text", "operator": "regex_match", "operand": ".*[\\n ]#$" }
+            { "key": "preceding_text", "operator": "regex_match", "operand": "(|.* )#$" },
+            { "key": "selection_empty" },
+            { "key": "num_selections", "operator": "equal", "operand": 1 }
         ]
     },
     {
@@ -520,7 +522,9 @@
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.commit_view", "operator": "equal", "operand": true },
-            { "key": "preceding_text", "operator": "regex_match", "operand": ".*[\\n ][a-zA-Z\\-_0-9\\.]+/[a-zA-Z\\-_0-9\\.]+#$" }
+            { "key": "preceding_text", "operator": "regex_match", "operand": "(|.* )[a-zA-Z\\-_0-9\\.]+/[a-zA-Z\\-_0-9\\.]+#$" },
+            { "key": "selection_empty" },
+            { "key": "num_selections", "operator": "equal", "operand": 1 }
         ]
     },
     {
@@ -529,7 +533,9 @@
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.commit_view", "operator": "equal", "operand": true },
-            { "key": "preceding_text", "operator": "regex_match", "operand": ".*[\\n ]@$" }
+            { "key": "preceding_text", "operator": "regex_match", "operand": "(|.* )@$" },
+            { "key": "selection_empty" },
+            { "key": "num_selections", "operator": "equal", "operand": 1 }
         ]
     },
     {

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -539,6 +539,31 @@
         ]
     },
     {
+        "keys": ["tab"],
+        "command": "gs_fixup_helper",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.commit_view", "operator": "equal", "operand": true },
+            { "key": "preceding_text", "operator": "regex_match", "operand": "fix(|up(! ?)?)$" },
+            { "key": "selection_empty" },
+            { "key": "num_selections", "operator": "equal", "operand": 1 },
+            { "key": "selector", "operator": "equal", "operand": "meta.commit.message.subject" }
+        ]
+    },
+    {
+        "keys": ["tab"],
+        "command": "gs_fixup_helper",
+        "args": { "action": "squash" },
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.commit_view", "operator": "equal", "operand": true },
+            { "key": "preceding_text", "operator": "regex_match", "operand": "sq(|uash(! ?)?)$" },
+            { "key": "selection_empty" },
+            { "key": "num_selections", "operator": "equal", "operand": 1 },
+            { "key": "selector", "operator": "equal", "operand": "meta.commit.message.subject" }
+        ]
+    },
+    {
         "keys": ["o"],
         "command": "gs_diff_open_file_at_hunk",
         "context": [

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -540,7 +540,21 @@
     },
     {
         "keys": ["tab"],
-        "command": "gs_fixup_helper",
+        "command": "gs_commit_log_helper",
+        "args": { "prefix": "", "move_to_eol": false },
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.commit_view", "operator": "equal", "operand": true },
+            { "key": "preceding_text", "operator": "regex_match", "operand": "^$" },
+            { "key": "selection_empty" },
+            { "key": "num_selections", "operator": "equal", "operand": 1 },
+            { "key": "selector", "operator": "equal", "operand": "meta.commit.message.subject" }
+        ]
+    },
+    {
+        "keys": ["tab"],
+        "command": "gs_commit_log_helper",
+        "args": { "prefix": "fixup! " },
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.commit_view", "operator": "equal", "operand": true },
@@ -552,8 +566,8 @@
     },
     {
         "keys": ["tab"],
-        "command": "gs_fixup_helper",
-        "args": { "action": "squash" },
+        "command": "gs_commit_log_helper",
+        "args": { "prefix": "squash! " },
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.commit_view", "operator": "equal", "operand": true },

--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -95,7 +95,6 @@ class gs_commit(WindowCommand, GitCommand):
             view = self.window.new_file()
             settings = view.settings()
             settings.set("git_savvy.repo_path", repo_path)
-            settings.set("git_savvy.get_long_text_view", True)
             settings.set("git_savvy.commit_view", True)
             settings.set("git_savvy.commit_view.include_unstaged", include_unstaged)
             settings.set("git_savvy.commit_view.amend", amend)

--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -34,11 +34,10 @@ if MYPY:
 
 
 COMMIT_HELP_TEXT_EXTRA = """##
-## You may also reference or close a GitHub issue with this commit.
-## To do so, type `#` followed by the `tab` key.  You will be shown a
-## list of issues related to the current repo.  You may also type
-## `owner/repo#` plus the `tab` key to reference an issue in a
-## different GitHub repo.
+## "fixup<tab>"  to create a fixup subject  (short: "fix<tab>")
+## "squash<tab>  to create a squash subject (short: "sq<tab>")
+## "#<tab>"      to reference a GitHub issue (or: "owner/repo#<tab>")
+## In the diff below, [o] will open the file under the cursor.
 """
 
 COMMIT_HELP_TEXT_ALT = """

--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -439,7 +439,11 @@ class gs_fixup_helper(TextCommand, GitCommand):
             })
 
         format_item = lambda entry: "  ".join(filter_(
-            (entry.short_hash, short_ref(entry.ref), entry.summary)
+            (
+                entry.short_hash,
+                short_ref(entry.ref) if not entry.ref.startswith("HEAD ->") else "",
+                entry.summary
+            )
         ))
         window.show_quick_panel(
             list(map(format_item, items)),

--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -22,7 +22,7 @@ __all__ = (
     "gs_commit_view_do_commit",
     "gs_commit_view_sign",
     "gs_commit_view_close",
-    "gs_fixup_helper",
+    "gs_commit_log_helper",
     "GsPrepareCommitFocusEventListener",
     "GsPedanticEnforceEventListener",
 )
@@ -34,6 +34,7 @@ if MYPY:
 
 
 COMMIT_HELP_TEXT_EXTRA = """##
+## "<tab>"       at the very first char to see the recent log
 ## "fixup<tab>"  to create a fixup subject  (short: "fix<tab>")
 ## "squash<tab>  to create a squash subject (short: "sq<tab>")
 ## "#<tab>"      to reference a GitHub issue (or: "owner/repo#<tab>")
@@ -409,8 +410,8 @@ class gs_commit_view_close(TextCommand, GitCommand):
             self.view.close()
 
 
-class gs_fixup_helper(TextCommand, GitCommand):
-    def run(self, edit, action="fixup"):
+class gs_commit_log_helper(TextCommand, GitCommand):
+    def run(self, edit, prefix="fixup! ", move_to_eol=True):
         view = self.view
         window = view.window()
         assert window
@@ -423,10 +424,11 @@ class gs_fixup_helper(TextCommand, GitCommand):
             if idx == -1:
                 return
             entry = items[idx]
-            text = "{}! {}".format(action, entry.summary)
+            text = "{}{}".format(prefix, entry.summary)
             replace_view_content(view, text, region=view.line(cursor))
-            view.sel().clear()
-            view.sel().add(len(text))
+            if move_to_eol:
+                view.sel().clear()
+                view.sel().add(len(text))
 
         # `on_highlight` also gets called `on_done`, and then
         # our "show|hide_panel" side-effects get muddled.  We

--- a/core/git_mixins/history.py
+++ b/core/git_mixins/history.py
@@ -42,7 +42,7 @@ class HistoryMixin():
             "--max-count={}".format(limit) if limit else None,
             "--skip={}".format(skip) if skip else None,
             "--reverse" if reverse else None,
-            '--format=%h%n%H%n%D%n%s%n%an%n%ae%n%at%x00%B%x00%x00%n',
+            r"--format=%h%n%H%n%D%n%s%n%an%n%ae%n%at%x00%B%x00%x00%n",  # `r"` to disable Sublime string highlighting
             "--author={}".format(author) if author else None,
             "--grep={}".format(msg_regexp) if msg_regexp else None,
             "--cherry" if cherry else None,

--- a/core/ui_mixins/quick_panel.py
+++ b/core/ui_mixins/quick_panel.py
@@ -1,8 +1,8 @@
-from functools import partial
 import itertools
 import sublime
 from ...common import util
 from ..git_command import GitCommand
+from GitSavvy.core.fns import filter_
 
 
 class PanelActionMixin(object):
@@ -526,9 +526,6 @@ def short_ref(ref):
     refs = ["|{}|".format(r) for r in refs]
 
     return ' '.join(refs)
-
-
-filter_ = partial(filter, None)
 
 
 class LogPanel(PaginatedPanel):

--- a/core/ui_mixins/quick_panel.py
+++ b/core/ui_mixins/quick_panel.py
@@ -545,10 +545,6 @@ class LogPanel(PaginatedPanel):
                 "Skip this set of commits and choose from the next-oldest batch."]
 
     def on_selection(self, commit):
-        self.commit = commit
-        sublime.set_timeout_async(lambda: self.on_selection_async(commit), 10)
-
-    def on_selection_async(self, commit):
         self.on_done(commit)
 
 

--- a/syntax/make_commit.sublime-syntax
+++ b/syntax/make_commit.sublime-syntax
@@ -46,6 +46,12 @@ contexts:
       scope: comment.help-text.git-savvy.make-commit
       set:
         - meta_scope: meta.dropped.git.commit
+        - match: '(\[)(.+?)(\])'
+          captures:
+            1: punctuation.definition.git-savvy.key-bindings-key-stroke
+            2: constant.character.git-savvy-key-binding-key
+            3: punctuation.definition.git-savvy.key-bindings-key-stroke
+        - match: '(<)(.+?)(>)'
         - match: ^$
           push: [scope:git-savvy.diff]
         - match: .

--- a/syntax/make_commit.sublime-syntax
+++ b/syntax/make_commit.sublime-syntax
@@ -10,11 +10,8 @@ contexts:
     - match: '(?=^## To make a commit.+)'
       set: dropped-content
 
-    - match: .
-      set: commit-subject
-
     - match: ^
-      set: commit-message
+      set: commit-subject
 
   references:
     - match: \@\w*
@@ -30,13 +27,20 @@ contexts:
       scope: constant.other.commit-sha.git-savvy.make-commit
 
   commit-subject:
-    - match: \n
-      pop: true
     - meta_scope: meta.commit.message.subject markup.heading.subject.git.commit
+    - match: (?=$)\n
+      set: commit-line-separator
     - include: references
 
+  commit-line-separator:
+    - meta_content_scope: meta.commit.message
+    - match: '(?=^## To make a commit.+)'
+      set: dropped-content
+    - match: \n
+      set: commit-message
+
   commit-message:
-    - meta_scope: meta.commit.message.body
+    - meta_content_scope: meta.commit.message.body
     - include: references
     - match: '(?=^## To make a commit.+)'
       set: dropped-content

--- a/syntax/test/syntax_test_make_commit.txt
+++ b/syntax/test/syntax_test_make_commit.txt
@@ -1,24 +1,23 @@
-// SYNTAX TEST "Packages/GitSavvy/syntax/make_commit.sublime-syntax"
-The subject
-^^^ meta.commit.message.subject
-
+# SYNTAX TEST "Packages/GitSavvy/syntax/make_commit.sublime-syntax"
+# <- meta.commit.message.subject
+# ^^^ meta.commit.message.subject
 Some body
-^^^ meta.commit.message.body
+# ^^^ meta.commit.message.body
 
 This is for @aziz and close #76 aziz/git#123 aziz/good
-//          ^^^^^ constant.other.github-username.git-savvy.make-commit
-//                          ^^^ constant.other.issue-ref.git-savvy.make-commit
-//                              ^^^^^^^^^^^^ constant.other.issue-ref.git-savvy.make-commit
-This is a ref to a commit 89d6780 
-//                        ^^^^^^^ constant.other.commit-sha.git-savvy.make-commit
+#           ^^^^^ constant.other.github-username.git-savvy.make-commit
+#                           ^^^ constant.other.issue-ref.git-savvy.make-commit
+#                               ^^^^^^^^^^^^ constant.other.issue-ref.git-savvy.make-commit
+This is a ref to a commit 89d6780
+#                         ^^^^^^^ constant.other.commit-sha.git-savvy.make-commit
 
 
 ## To make a commit, type your commit message and press SUPER-ENTER. To cancel
-// <- meta.dropped.git.commit comment.help-text.git-savvy.make-commit
-// ^^^ meta.dropped.git.commit comment.help-text.git-savvy.make-commit
-More help text 
-// <- comment.help-text.git-savvy.make-commit
-// ^^^ comment.help-text.git-savvy.make-commit
+# <- meta.dropped.git.commit comment.help-text.git-savvy.make-commit
+# ^^^ meta.dropped.git.commit comment.help-text.git-savvy.make-commit
+More help text
+# <- comment.help-text.git-savvy.make-commit
+# ^^^ comment.help-text.git-savvy.make-commit
 
  core/commands/commit.py | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)


### PR DESCRIPTION
In addition to the `@<tab>` and `#<tab>` helper, 

1) add `fixup<tab>` and `squash<tab>` helpers.  When invoked a custom log panel opens.  On selecting a commit, we construct a fixup (or squash) commit message subject.  The user can add some further comments after that or `ctrl+enter` to actually commit.  (T.i. we don't commit automatically.)

2) Hitting `<tab>`exatly on BOF position, t.i. usually immediately after opening the view, will also show the recent log.  Either just for reading, or, on `enter`, to use the commit subject, usually as a template for further editing so we stay at BOF position after that.

Also some small fixes and glitches around that code. 

Fixes #487 
Ref #1355  