### PR TITLE
Fix: List `intent-to-add`ed files as unstaged

### DIFF
--- a/core/git_mixins/status.py
+++ b/core/git_mixins/status.py
@@ -113,7 +113,7 @@ class StatusMixin():
             if f.index_status == "?":
                 untracked.append(f)
                 continue
-            elif f.working_status in ("M", "D", "T"):
+            elif f.working_status in ("M", "D", "T", "A"):
                 unstaged.append(f)
             if f.index_status != " ":
                 staged.append(f)


### PR DESCRIPTION
The current behavior is to *not* list `i-t-a` files at all.  Basically
they disappear after adding.

We move the `i-t-a` files to the unstaged section, following git cli
behavior here.  This indicates that diffing the file will work.