### PR TITLE
Do not attempt to save a git file if it doesn't exist

### DIFF
--- a/common/global_events.py
+++ b/common/global_events.py
@@ -52,7 +52,11 @@ class GitCommandFromTerminal(EventListener, SettingsMixin):
     def on_pre_close(self, view):
         # type: (sublime.View) -> None
         file_path = view.file_name()
-        if file_path and os.path.basename(file_path) in NATIVE_GIT_EDITOR_FILES:
+        if (
+            file_path
+            and os.path.basename(file_path) in NATIVE_GIT_EDITOR_FILES
+            and os.path.exists(file_path)
+        ):
             view.run_command("save")
 
 


### PR DESCRIPTION
For example, the user might `rebase --abort` while looking at the
"git-rebase-todo" file which will in turn delete the file.