### PR TITLE
Rebase actions in the graph view

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -377,6 +377,18 @@
         "command": "gs_show_rebase"
     },
     {
+        "caption": "git: rebase --abort",
+        "command": "gs_rebase_abort"
+    },
+    {
+        "caption": "git: rebase --continue",
+        "command": "gs_rebase_continue"
+    },
+    {
+        "caption": "git: rebase --skip",
+        "command": "gs_rebase_skip"
+    },
+    {
         "caption": "git: reset",
         "command": "gs_reset"
     },

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -329,10 +329,6 @@
         "command": "gs_abort_merge"
     },
     {
-        "caption": "git: abort rebase",
-        "command": "gs_rebase_abort"
-    },
-    {
         "caption": "git: restart merge for file...",
         "command": "gs_restart_merge_for_file"
     },

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1892,7 +1892,6 @@
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.vintageous_friendly", "operator": "equal", "operand": false },
-
             { "key": "setting.git_savvy.rebase_view", "operator": "equal", "operand": true }
         ]
     },

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1483,14 +1483,6 @@
         ]
     },
     {
-        "keys": ["R"],
-        "command": "gs_rebase_just_autosquash",
-        "context": [
-            { "key": "setting.command_mode", "operator": "equal", "operand": false },
-            { "key": "setting.git_savvy.log_graph_view", "operator": "equal", "operand": true }
-        ]
-    },
-    {
         "keys": ["W"],
         "command": "gs_rebase_reword_commit",
         "context": [

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1484,7 +1484,7 @@
     },
     {
         "keys": ["R"],
-        "command": "gs_native_rebase_interactive",
+        "command": "gs_rebase_just_autosquash",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.log_graph_view", "operator": "equal", "operand": true }

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1475,6 +1475,39 @@
         ]
     },
     {
+        "keys": ["r"],
+        "command": "gs_rebase_action",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.log_graph_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["R"],
+        "command": "gs_native_rebase_interactive",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.log_graph_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["W"],
+        "command": "gs_rebase_reword_commit",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.log_graph_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["E"],
+        "command": "gs_rebase_edit_commit",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.log_graph_view", "operator": "equal", "operand": true }
+        ]
+    },
+
+    {
         "keys": ["?"],
         "command": "gs_interface_toggle_popup_help",
         "args": { "view_name": "log_graph_view" },

--- a/core/base_commands.py
+++ b/core/base_commands.py
@@ -1,0 +1,139 @@
+from contextlib import contextmanager
+from functools import lru_cache
+import inspect
+import threading
+
+import sublime
+import sublime_plugin
+
+
+MYPY = False
+if MYPY:
+    from typing import Any, Callable, Dict, Iterator, List, TypeVar
+    CommandT = TypeVar("CommandT", bound=sublime_plugin.Command)
+    Kont = Callable[[object], None]
+    ArgProvider = Callable[[CommandT, Kont], None]
+    Args = Dict[str, Any]
+
+
+class WithProvideWindow:
+    window = None  # type: sublime.Window
+
+    def run_(self, edit_token, args):
+        window = self.view.window()  # type: ignore[attr-defined]
+        if not window:
+            return
+        # Very difficult to tell when Sublime actually instantiates
+        # new objects (selfs).  However, for some commands a TextCommand
+        # instance is long-lived.  Since we usually defer to the worker
+        # or some other thread **and** want to use `self` as the current
+        # context object, we clone manually here.
+        # So we get a new context per call which also means we can't store
+        # state on `self` to be available on the next call.
+        cloned = self.__class__(self.view)  # type: ignore[attr-defined, call-arg]
+        cloned.window = window
+        return super(WithProvideWindow, cloned).run_(edit_token, args)  # type: ignore[misc]
+
+
+class WithInputHandlers:
+    defaults = {}  # type: Dict[str, ArgProvider]
+
+    def run_(self, edit_token, args):
+        if not self.defaults:
+            return super().run_(edit_token, args)  # type: ignore[misc]
+
+        args = self.filter_args(args)  # type: ignore[attr-defined]
+        if args is None:
+            args = {}
+
+        present = args.keys()
+        for name in ordered_positional_args(self.run):  # type: ignore[attr-defined]
+            if name not in present and name in self.defaults:
+                sync_mode = Flag()
+                done = make_on_done_fn(
+                    lambda: (
+                        None
+                        if sync_mode
+                        else run_command(self, args)  # type: ignore[arg-type]
+                    ),
+                    args,
+                    name
+                )
+                with sync_mode.set():
+                    self.defaults[name](self, done)
+                if not done.called:
+                    break
+        else:
+            return super().run_(edit_token, args)  # type: ignore[misc]
+
+
+@lru_cache()
+def ordered_positional_args(fn):
+    # type: (Callable) -> List[str]
+    return [
+        name
+        for name, parameter in inspect.signature(fn).parameters.items()
+        if parameter.default is inspect.Parameter.empty
+    ]
+
+
+class Flag:
+    def __init__(self):
+        self._event = threading.Event()
+
+    @contextmanager
+    def set(self):
+        # type: () -> Iterator[None]
+        self._event.set()
+        try:
+            yield
+        finally:
+            self._event.clear()
+
+    def __bool__(self):
+        # type: () -> bool
+        return self._event.is_set()
+
+
+def make_on_done_fn(kont, args, name):
+    def on_done(value):
+        on_done.called = True  # type: ignore[attr-defined]
+        args[name] = value
+        kont()
+    on_done.called = False  # type: ignore[attr-defined]
+    return on_done
+
+
+def run_command(cmd, args):
+    # type: (sublime_plugin.Command, Args) -> None
+    _get_run_command(cmd)(cmd.name(), args)
+
+
+def _get_run_command(cmd):
+    # type: (sublime_plugin.Command) -> Callable[[str, Dict], None]
+    if isinstance(cmd, sublime_plugin.TextCommand):
+        return cmd.view.run_command
+    elif isinstance(cmd, sublime_plugin.WindowCommand):
+        return cmd.window.run_command
+    else:
+        return sublime.run_command
+
+
+class GsTextCommand(
+    WithInputHandlers,
+    WithProvideWindow,
+    sublime_plugin.TextCommand,
+):
+    defaults = {}  # type: Dict[str, Callable[[GsTextCommand, Kont], None]]
+
+
+class GsWindowCommand(
+    WithInputHandlers,
+    sublime_plugin.WindowCommand,
+):
+    defaults = {}  # type: Dict[str, Callable[[GsWindowCommand, Kont], None]]
+
+
+if MYPY:
+    from typing import Union
+    GsCommand = Union[GsTextCommand, GsWindowCommand]

--- a/core/commands/__init__.py
+++ b/core/commands/__init__.py
@@ -17,6 +17,7 @@ from .inline_diff import *
 from .line_history import *
 from .log import *
 from .log_graph import *
+from .log_graph_rebase_actions import *
 from .log_graph_smart_copy import *
 from .merge import *
 from .mv import *

--- a/core/commands/branch.py
+++ b/core/commands/branch.py
@@ -58,13 +58,10 @@ class gs_delete_branch(WindowCommand, GitCommand):
             )
         else:
             try:
