### PR TITLE
Fine tune fixup helpers

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -558,7 +558,8 @@
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.commit_view", "operator": "equal", "operand": true },
-            { "key": "preceding_text", "operator": "regex_match", "operand": "fix(|up(! ?)?)$" },
+            { "key": "preceding_text", "operator": "regex_match", "operand": "fix(|up(! ?)?).*" },
+            { "key": "following_text", "operator": "regex_match", "operand": "^$" },
             { "key": "selection_empty" },
             { "key": "num_selections", "operator": "equal", "operand": 1 },
             { "key": "selector", "operator": "equal", "operand": "meta.commit.message.subject" }
@@ -571,7 +572,8 @@
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.commit_view", "operator": "equal", "operand": true },
-            { "key": "preceding_text", "operator": "regex_match", "operand": "sq(|uash(! ?)?)$" },
+            { "key": "preceding_text", "operator": "regex_match", "operand": "sq(|uash(! ?)?).*" },
+            { "key": "following_text", "operator": "regex_match", "operand": "^$" },
             { "key": "selection_empty" },
             { "key": "num_selections", "operator": "equal", "operand": 1 },
             { "key": "selector", "operator": "equal", "operand": "meta.commit.message.subject" }


### PR DESCRIPTION
1. Allow the helpers at EOL position if the line is a fixup or squash
line.

This is actually the position the user lands on after using the helper,
and we want to allow selecting a different commit easily.

2. Only trigger the helper if there no text follows.

Here, for example the user first wanted to do a "fixup" but then decides
to edit the first word from "fixup" to "squash".  The user therefore
goes to BOL, deletes the right word, and types "sq<tab>" to autocomplete
to "squash".  This just works now because "squash" is via the help text
always in the buffer.

3. Preselect a possible given commit in the subject line.

