### PR TITLE
Fix `vintageous_enter_insert_mode` for NeoVintageous 1.22.0

### DIFF
--- a/common/commands/view_manipulation.py
+++ b/common/commands/view_manipulation.py
@@ -20,7 +20,10 @@ class gs_handle_vintageous(TextCommand, GitCommand):
             self.view.settings().set("git_savvy.vintageous_friendly", True)
             if self.savvy_settings.get("vintageous_enter_insert_mode"):
                 self.view.settings().set("vintageous_reset_mode_when_switching_tabs", False)
+                # NeoVintageous renamed the command starting with v1.22.0.
+                # We call both commands for backwards compatibility.
                 self.view.run_command("_enter_insert_mode")
+                self.view.run_command("nv_enter_insert_mode")  # since NeoVintageous 1.22.0
 
 
 class gs_handle_arrow_keys(TextCommand, GitCommand):


### PR DESCRIPTION
Fixes #1395

In NeoVintageous/NeoVintageous#749, pushed as 1.22.0 (Oct 2020), the
relevant commands were renamed.

We follow the new names, but for now also call the old ones.