-                rv = self.git(
+                rv = self.git_throwing_silently(
                     "branch",
                     "-d",
-                    branch_name,
-                    throw_on_stderr=True,
-                    show_status_message_on_stderr=False,
-                    show_panel_on_stderr=False,
+                    branch_name
                 )
             except GitSavvyError as e:
                 if NOT_MERGED_WARNING.search(e.stderr):

--- a/core/commands/log_graph_rebase_actions.py
+++ b/core/commands/log_graph_rebase_actions.py
@@ -12,6 +12,7 @@ from GitSavvy.common import util
 from GitSavvy.core.base_commands import GsTextCommand, GsWindowCommand
 from GitSavvy.core.commands import log_graph
 from GitSavvy.core.git_command import GitCommand, GitSavvyError
+from GitSavvy.core.parse_diff import TextRange
 from GitSavvy.core.runtime import on_new_thread, run_on_new_thread, throttled
 from GitSavvy.core.ui_mixins.quick_panel import show_branch_panel
 from GitSavvy.core.utils import flash
@@ -63,6 +64,13 @@ else:
     Commit = namedtuple("Commit", "commit_hash commit_message")
 
 
+def line_from_pt(view, pt):
+    # type: (sublime.View, int) -> TextRange
+    line_span = view.line(pt)
+    line_text = view.substr(line_span)
+    return TextRange(line_text, line_span.a, line_span.b)
+
+
 def extract_symbol_from_graph(self, done):
     # type: (GsCommand, Kont) -> None
     view = get_view_for_command(self)
@@ -73,9 +81,8 @@ def extract_symbol_from_graph(self, done):
         flash(view, "Only single cursors are supported.")
         return
 
-    line_span = view.line(sel)
-    line_text = view.substr(line_span)
-    info = log_graph.describe_graph_line(line_text, remotes=[])
+    line = line_from_pt(view, sel.b)
+    info = log_graph.describe_graph_line(line.text, remotes=[])
     if info is None:
         flash(view, "Not on a line with a commit.")
         return
@@ -104,9 +111,8 @@ def extract_commit_hash_from_graph(self, done):
         flash(view, "Only single cursors are supported.")
         return
 
-    line_span = view.line(sel)
-    line_text = view.substr(line_span)
-    info = log_graph.describe_graph_line(line_text, remotes=[])
+    line = line_from_pt(view, sel.b)
+    info = log_graph.describe_graph_line(line.text, remotes=[])
     if info is None:
         flash(view, "Not on a line with a commit.")
         return
@@ -155,9 +161,8 @@ class gs_rebase_action(GsWindowCommand, GitCommand):
             flash(view, "Only single cursors are supported.")
             return
 
-        line_span = view.line(sel)
-        line_text = view.substr(line_span)
-        info = log_graph.describe_graph_line(line_text, remotes=[])
+        line = line_from_pt(view, sel.b)
+        info = log_graph.describe_graph_line(line.text, remotes=[])
         if info is None:
             flash(view, "Not on a line with a commit.")
             return

--- a/core/commands/log_graph_rebase_actions.py
+++ b/core/commands/log_graph_rebase_actions.py
@@ -20,7 +20,7 @@ from GitSavvy.core.view import replace_view_content
 
 __all__ = (
     "gs_rebase_action",
-    "gs_native_rebase_interactive",
+    "gs_rebase_interactive",
     "gs_rebase_interactive_onto_branch",
     "gs_rebase_on_branch",
     "gs_rebase_abort",
@@ -218,7 +218,7 @@ class gs_rebase_action(GsWindowCommand, GitCommand):
         view.run_command("gs_rebase_just_autosquash", {"commitish": commitish})
 
     def rebase_interactive(self, view, commitish):
-        view.run_command("gs_native_rebase_interactive", {"commitish": commitish})
+        view.run_command("gs_rebase_interactive", {"commitish": commitish})
 
     def rebase_onto(self, view, commitish):
         view.run_command("gs_rebase_interactive_onto_branch", {"commitish": commitish})
@@ -519,7 +519,7 @@ class gs_rebase_skip(sublime_plugin.WindowCommand, RebaseCommand):
         self.rebase('--skip')
 
 
-class gs_native_rebase_interactive(GsTextCommand, RebaseCommand):
+class gs_rebase_interactive(GsTextCommand, RebaseCommand):
     defaults = {
         "commitish": extract_symbol_from_graph,
     }

--- a/core/commands/log_graph_rebase_actions.py
+++ b/core/commands/log_graph_rebase_actions.py
@@ -146,6 +146,12 @@ class gs_rebase_action(GsWindowCommand, GitCommand):
                     )
                 ]
 
