### PR TITLE
Add `[R]` binding to start an interactive rebase

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1550,6 +1550,14 @@
         ]
     },
     {
+        "keys": ["R"],
+        "command": "gs_rebase_interactive",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.log_graph_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
         "keys": ["W"],
         "command": "gs_rebase_reword_commit",
         "context": [

--- a/core/commands/log_graph_rebase_actions.py
+++ b/core/commands/log_graph_rebase_actions.py
@@ -224,7 +224,7 @@ class gs_rebase_action(GsWindowCommand, GitCommand):
 
         actions += [
             (
-                "Rebase from {} on interactive".format(parent_commitish),
+                "[R]ebase from {} on interactive".format(parent_commitish),
                 partial(self.rebase_interactive, view, parent_commitish)
             ),
             (

--- a/popups/log_graph_view.html
+++ b/popups/log_graph_view.html
@@ -23,6 +23,7 @@
   <div><code><span class="shortcut-key">r&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>open rebase menu</code></div>
   <div><code><span class="shortcut-key">W&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>reWord commit message</code></div>
   <div><code><span class="shortcut-key">E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>Edit commit</code></div>
+  <div><code><span class="shortcut-key">R&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>Rebase --interactive from here</code></div>
 </div>
 
 <h3>Navigation</h3>


### PR DESCRIPTION
`[R]` was always bound to start an interactive rebase session in the pre-release phase. 
This was not a stupid idea and we switch it on again.  