### PR TITLE
Maybe offer `force-with-lease` if push fails

### DIFF
--- a/core/commands/push.py
+++ b/core/commands/push.py
@@ -97,7 +97,7 @@ class gs_push(PushBase):
         self.force = force
         self.force_with_lease = force_with_lease
         self.local_branch_name = local_branch_name
-        sublime.set_timeout_async(self.run_async)
+        enqueue_on_worker(self.run_async)
 
     def run_async(self):
         if not self.local_branch_name:
@@ -139,7 +139,7 @@ class gs_push_to_branch(PushBase):
     """
 
     def run(self):
-        sublime.set_timeout_async(self.run_async)
+        enqueue_on_worker(self.run_async)
 
     def run_async(self):
         show_branch_panel(self.on_branch_selection, ask_remote_first=True)
@@ -149,9 +149,12 @@ class gs_push_to_branch(PushBase):
             return
         current_local_branch = self.get_current_branch_name()
         selected_remote, selected_branch = branch.split("/", 1)
-        sublime.set_timeout_async(
-            lambda: self.do_push(
-                selected_remote, current_local_branch, remote_branch=selected_branch))
+        enqueue_on_worker(
+            self.do_push,
+            selected_remote,
+            current_local_branch,
+            remote_branch=selected_branch
+        )
 
 
 class gs_push_to_branch_name(PushBase):
@@ -175,7 +178,7 @@ class gs_push_to_branch_name(PushBase):
         self.set_upstream = set_upstream
         self.force = force
         self.force_with_lease = force_with_lease
-        sublime.set_timeout_async(self.run_async)
+        enqueue_on_worker(self.run_async)
 
     def run_async(self):
         show_remote_panel(self.on_remote_selection)
@@ -204,9 +207,11 @@ class gs_push_to_branch_name(PushBase):
         Push to the remote that was previously selected and provided branch
         name.
         """
-        sublime.set_timeout_async(lambda: self.do_push(
+        enqueue_on_worker(
+            self.do_push,
             self.selected_remote,
             self.local_branch_name,
             force=self.force,
             force_with_lease=self.force_with_lease,
-            remote_branch=branch))
+            remote_branch=branch
+        )

--- a/core/commands/push.py
+++ b/core/commands/push.py
@@ -35,7 +35,7 @@ class PushBase(WindowCommand, GitCommand):
                 if not sublime.ok_cancel_dialog(CONFIRM_FORCE_PUSH.format("--force")):
                     return
             elif force_with_lease:
-                if not sublime.ok_cancel_dialog(CONFIRM_FORCE_PUSH.format("--force--with-lease")):
+                if not sublime.ok_cancel_dialog(CONFIRM_FORCE_PUSH.format("--force-with-lease")):
                     return
 
         self.window.status_message("Pushing '{}' to '{}'...".format(branch, remote))

--- a/core/git_mixins/remotes.py
+++ b/core/git_mixins/remotes.py
@@ -61,7 +61,9 @@ class RemotesMixin():
             force=False,
             force_with_lease=False,
             remote_branch=None,
-            set_upstream=False):
+            set_upstream=False,
+            **kwargs
+    ):
         """
         Push to the specified remote and branch if provided, otherwise
         perform default `git push`.
@@ -74,7 +76,8 @@ class RemotesMixin():
             "--force-with-lease" if force_with_lease else None,
             "--set-upstream" if set_upstream else None,
             remote,
-            branch if not remote_branch else "{}:{}".format(branch, remote_branch)
+            branch if not remote_branch else "{}:{}".format(branch, remote_branch),
+            **kwargs
         )
 
     def project_name_from_url(self, input_url):


### PR DESCRIPTION
Fixes #1130 

This generally follows the "Delete Tag" philosophy.  For "Delete Tag" in the graph view, we automatically offer a forced deletion if the branch is not fully merged.  But the default action we select in the quick panel is "Nah, ok". 

We do this here for "pushing" as well.  If the push fails, we show a quick panel to either "abort" or "proceed", the second item offers a retry with `--force-with-lease` set.

Of course, ideally we wouldn't try a push (because it's very slow) *if* we could know that we're behind the upstream.  But we don't since the app state is still not shared.  