+        head_info = log_graph.describe_head(view, [])
+        good_head_name = (
+            "HEAD"
+            if not head_info or head_info["HEAD"] == head_info["commit"]
+            else head_info["HEAD"]
+        )
         actions += [
             (
                 "Re[W]ord commit message",
@@ -161,7 +167,7 @@ class gs_rebase_action(GsWindowCommand, GitCommand):
             ),
             SEPARATOR,
             (
-                "[R] Apply fixes and squashes {}^..HEAD".format(commitish),
+                "[R] Apply fixes and squashes {}^..{}".format(commitish, good_head_name),
                 partial(self.autosquash, view, commitish),
             ),
             (

--- a/core/commands/log_graph_rebase_actions.py
+++ b/core/commands/log_graph_rebase_actions.py
@@ -288,29 +288,6 @@ class RebaseCommand(GitCommand):
                 flash(window, ok_message)
             util.view.refresh_gitsavvy_interfaces(window)
 
-    def commit_is_ancestor_of_head(self, commit_hash):
-        # type: (str) -> bool
-        try:
-            self.git_throwing_silently(
-                "merge-base",
-                "--is-ancestor",
-                commit_hash,
-                "HEAD",
-            )
-        except GitSavvyError:
-            return False
-        else:
-            return True
-
-    def git_throwing_silently(self, *args, **kwargs):
-        return self.git(
-            *args,
-            throw_on_stderr=True,
-            show_status_message_on_stderr=False,
-            show_panel_on_stderr=False,
-            **kwargs
-        )
-
 
 def search_git_output(window, needle):
     # type: (sublime.Window, str) -> bool

--- a/core/commands/log_graph_rebase_actions.py
+++ b/core/commands/log_graph_rebase_actions.py
@@ -167,7 +167,7 @@ class gs_rebase_action(GsWindowCommand, GitCommand):
             ),
             SEPARATOR,
             (
-                "[R] Apply fixes and squashes {}^..{}".format(commitish, good_head_name),
+                "Apply fixes and squashes {}^..{}".format(commitish, good_head_name),
                 partial(self.autosquash, view, commitish),
             ),
             (

--- a/core/commands/log_graph_rebase_actions.py
+++ b/core/commands/log_graph_rebase_actions.py
@@ -144,11 +144,11 @@ class gs_rebase_action(GsWindowCommand, GitCommand):
             ),
             SEPARATOR,
             (
-                "Apply fixes and squashes {}^..HEAD".format(commitish),
+                "[R] Apply fixes and squashes {}^..HEAD".format(commitish),
                 partial(self.autosquash, view, commitish),
             ),
             (
-                "[R]ebase --interactive {}^".format(commitish),
+                "Rebase --interactive {}^".format(commitish),
                 partial(self.rebase_interactive, view, commitish)
             ),
             (

--- a/core/commands/log_graph_rebase_actions.py
+++ b/core/commands/log_graph_rebase_actions.py
@@ -1,0 +1,584 @@
+from collections import namedtuple
+from contextlib import contextmanager
+from functools import lru_cache, partial, wraps
+from itertools import takewhile
+import os
+import shlex
+
+import sublime
+import sublime_plugin
+
+from GitSavvy.common import util
+from GitSavvy.core.base_commands import GsTextCommand, GsWindowCommand
+from GitSavvy.core.commands import log_graph
+from GitSavvy.core.git_command import GitCommand, GitSavvyError
+from GitSavvy.core.runtime import run_on_new_thread, throttled
+from GitSavvy.core.ui_mixins.quick_panel import show_branch_panel
+from GitSavvy.core.view import replace_view_content
+
+
+__all__ = (
+    "gs_rebase_action",
+    "gs_native_rebase_interactive",
+    "gs_rebase_interactive_onto_branch",
+    "gs_rebase_on_branch",
+    "gs_rebase_abort",
+    "gs_rebase_continue",
+    "gs_rebase_skip",
+    "gs_rebase_just_autosquash",
+    "gs_rebase_edit_commit",
+    "gs_rebase_drop_commit",
+    "gs_rebase_reword_commit",
+    "gs_rebase_apply_fixup",
+    "AwaitTodoListView"
+)
+
+
+MYPY = False
+if MYPY:
+    from typing import (
+        Callable,
+        List,
+        Iterator,
+        NamedTuple,
+        Optional,
+        Tuple
+    )
+    from GitSavvy.core.base_commands import GsCommand, Kont
+
+    RebaseItem = NamedTuple("RebaseItem", [
+        ("action", str),
+        ("commit_hash", str),
+        ("commit_message", str)
+    ])
+    Commit = NamedTuple("Commit", [
+        ("commit_hash", str),
+        ("commit_message", str)
+    ])
+    QuickAction = Callable[[List[RebaseItem]], List[RebaseItem]]
+
+else:
+    RebaseItem = namedtuple("RebaseItem", "action commit_hash commit_message")
+    Commit = namedtuple("Commit", "commit_hash commit_message")
+
+
+def extract_symbol_from_graph(self, done):
+    # type: (GsCommand, Kont) -> None
+    view = get_view_for_command(self)
+    if not view:
+        return
+    symbol = log_graph.extract_symbol_to_follow(view)
+    if symbol:
+        done(symbol)
+    else:
+        flash(self.window, "Not on a line with a commit.")
+        return
+
+
+def ask_for_local_branch(self, done):
+    # type: (GsCommand, Kont) -> None
+    def on_done(branch):
+        if branch:
+            done(branch)
+
+    show_branch_panel(
+        on_done,
+        local_branches_only=True,
+        ignore_current_branch=True,
+    )
+
+
+def get_view_for_command(cmd):
+    # type: (sublime_plugin.Command) -> Optional[sublime.View]
+    if isinstance(cmd, sublime_plugin.TextCommand):
+        return cmd.view
+    elif isinstance(cmd, sublime_plugin.WindowCommand):
+        return cmd.window.active_view()
+    else:
+        return sublime.active_window().active_view()
+
+
+SEPARATOR = ("-" * 75, lambda: None)
+
+
+class gs_rebase_action(GsWindowCommand, GitCommand):
+    defaults = {
+        "commitish": extract_symbol_from_graph
+    }
+    selected_index = 0
+
+    def run(self, commitish):
+        # type: (str) -> None
+        view = self.window.active_view()
+        if not view:
+            return
+
+        actions = []  # type: List[Tuple[str, Callable[[], None]]]
+
+        base_commit = find_base_commit_for_fixup(view)
+        if base_commit:
+            fixup_commit = current_commit(view)
+            if fixup_commit:
+                actions += [
+                    (
+                        "Apply fix to '{}'".format(base_commit)
+                        if is_fixup(fixup_commit)
+                        else "Squash with '{}'".format(base_commit),
+                        partial(self.apply_fixup, view, base_commit, [fixup_commit])
+                    )
+                ]
+
+        actions += [
+            (
+                "Re[W]ord commit message",
+                partial(self.reword, view, commitish)
+            ),
+            (
+                "[E]dit commit",
+                partial(self.edit, view, commitish)
+            ),
+            (
+                "Drop commit",
+                partial(self.drop, view, commitish)
+            ),
+            SEPARATOR,
+            (
+                "Apply fixes and squashes {}^..HEAD".format(commitish),
+                partial(self.autosquash, view, commitish),
+            ),
+            (
+                "[R]ebase --interactive {}^".format(commitish),
+                partial(self.rebase_interactive, view, commitish)
+            ),
+            (
+                "Rebase {}^ --onto <branch>".format(commitish),
+                partial(self.rebase_onto, view, commitish)
+            ),
+            (
+                "Rebase on <branch>",
+                partial(self.rebase_on, view)
+            ),
+        ]
+
+        def on_action_selection(index):
+            if index == -1:
+                return
+
+            self.selected_index = index
+            description, action = actions[index]
+            action()
+
+        self.window.show_quick_panel(
+            [a[0] for a in actions],
+            on_action_selection,
+            flags=sublime.MONOSPACE_FONT,
+            selected_index=self.selected_index,
+        )
+
+    def apply_fixup(self, view, base_commit, fixup_commits):
+        view.run_command("gs_rebase_apply_fixup", {
+            "base_commit": base_commit,
+            "fixes": fixup_commits
+        })
+
+    def reword(self, view, commitish):
+        view.run_command("gs_rebase_reword_commit", {"commitish": commitish})
+
+    def edit(self, view, commitish):
+        view.run_command("gs_rebase_edit_commit", {"commitish": commitish})
+
+    def drop(self, view, commitish):
+        view.run_command("gs_rebase_drop_commit", {"commitish": commitish})
+
+    def autosquash(self, view, commitish):
+        view.run_command("gs_rebase_just_autosquash", {"commitish": commitish})
+
+    def rebase_interactive(self, view, commitish):
+        view.run_command("gs_native_rebase_interactive", {"commitish": commitish})
+
+    def rebase_onto(self, view, commitish):
+        view.run_command("gs_rebase_interactive_onto_branch", {"commitish": commitish})
+
+    def rebase_on(self, view):
+        view.run_command("gs_rebase_on_branch")
+
+
+# Note: Just as `extract_symbol_to_follow` we always use the
+# `b` of the last cursor.
+# Multi cursor support or proper error handling for selections TBD.
+
+def current_commit(view):
+    # type: (sublime.View) -> Optional[Commit]
+    try:
+        cursor = [s.b for s in view.sel()][-1]
+    except IndexError:
+        return None
+
+    line_span = view.line(cursor)
+    line_text = view.substr(line_span)
+    commit_hash = log_graph.extract_commit_hash(line_text)
+    if not commit_hash:
+        return None
+
+    commit_message = log_graph.commit_message_from_point(view, cursor)
+    if not commit_message:
+        return None
+    return Commit(commit_hash, commit_message)
+
+
+def find_base_commit_for_fixup(view):
+    # type: (sublime.View) -> Optional[str]
+    dot = list(log_graph._find_dots(view))[-1]
+    fixup_message = log_graph.message_from_fixup_squash_line(view.id(), dot)
+    if not fixup_message:
+        return None
+
+    target_dot = log_graph.find_matching_commit(view.id(), dot, fixup_message)
+    if not target_dot:
+        return None
+
+    target_line = view.substr(view.line(target_dot.pt))
+    target_commit_hash = log_graph.extract_commit_hash(target_line)
+    return target_commit_hash
+
+
+def is_fixup(commit):
+    # type: (Commit) -> bool
+    return commit.commit_message.startswith("fixup")
+
+
+def on_new_thread(fn):
+    @wraps(fn)
+    def wrapped(*a, **kw):
+        run_on_new_thread(fn, *a, **kw)
+    return wrapped
+
+
+def check_success(_func=None, *, cmd=None, ok_message="rebase finished"):
+    def wrapper(fn):
+        @wraps(fn)
+        def wrapped(*args, **kwargs):
+            self = cmd or args[0]
+            window = self.window
+            try:
+                fn(*args, **kwargs)
+            except GitSavvyError:
+                ...
+            else:
+                if not check_git_output(window, "rebase --continue"):
+                    auto_close_panel(window)
+            finally:
+                if self.in_rebase():
+                    flash(window, "rebase needs your attention")
+                else:
+                    flash(window, ok_message)
+                util.view.refresh_gitsavvy_interfaces(window)
+        return wrapped
+
+    if _func is None:
+        return wrapper
+    else:
+        return wrapper(_func)
+
+
+def check_git_output(window, needle):
+    # type: (sublime.Window, str) -> bool
+    view = window.find_output_panel("GitSavvy")
+    if not view:
+        return False
+
+    return needle in view.substr(sublime.Region(0, view.size()))
+
+
+def auto_close_panel(window, after=800):
+    # type: (sublime.Window, int) -> None
+    sublime.set_timeout(throttled(_close_panel, window), after)
+
+
+def _close_panel(window):
+    # type: (sublime.Window) -> None
+    window.run_command("hide_panel", {"panel": "output.GitSavvy"})
+
+
+class RebaseCommand(GitCommand):
+    def rebase(self, *args, show_panel=True, custom_environ=None, **kwargs):
+        editor = sublime_git_editor()
+        environ = {
+            "GIT_EDITOR": editor,
+            "GIT_SEQUENCE_EDITOR": editor
+        }
+        if custom_environ:
+            environ.update(custom_environ)
+
+        return self.git(
+            "rebase",
+            *args,
+            show_panel=show_panel,
+            custom_environ=environ,
+            **kwargs
+        )
+
+    def commit_is_ancestor_of_head(self, commit_hash):
+        # type: (str) -> bool
+        try:
+            self.git_throwing_silently(
+                "merge-base",
+                "--is-ancestor",
+                commit_hash,
+                "HEAD",
+            )
+        except GitSavvyError:
+            return False
+        else:
+            return True
+
+    def git_throwing_silently(self, *args, **kwargs):
+        return self.git(
+            *args,
+            throw_on_stderr=True,
+            show_status_message_on_stderr=False,
+            show_panel_on_stderr=False,
+            **kwargs
+        )
+
+
+@lru_cache(1)
+def sublime_git_editor():
+    normalized_executable = get_sublime_executable().replace("\\", "/")
+    return "{} -w".format(shlex.quote(normalized_executable))
+
+
+def get_sublime_executable() -> str:
+    executable_path = sublime.executable_path()
+    if sublime.platform() == "osx":
+        app_path = executable_path[: executable_path.rfind(".app/") + 5]
+        executable_path = app_path + "Contents/SharedSupport/bin/subl"
+
+    return executable_path
+
+
+AWAITING = None  # type: Optional[QuickAction]
+
+
+@contextmanager
+def await_todo_list(action):
+    # type: (QuickAction) -> Iterator[None]
+    global AWAITING
+    AWAITING = action
+    try:
+        yield
+    finally:
+        AWAITING = None
+
+
+class AwaitTodoListView(sublime_plugin.EventListener):
+    def on_activated(self, view):
+        # type: (sublime.View) -> None
+        global AWAITING
+        if AWAITING is None:
+            return
+        action = AWAITING
+
+        filename = view.file_name()
+        if not filename:
+            return
+        if os.path.basename(filename) == "git-rebase-todo":
+            AWAITING = None
+
+            todo_items = extract_rebase_items_from_view(view)
+            replace_view_content(view, format_rebase_items(action(todo_items)))
+            view.run_command("save")
+            view.close()
+
+
+def extract_rebase_items_from_view(view):
+    # type: (sublime.View) -> List[RebaseItem]
+    buffer_content = view.substr(sublime.Region(0, view.size()))
+    return [
+        RebaseItem(*line.split(" ", 2))
+        for line in takewhile(
+            lambda line: bool(line.strip()),
+            buffer_content.splitlines(keepends=True)
+        )
+    ]
+
+
+def ensure_newline(text):
+    # type: (str) -> str
+    return text if text.endswith("\n") else "{}\n".format(text)
+
+
+def format_rebase_items(items):
+    # type: (List[RebaseItem]) -> str
+    return "".join(
+        ensure_newline(" ".join(item)) for item in items
+    )
+
+
+class gs_rebase_quick_action(GsTextCommand, RebaseCommand):
+    action = None  # type: QuickAction
+    autosquash = False
+    defaults = {
+        "commitish": extract_symbol_from_graph,
+    }
+
+    def run(self, edit, commitish):
+        # type: (sublime.Edit, str) -> None
+        action = self.action  # type: ignore[misc]
+        if action is None:
+            raise NotImplementedError("action must be defined")
+
+        if not self.commit_is_ancestor_of_head(commitish):
+            flash(self.window, "Selected commit is not part of the current branch.")
+            return
+
+        @check_success(cmd=self)
+        def program():
+            with await_todo_list(action):  # type: ignore[arg-type]  # mypy bug
+                self.rebase(
+                    '--interactive',
+                    "--autostash",
+                    "--autosquash" if self.autosquash else "--no-autosquash",
+                    "{}^".format(commitish),
+                )
+
+        run_on_new_thread(program)
+
+
+def change_first_action(new_action, items):
+    # type: (str, List[RebaseItem]) -> List[RebaseItem]
+    return [items[0]._replace(action=new_action)] + items[1:]
+
+
+def fixup_commits(fixup_commits, items):
+    # type: (List[Commit], List[RebaseItem]) -> List[RebaseItem]
+    fixup_commit_hashes = {commit.commit_hash for commit in fixup_commits}
+    return [items[0]] + [
+        RebaseItem(
+            "fixup" if is_fixup(commit) else "squash",
+            *commit
+        )
+        for commit in reversed(fixup_commits)
+    ] + [
+        item for item in items[1:]
+        if item.commit_hash not in fixup_commit_hashes
+    ]
+
+
+class gs_rebase_edit_commit(gs_rebase_quick_action):
+    action = partial(change_first_action, "edit")
+    autosquash = False
+
+
+class gs_rebase_drop_commit(gs_rebase_quick_action):
+    action = partial(change_first_action, "drop")
+    autosquash = False
+
+
+class gs_rebase_reword_commit(gs_rebase_quick_action):
+    action = partial(change_first_action, "reword")
+    autosquash = False
+
+
+class gs_rebase_apply_fixup(gs_rebase_quick_action):
+    action = partial(fixup_commits)
+    autosquash = False
+
+    def run(self, edit, base_commit, fixes):
+        self.action = partial(self.action, [Commit(*fix) for fix in fixes])
+        super().run(edit, base_commit)
+
+
+class gs_rebase_just_autosquash(GsTextCommand, RebaseCommand):
+    defaults = {
+        "commitish": extract_symbol_from_graph,
+    }
+
+    def run(self, edit, commitish):
+        # type: (sublime.Edit, str) -> None
+        if not self.commit_is_ancestor_of_head(commitish):
+            flash(self.window, "Selected commit is not part of the current branch.")
+            return
+
+        @check_success(cmd=self)
+        def program():
+            self.rebase(
+                '--interactive',
+                "--autostash",
+                "--autosquash",
+                "{}^".format(commitish),
+                custom_environ={"GIT_SEQUENCE_EDITOR": ":"}
+            )
+
+        run_on_new_thread(program)
+
+
+class gs_rebase_abort(sublime_plugin.WindowCommand, RebaseCommand):
+    @on_new_thread
+    @check_success(ok_message="rebase aborted")
+    def run(self):
+        self.rebase('--abort', show_panel=False)
+
+
+class gs_rebase_continue(sublime_plugin.WindowCommand, RebaseCommand):
+    @on_new_thread
+    @check_success
+    def run(self):
+        self.rebase('--continue')
+
+
+class gs_rebase_skip(sublime_plugin.WindowCommand, RebaseCommand):
+    @on_new_thread
+    @check_success
+    def run(self):
+        self.rebase('--skip')
+
+
+class gs_native_rebase_interactive(GsTextCommand, RebaseCommand):
+    defaults = {
+        "commitish": extract_symbol_from_graph,
+    }
+
+    @on_new_thread
+    @check_success
+    def run(self, edit, commitish):
+        # type: (sublime.Edit, str) -> None
+        self.rebase(
+            '--interactive',
+            "{}^".format(commitish),
+        )
+
+
+class gs_rebase_interactive_onto_branch(GsTextCommand, RebaseCommand):
+    defaults = {
+        "commitish": extract_symbol_from_graph,
+        "onto": ask_for_local_branch
+    }
+
+    @on_new_thread
+    @check_success
+    def run(self, edit, commitish, onto):
+        # type: (sublime.Edit, str, str) -> None
+        self.rebase(
+            '--interactive',
+            "{}^".format(commitish),
+            "--onto",
+            onto,
+        )
+
+
+class gs_rebase_on_branch(GsTextCommand, RebaseCommand):
+    defaults = {
+        "on": ask_for_local_branch,
+    }
+
+    @on_new_thread
+    @check_success
+    def run(self, edit, on):
+        # type: (sublime.Edit, str) -> None
+        self.rebase(on)
+
+
+def flash(window, msg):
+    # type: (sublime.Window, str) -> None
+    window.status_message(msg)

--- a/core/commands/log_graph_rebase_actions.py
+++ b/core/commands/log_graph_rebase_actions.py
@@ -12,7 +12,7 @@ from GitSavvy.common import util
 from GitSavvy.core.base_commands import GsTextCommand, GsWindowCommand
 from GitSavvy.core.commands import log_graph
 from GitSavvy.core.git_command import GitCommand, GitSavvyError
-from GitSavvy.core.runtime import run_on_new_thread, throttled
+from GitSavvy.core.runtime import on_new_thread, run_on_new_thread, throttled
 from GitSavvy.core.ui_mixins.quick_panel import show_branch_panel
 from GitSavvy.core.view import replace_view_content
 
@@ -245,13 +245,6 @@ def find_base_commit_for_fixup(view):
 def is_fixup(commit):
     # type: (Commit) -> bool
     return commit.commit_message.startswith("fixup")
-
-
-def on_new_thread(fn):
-    @wraps(fn)
-    def wrapped(*a, **kw):
-        run_on_new_thread(fn, *a, **kw)
-    return wrapped
 
 
 def check_success(_func=None, *, cmd=None, ok_message="rebase finished"):

--- a/core/commands/log_graph_rebase_actions.py
+++ b/core/commands/log_graph_rebase_actions.py
@@ -68,8 +68,8 @@ def commitish_from_info(info):
     # type: (log_graph.LineInfo) -> str
     return next(
         chain(
+            reversed(info.get("branches", [])),
             info.get("tags", []),
-            reversed(info.get("branches", []))
         ),
         info["commit"]
     )

--- a/core/commands/log_graph_rebase_actions.py
+++ b/core/commands/log_graph_rebase_actions.py
@@ -14,6 +14,7 @@ from GitSavvy.core.commands import log_graph
 from GitSavvy.core.git_command import GitCommand, GitSavvyError
 from GitSavvy.core.runtime import on_new_thread, run_on_new_thread, throttled
 from GitSavvy.core.ui_mixins.quick_panel import show_branch_panel
+from GitSavvy.core.utils import flash
 from GitSavvy.core.view import replace_view_content
 
 
@@ -71,7 +72,7 @@ def extract_symbol_from_graph(self, done):
     if symbol:
         done(symbol)
     else:
-        flash(self.window, "Not on a line with a commit.")
+        flash(view, "Not on a line with a commit.")
         return
 
 
@@ -283,9 +284,9 @@ class RebaseCommand(GitCommand):
             return rv
         finally:
             if self.in_rebase():
-                flash(window, "rebase needs your attention")
+                window.status_message("rebase needs your attention")
             else:
-                flash(window, ok_message)
+                window.status_message(ok_message)
             util.view.refresh_gitsavvy_interfaces(window)
 
 
@@ -395,7 +396,7 @@ class gs_rebase_quick_action(GsTextCommand, RebaseCommand):
             raise NotImplementedError("action must be defined")
 
         if not self.commit_is_ancestor_of_head(commitish):
-            flash(self.window, "Selected commit is not part of the current branch.")
+            flash(self.view, "Selected commit is not part of the current branch.")
             return
 
         def program():
@@ -462,7 +463,7 @@ class gs_rebase_just_autosquash(GsTextCommand, RebaseCommand):
     def run(self, edit, commitish):
         # type: (sublime.Edit, str) -> None
         if not self.commit_is_ancestor_of_head(commitish):
-            flash(self.window, "Selected commit is not part of the current branch.")
+            flash(self.view, "Selected commit is not part of the current branch.")
             return
 
         def program():
@@ -535,8 +536,3 @@ class gs_rebase_on_branch(GsTextCommand, RebaseCommand):
     def run(self, edit, on):
         # type: (sublime.Edit, str) -> None
         self.rebase(on)
-
-
-def flash(window, msg):
-    # type: (sublime.Window, str) -> None
-    window.status_message(msg)

--- a/core/commands/log_graph_rebase_actions.py
+++ b/core/commands/log_graph_rebase_actions.py
@@ -480,7 +480,7 @@ class gs_rebase_just_autosquash(GsTextCommand, RebaseCommand):
 class gs_rebase_abort(sublime_plugin.WindowCommand, RebaseCommand):
     @on_new_thread
     def run(self):
-        self.rebase('--abort', show_panel=False, ok_message="rebase aborted")
+        self.rebase('--abort', ok_message="rebase aborted")
 
 
 class gs_rebase_continue(sublime_plugin.WindowCommand, RebaseCommand):

--- a/core/commands/log_graph_rebase_actions.py
+++ b/core/commands/log_graph_rebase_actions.py
@@ -171,7 +171,7 @@ class gs_rebase_action(GsWindowCommand, GitCommand):
                 partial(self.autosquash, view, commitish),
             ),
             (
-                "Rebase --interactive {}^".format(commitish),
+                "Rebase from {}^ on interactive".format(commitish),
                 partial(self.rebase_interactive, view, commitish)
             ),
             (

--- a/core/commands/log_graph_rebase_actions.py
+++ b/core/commands/log_graph_rebase_actions.py
@@ -287,7 +287,7 @@ class RebaseCommand(GitCommand):
                 window.status_message("rebase needs your attention")
             else:
                 window.status_message(ok_message)
-            util.view.refresh_gitsavvy_interfaces(window)
+            util.view.refresh_gitsavvy_interfaces(window, refresh_sidebar=True)
 
 
 def search_git_output(window, needle):

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -285,6 +285,15 @@ class GitCommand(StatusMixin,
 
         return stdout
 
+    def git_throwing_silently(self, *args, **kwargs):
+        return self.git(
+            *args,
+            throw_on_stderr=True,
+            show_status_message_on_stderr=False,
+            show_panel_on_stderr=False,
+            **kwargs
+        )
+
     def get_encoding_candidates(self):
         # type: () -> Sequence[str]
         return [

--- a/core/git_mixins/history.py
+++ b/core/git_mixins/history.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
 from .. import store
+from ..exceptions import GitSavvyError
 from ...common import util
 
 
@@ -149,6 +150,20 @@ class HistoryMixin():
     def commit_is_merge(self, commit_hash):
         sha = self.git("rev-list", "--merges", "-1", "{0}~1..{0}".format(commit_hash)).strip()
         return sha != ""
+
+    def commit_is_ancestor_of_head(self, commit_hash):
+        # type: (str) -> bool
+        try:
+            self.git_throwing_silently(
+                "merge-base",
+                "--is-ancestor",
+                commit_hash,
+                "HEAD",
+            )
+        except GitSavvyError:
+            return False
+        else:
+            return True
 
     def get_short_hash(self, commit_hash):
         # type: (str) -> str

--- a/core/interfaces/rebase.py
+++ b/core/interfaces/rebase.py
@@ -1007,42 +1007,6 @@ class GsRebaseOnTopOfCommand(GsRebaseDefineBaseRefCommand):
         util.view.refresh_gitsavvy(self.view, refresh_sidebar=True)
 
 
-class GsRebaseAbortCommand(TextCommand, GitCommand):
-
-    def run(self, edit):
-        sublime.set_timeout_async(self.run_async, 0)
-
-    def run_async(self):
-        try:
-            self.git("rebase", "--abort")
-        finally:
-            util.view.refresh_gitsavvy(self.view, refresh_sidebar=True)
-
-
-class GsRebaseContinueCommand(TextCommand, GitCommand):
-
-    def run(self, edit):
-        sublime.set_timeout_async(self.run_async)
-
-    def run_async(self):
-        try:
-            self.git("rebase", "--continue")
-        finally:
-            util.view.refresh_gitsavvy(self.view)
-
-
-class GsRebaseSkipCommand(TextCommand, GitCommand):
-
-    def run(self, edit):
-        sublime.set_timeout_async(self.run_async, 0)
-
-    def run_async(self):
-        try:
-            self.git("rebase", "--skip")
-        finally:
-            util.view.refresh_gitsavvy(self.view, refresh_sidebar=True)
-
-
 class GsRebaseTogglePreserveModeCommand(TextCommand, GitCommand):
 
     def run(self, edit):

--- a/core/runtime.py
+++ b/core/runtime.py
@@ -51,6 +51,13 @@ def run_on_new_thread(fn, *args, **kwargs):
     threading.Thread(target=fn, args=args, kwargs=kwargs).start()
 
 
+def on_new_thread(fn):
+    @wraps(fn)
+    def wrapped(*a, **kw):
+        run_on_new_thread(fn, *a, **kw)
+    return wrapped
+
+
 def run_or_timeout(fn, timeout):
     cond = threading.Condition()
     result = None

--- a/syntax/graph.sublime-syntax
+++ b/syntax/graph.sublime-syntax
@@ -106,9 +106,10 @@ contexts:
             1: punctuation.string.begin.git-savvy
             2: string.other.merge.branch-name.git-savvy
             3: punctuation.string.end.git-savvy
-        - match: (?:of|into)\s+(\S*)
+        - match: (?:of|into)\s*(\S*)
           captures:
             1: string.other.merge.remote.git-savvy
+          pop: true
         - match: (?=\S)
           pop: true
 
@@ -123,18 +124,19 @@ contexts:
       scope: punctuation.separator.key-value.git-savvy
 
 
-    - match: '(?=\s+(\|) ([^|]+), ([^|]+)$\n?)'
+    - match: '(?=\s*(\|) ([^|]+), ([^|]+)$\n?)'
       set: date-author-info
 
     - match: $
       pop: true
 
   date-author-info:
-    - match: '\s+(\|) ([^|]+), ([^|]+)$\n?'
+    - match: '\s*(\|) ([^|]+), ([^|]+)$\n?'
       scope: meta.git-savvy.grph.info
       captures:
         1: punctuation.separator.git-savvy
         2: storage.type.time.git-savvy
         3: entity.name.tag.author.git-savvy
+
     - match: $
       pop: true

--- a/syntax/test/syntax_test_graph.txt
+++ b/syntax/test/syntax_test_graph.txt
@@ -18,6 +18,36 @@
 * ede734e update diff syntax format
 # <- keyword.graph.commit
 #  ^ constant.numeric.graph.commit-hash
+
+| | ● 46652a2 Remove old "abort", "continue", and "skip" commands                | Fri 13:23, herr kaste
+# <- meta.graph.branch-art
+#^^^^^ meta.graph.branch-art
+#   ^ meta.graph.branch-art keyword.graph.commit
+#                                                                                ^ meta.git-savvy.grph.info punctuation.separator.git-savvy
+#                                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.git-savvy.grph.info
+#                                                                                  ^^^^^^^^^ meta.git-savvy.grph.info storage.type.time.git-savvy
+#                                                                                             ^^^^^^^^^^ entity.name.tag.author.git-savvy
+
+| | ● 49116e9 Fix some WS                                                        | Fri 13:22, herr kaste
+| | ● e697d93 Implement rebase commands for the graph view                       | Fri 13:03, herr kaste
+| ● |   ea2fe1c Merge branches 'graph-f-help' and 'iterate-commit-view' into m.. | Fri 17:06, herr kaste
+#                                                                               ^^^^^^^^^^^^^^^^^^^^^^^^ meta.git-savvy.grph.info
+#                                                                                ^ meta.git-savvy.grph.info punctuation.separator.git-savvy
+#                                                                                  ^^^^^^^^^ meta.git-savvy.grph.info storage.type.time.git-savvy
+#                                                                                             ^^^^^^^^^^ entity.name.tag.author.git-savvy
+
+| ● |   ea2fe1c Merge branches 'graph-f-help' and 'iterate-commit-view' into.. | Fri 17:06, herr kaste
+#                                                                             ^^^^^^^^^^^^^^^^^^^^^^^^ meta.git-savvy.grph.info
+| ● |   ea2fe1c Merge branches 'graph-f-help' and 'iterate-commit-view' in.. | Fri 17:06, herr kaste
+#                                                                           ^^^^^^^^^^^^^^^^^^^^^^^^ meta.git-savvy.grph.info
+| ● |   ea2fe1c Merge branches 'graph-f-help' and 'iterate-commit-vie.. | Fri 17:06, herr kaste
+#                                                                      ^^^^^^^^^^^^^^^^^^^^^^^^ meta.git-savvy.grph.info
+
+| |\ \
+# <- meta.graph.branch-art punctuation.other.git-savvy.graph.graph-line
+#^^^^^ meta.graph.branch-art punctuation.other.git-savvy.graph.graph-line
+
+| | ● | ffc45b7 (origin/iterate-commit-view) Adjust commit message help text     | Thu 21:54, herr kaste
 * c39b5de (divmain/master) Fix: plugin_host would crash when navigating past end of graph view
 * 1bca3e0 Fix: When amending, prepopulated commit message would include two extra spaces.
 * 76ceacf Fix: When amending with show_commit_diff enabled, unstaged changes were displayed.


### PR DESCRIPTION
This adds rebase functionality to the graph view. 

![image](https://user-images.githubusercontent.com/8558/95633391-dc6e2200-0a87-11eb-9a1b-318f07fb342f.png)

- `[r]` to open above rebase menu 
- `[W]` to reword/edit the commit message of the selected commit
- `[E]` to edit the selected commit
- `[R]` to start automatic autosquashing beginning with the selected commit  (t.i. apply all fixup and squash commits without further asking)

If the cursor is on a fixup or squash commit, the menu has an additional item "Apply fix" which just applies the selected fixup. 

What's not in:

- [ ] Create fixup commit for the selected commit (as suggested per #1355)
- [ ] `--rebase-merges` [1]
- [ ] Anything with selections or multiple cursors [2]

[1] `rebase-merges` requires git v2.18; the `preserve-merges` we used to emulate is deprecated.  Sublime does not ship a syntax for the new todo format, so it looks very ugly.  But it is very powerful, for example "Extract selected commits to a new branch" is possible.  
[2] Examples: "Squash selected commits", "Flip commits" (if 2 are selected)