### PR TITLE
Fix: Close rebase panel automatically if the rebase finished

### DIFF
--- a/core/commands/log_graph_rebase_actions.py
+++ b/core/commands/log_graph_rebase_actions.py
@@ -362,7 +362,7 @@ class RebaseCommand(GitCommand):
         except GitSavvyError:
             ...
         else:
-            if show_panel and not search_git_output(window, "rebase --continue"):
+            if show_panel and not self.in_rebase():
                 auto_close_panel(window)
             return rv
         finally:
@@ -371,15 +371,6 @@ class RebaseCommand(GitCommand):
             else:
                 window.status_message(ok_message)
             util.view.refresh_gitsavvy_interfaces(window, refresh_sidebar=True)
-
-
-def search_git_output(window, needle):
-    # type: (sublime.Window, str) -> bool
-    view = window.find_output_panel("GitSavvy")
-    if not view:
-        return False
-
-    return needle in view.substr(sublime.Region(0, view.size()))
 
 
 def auto_close_panel(window, after=800):


### PR DESCRIPTION
Fixes #1391

We closed the panel automatically if it didn't contain the text
"rebase --continue" which works okay unless the command itself is
"rebase --continue".  (The idea was rather to check the output help
text from git.)

We switch to check for `not in_rebase()` which seems a natural fit.