### PR TITLE
Fix possible freeze when undoing in the commit message view

### DIFF
--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -202,7 +202,8 @@ class GsPrepareCommitFocusEventListener(ViewEventListener):
     def on_activated(self):
         self.view.run_command("gs_prepare_commit_refresh_diff", {"sync": False})
 
-    def on_selection_modified(self) -> None:
+    # Must be "async", see: https://github.com/timbrel/GitSavvy/pull/1382
+    def on_selection_modified_async(self) -> None:
         view = self.view
         in_dropped_content = any(
             r.contains(s) or r.intersects(s)


### PR DESCRIPTION
The interaction between automatically setting the `read_only` state and
automatically updating the diff in the background confuses Sublime
in a way that it freezes and shuts down.

A reproduction was:  Put the cursor in the read only area, for example
the help comment.  Try `ctrl+z` for undo **while in the read-only area**.
Note that it tells you in the status bar "Undo: ..." without any visual
difference.  Move to the writeable area, `ctrl+z` again.  Now, Sublime
freezes.

The fix is to switch the `read-only` state not sync, t.i. using the
`on_selection_modified_async` callback.  From the perspective of the
fix it looks like "undoing" triggers a cursor movement *to* the
read-only area, and a sync selection-modified event then toggles the
read-only state which crashes Sublime.