### PR TITLE
GitHub remotes simplified

### DIFF
--- a/core/git_mixins/remotes.py
+++ b/core/git_mixins/remotes.py
@@ -10,7 +10,7 @@ class RemotesMixin():
         url/resource.
         """
         entries = self.git("remote", "-v").splitlines()
-        return OrderedDict(re.match("([0-9a-zA-Z_-]+)\t([^ ]+)", entry).groups() for entry in entries)
+        return OrderedDict(entry.split()[:2] for entry in entries)
 
     def fetch(self, remote=None, prune=True, branch=None, remote_branch=None):
         """

--- a/github/commands/open_on_remote.py
+++ b/github/commands/open_on_remote.py
@@ -35,10 +35,10 @@ class GsGithubOpenFileOnRemoteCommand(TextCommand, git_mixins.GithubRemotesMixin
         self.fpath = fpath or self.get_rel_path()
         self.preselect = preselect
 
-        self.remotes = self.get_remotes()
+        self.remotes = remotes = self.get_remotes()
 
         if not remote:
-            remote = self.guess_github_remote()
+            remote = self.guess_github_remote(remotes)
 
         if remote:
             self.open_file_on_remote(remote)
@@ -117,10 +117,10 @@ class GsGithubOpenRepoCommand(TextCommand, git_mixins.GithubRemotesMixin, GitCom
         sublime.set_timeout_async(lambda: self.run_async(remote))
 
     def run_async(self, remote):
-        self.remotes = self.get_remotes()
+        self.remotes = remotes = self.get_remotes()
 
         if not remote:
-            remote = self.guess_github_remote()
+            remote = self.guess_github_remote(remotes)
 
         if remote:
             open_repo(self.remotes[remote])

--- a/github/commands/open_on_remote.py
+++ b/github/commands/open_on_remote.py
@@ -15,7 +15,7 @@ EARLIER_COMMIT_PROMPT = ("The remote chosen may not contain the commit. "
                          "Open the file {} before?")
 
 
-class GsGithubOpenFileOnRemoteCommand(TextCommand, GitCommand, git_mixins.GithubRemotesMixin):
+class GsGithubOpenFileOnRemoteCommand(TextCommand, git_mixins.GithubRemotesMixin, GitCommand):
 
     """
     Open a new browser window to the web-version of the currently opened
@@ -107,7 +107,7 @@ class GsGithubOpenFileOnRemoteCommand(TextCommand, GitCommand, git_mixins.Github
             )
 
 
-class GsGithubOpenRepoCommand(TextCommand, GitCommand, git_mixins.GithubRemotesMixin):
+class GsGithubOpenRepoCommand(TextCommand, git_mixins.GithubRemotesMixin, GitCommand):
 
     """
     Open a new browser window to the GitHub remote repository.
@@ -133,7 +133,7 @@ class GsGithubOpenRepoCommand(TextCommand, GitCommand, git_mixins.GithubRemotesM
         open_repo(self.remotes[remote])
 
 
-class GsGithubOpenIssuesCommand(TextCommand, GitCommand, git_mixins.GithubRemotesMixin):
+class GsGithubOpenIssuesCommand(TextCommand, git_mixins.GithubRemotesMixin, GitCommand):
 
     """
     Open a new browser window to the GitHub remote repository's issues page.

--- a/github/commands/open_on_remote.py
+++ b/github/commands/open_on_remote.py
@@ -1,9 +1,7 @@
 import sublime
 from sublime_plugin import TextCommand
 
-from ..github import open_file_in_browser  # , open_repo, open_issues
-from ..github import open_repo
-from ..github import open_issues
+from ..github import open_file_in_browser, open_issues, open_repo
 
 from .. import git_mixins
 from ...core.git_command import GitCommand

--- a/github/commands/pull_request.py
+++ b/github/commands/pull_request.py
@@ -18,7 +18,7 @@ PUSH_PROMPT = ("You have not set an upstream for the active branch.  "
                "Would you like to push to a remote?")
 
 
-class GsGithubPullRequestCommand(WindowCommand, GitCommand, git_mixins.GithubRemotesMixin):
+class GsGithubPullRequestCommand(WindowCommand, git_mixins.GithubRemotesMixin, GitCommand):
 
     """
     Display open pull requests on the base repo.  When a pull request is selected,
@@ -162,7 +162,7 @@ class GsGithubPullRequestCommand(WindowCommand, GitCommand, git_mixins.GithubRem
         open_in_browser(self.pr["html_url"])
 
 
-class GsGithubCreatePullRequestCommand(WindowCommand, GitCommand, git_mixins.GithubRemotesMixin):
+class GsGithubCreatePullRequestCommand(WindowCommand, git_mixins.GithubRemotesMixin, GitCommand):
     """
     Create pull request of the current commit on the current repo.
     """

--- a/github/commands/pull_request.py
+++ b/github/commands/pull_request.py
@@ -202,13 +202,13 @@ class GsGithubCreatePullRequestCommand(WindowCommand, git_mixins.GithubRemotesMi
         remote_url = base_remote.url
         base_owner = base_remote.owner
         base_branch = self.get_integrated_branch_name()
-        url = "{}/compare/{}:{}...{}:{}?expand=1".format(
-            remote_url,
-            base_owner,
-            urllib.parse.quote_plus(base_branch),
-            owner,
-            urllib.parse.quote_plus(branch)
+        start = (
+            "{}:{}...".format(base_owner, urllib.parse.quote_plus(base_branch))
+            if base_branch
+            else ""
         )
+        end = "{}:{}".format(owner, urllib.parse.quote_plus(branch))
+        url = "{}/compare/{}{}?expand=1".format(remote_url, start, end)
         open_in_browser(url)
 
 

--- a/github/git_mixins/remotes.py
+++ b/github/git_mixins/remotes.py
@@ -28,6 +28,12 @@ class GithubRemotesMixin(base):
 
     def get_integrated_remote_name(self, remotes):
         # type: (Dict[name, url]) -> name
+        if len(remotes) == 0:
+            raise ValueError("GitHub integration will not function when no remotes defined.")
+
+        if len(remotes) == 1:
+            return list(remotes.keys())[0]
+
         configured_remote_name = self.git(
             "config",
             "--local",
@@ -35,14 +41,8 @@ class GithubRemotesMixin(base):
             "GitSavvy.ghRemote",
             throw_on_stderr=False
         ).strip()
-
-        if len(remotes) == 0:
-            raise ValueError("GitHub integration will not function when no remotes defined.")
-
         if configured_remote_name and configured_remote_name in remotes:
             return configured_remote_name
-        elif len(remotes) == 1:
-            return list(remotes.keys())[0]
         elif "origin" in remotes:
             return "origin"
         elif self.get_upstream_for_active_branch():

--- a/github/git_mixins/remotes.py
+++ b/github/git_mixins/remotes.py
@@ -43,13 +43,12 @@ class GithubRemotesMixin(base):
         ).strip()
         if configured_remote_name in remotes:
             return configured_remote_name
-        elif "origin" in remotes:
+        if "origin" in remotes:
             return "origin"
-        elif self.get_upstream_for_active_branch():
-            # fall back to the current active remote
-            return self.get_upstream_for_active_branch().split("/")[0]
-        else:
-            raise ValueError("Cannot determine GitHub integrated remote.")
+        current_upstream = self.get_upstream_for_active_branch()
+        if current_upstream:
+            return current_upstream.split("/")[0]
+        raise ValueError("Cannot determine GitHub integrated remote.")
 
     def get_integrated_remote_url(self):
         # type: () -> url

--- a/github/git_mixins/remotes.py
+++ b/github/git_mixins/remotes.py
@@ -21,10 +21,7 @@ class GithubRemotesMixin(base):
             "GitSavvy.ghBranch",
             throw_on_stderr=False
         ).strip()
-        if configured_branch_name:
-            return configured_branch_name
-        else:
-            return "master"
+        return configured_branch_name or "master"
 
     def get_integrated_remote_name(self, remotes):
         # type: (Dict[name, url]) -> name

--- a/github/git_mixins/remotes.py
+++ b/github/git_mixins/remotes.py
@@ -67,7 +67,7 @@ class GithubRemotesMixin(base):
         integrated_remote = self.get_integrated_remote_name(remotes)
         upstream = self.get_upstream_for_active_branch()
         if upstream:
-            tracked_remote = upstream.split("/")[0] if upstream else None
+            tracked_remote = upstream.split("/")[0]
 
             if tracked_remote and tracked_remote == integrated_remote:
                 return tracked_remote

--- a/github/git_mixins/remotes.py
+++ b/github/git_mixins/remotes.py
@@ -43,11 +43,15 @@ class GithubRemotesMixin(base):
         ).strip()
         if configured_remote_name in remotes:
             return configured_remote_name
-        if "origin" in remotes:
-            return "origin"
+
+        for name in ("upstream", "origin"):
+            if name in remotes:
+                return name
+
         current_upstream = self.get_upstream_for_active_branch()
         if current_upstream:
             return current_upstream.split("/")[0]
+
         raise ValueError("Cannot determine GitHub integrated remote.")
 
     def get_integrated_remote_url(self):

--- a/github/git_mixins/remotes.py
+++ b/github/git_mixins/remotes.py
@@ -13,15 +13,14 @@ else:
 
 class GithubRemotesMixin(base):
     def get_integrated_branch_name(self):
-        # type: () -> str
-        configured_branch_name = self.git(
+        # type: () -> Optional[str]
+        return self.git(
             "config",
             "--local",
             "--get",
             "GitSavvy.ghBranch",
             throw_on_stderr=False
-        ).strip()
-        return configured_branch_name or "master"
+        ).strip() or None
 
     def get_integrated_remote_name(self, remotes):
         # type: (Dict[name, url]) -> name

--- a/github/git_mixins/remotes.py
+++ b/github/git_mixins/remotes.py
@@ -59,13 +59,14 @@ class GithubRemotesMixin(base):
 
     def guess_github_remote(self):
         # type: () -> Optional[name]
-        upstream = self.get_upstream_for_active_branch()
         remotes = self.get_remotes()
-        integrated_remote = self.get_integrated_remote_name(remotes)
 
         if len(remotes) == 1:
             return list(remotes.keys())[0]
-        elif upstream:
+
+        integrated_remote = self.get_integrated_remote_name(remotes)
+        upstream = self.get_upstream_for_active_branch()
+        if upstream:
             tracked_remote = upstream.split("/")[0] if upstream else None
 
             if tracked_remote and tracked_remote == integrated_remote:

--- a/github/git_mixins/remotes.py
+++ b/github/git_mixins/remotes.py
@@ -1,6 +1,19 @@
-class GithubRemotesMixin():
 
+MYPY = False
+if MYPY:
+    from typing import Dict, Optional
+    from GitSavvy.core.git_command import GitCommand
+    name = str
+    url = str
+
+    base = GitCommand
+else:
+    base = object
+
+
+class GithubRemotesMixin(base):
     def get_integrated_branch_name(self):
+        # type: () -> str
         configured_branch_name = self.git(
             "config",
             "--local",
@@ -14,6 +27,7 @@ class GithubRemotesMixin():
             return "master"
 
     def get_integrated_remote_name(self, remotes=None):
+        # type: (Dict[name, url]) -> name
         if remotes is None:
             remotes = self.get_remotes()
         configured_remote_name = self.git(
@@ -40,11 +54,13 @@ class GithubRemotesMixin():
             raise ValueError("Cannot determine GitHub integrated remote.")
 
     def get_integrated_remote_url(self):
+        # type: () -> url
         configured_remote_name = self.get_integrated_remote_name()
         remotes = self.get_remotes()
         return remotes[configured_remote_name]
 
     def guess_github_remote(self):
+        # type: () -> Optional[name]
         upstream = self.get_upstream_for_active_branch()
         integrated_remote = self.get_integrated_remote_name()
         remotes = self.get_remotes()

--- a/github/git_mixins/remotes.py
+++ b/github/git_mixins/remotes.py
@@ -60,7 +60,6 @@ class GithubRemotesMixin(base):
     def guess_github_remote(self):
         # type: () -> Optional[name]
         remotes = self.get_remotes()
-
         if len(remotes) == 1:
             return list(remotes.keys())[0]
 
@@ -68,10 +67,7 @@ class GithubRemotesMixin(base):
         upstream = self.get_upstream_for_active_branch()
         if upstream:
             tracked_remote = upstream.split("/")[0]
-
-            if tracked_remote == integrated_remote:
-                return tracked_remote
-            else:
+            if tracked_remote != integrated_remote:
                 return None
-        else:
-            return integrated_remote
+
+        return integrated_remote

--- a/github/git_mixins/remotes.py
+++ b/github/git_mixins/remotes.py
@@ -41,7 +41,7 @@ class GithubRemotesMixin(base):
             "GitSavvy.ghRemote",
             throw_on_stderr=False
         ).strip()
-        if configured_remote_name and configured_remote_name in remotes:
+        if configured_remote_name in remotes:
             return configured_remote_name
         elif "origin" in remotes:
             return "origin"

--- a/github/git_mixins/remotes.py
+++ b/github/git_mixins/remotes.py
@@ -69,7 +69,7 @@ class GithubRemotesMixin(base):
         if upstream:
             tracked_remote = upstream.split("/")[0]
 
-            if tracked_remote and tracked_remote == integrated_remote:
+            if tracked_remote == integrated_remote:
                 return tracked_remote
             else:
                 return None

--- a/github/git_mixins/remotes.py
+++ b/github/git_mixins/remotes.py
@@ -63,7 +63,7 @@ class GithubRemotesMixin(base):
         remotes = self.get_remotes()
         integrated_remote = self.get_integrated_remote_name(remotes)
 
-        if len(self.remotes) == 1:
+        if len(remotes) == 1:
             return list(remotes.keys())[0]
         elif upstream:
             tracked_remote = upstream.split("/")[0] if upstream else None

--- a/github/git_mixins/remotes.py
+++ b/github/git_mixins/remotes.py
@@ -26,10 +26,8 @@ class GithubRemotesMixin(base):
         else:
             return "master"
 
-    def get_integrated_remote_name(self, remotes=None):
+    def get_integrated_remote_name(self, remotes):
         # type: (Dict[name, url]) -> name
-        if remotes is None:
-            remotes = self.get_remotes()
         configured_remote_name = self.git(
             "config",
             "--local",

--- a/github/git_mixins/remotes.py
+++ b/github/git_mixins/remotes.py
@@ -57,9 +57,8 @@ class GithubRemotesMixin(base):
         configured_remote_name = self.get_integrated_remote_name(remotes)
         return remotes[configured_remote_name]
 
-    def guess_github_remote(self):
-        # type: () -> Optional[name]
-        remotes = self.get_remotes()
+    def guess_github_remote(self, remotes):
+        # type: (Dict[name, url]) -> Optional[name]
         if len(remotes) == 1:
             return list(remotes.keys())[0]
 

--- a/github/git_mixins/remotes.py
+++ b/github/git_mixins/remotes.py
@@ -55,15 +55,15 @@ class GithubRemotesMixin(base):
 
     def get_integrated_remote_url(self):
         # type: () -> url
-        configured_remote_name = self.get_integrated_remote_name()
         remotes = self.get_remotes()
+        configured_remote_name = self.get_integrated_remote_name(remotes)
         return remotes[configured_remote_name]
 
     def guess_github_remote(self):
         # type: () -> Optional[name]
         upstream = self.get_upstream_for_active_branch()
-        integrated_remote = self.get_integrated_remote_name()
         remotes = self.get_remotes()
+        integrated_remote = self.get_integrated_remote_name(remotes)
 
         if len(self.remotes) == 1:
             return list(remotes.keys())[0]

--- a/github/github.py
+++ b/github/github.py
@@ -30,13 +30,13 @@ def remote_to_url(remote):
     Parse out a Github HTTP URL from a remote URI:
 
     r1 = remote_to_url("git://github.com/timbrel/GitSavvy.git")
-    assert r1 == "https://github.com/timbrel/GitSavvy.git"
+    assert r1 == "https://github.com/timbrel/GitSavvy"
 
     r2 = remote_to_url("git@github.com:divmain/GitSavvy.git")
-    assert r2 == "https://github.com/timbrel/GitSavvy.git"
+    assert r2 == "https://github.com/timbrel/GitSavvy"
 
     r3 = remote_to_url("https://github.com/timbrel/GitSavvy.git")
-    assert r3 == "https://github.com/timbrel/GitSavvy.git"
+    assert r3 == "https://github.com/timbrel/GitSavvy"
     """
 
     if remote.endswith(".git"):


### PR DESCRIPTION
While investigating #1384, cleanup and optimize code in `github.remotes.py`. As a refactoring, to be read commit for commit. 

Only notable change is to consider "upstream" (not only "origin") as a good automatic integration candidate.  (Actually the GitHub tooling puts the fork under "origin" and the original "source" repo under "upstream", see https://github.com/timbrel/GitSavvy/issues/1384#issuecomment-706601919, so this change provides better inter-op.)

The last commit implements option (2) from https://github.com/timbrel/GitSavvy/issues/1384#issuecomment-707134940

Fixes #1384 

I decided for (2) here (although there is really no clear winner) because

- It is generally simpler *and* faster
- ~Asking the internet (GitHub API) is way more flaky.  It is unclear what we should do if the call fails (usually because the internet is down at that moment).~ See below
- It makes the special case, creating a PR on the fork, special.  

For reference, if we wanted to implement (1) , to get the default branch, we *could* ask the GitHub API, for example

```
base_branch = (
	self.get_integrated_branch_name() 
	or github.get_repo_data(base_remote)["default_branch"]
)
```

This is flaky and slow. Or, we resolve 

```
git symbolic-ref --short -q refs/remotes/<remote>/HEAD
```
