### PR TITLE
Fix: Graph menu should open if cursor is on a detached HEAD

### DIFF
--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -2067,7 +2067,7 @@ class gs_log_graph_action(WindowCommand, GitCommand):
         commit_hash = info["commit"]
         file_path = self.file_path
         actions = []  # type: List[Tuple[str, Callable[[], None]]]
-        on_checked_out_branch = "HEAD" in info and info["HEAD"] in info["local_branches"]
+        on_checked_out_branch = "HEAD" in info and info["HEAD"] in info.get("local_branches", [])
         if on_checked_out_branch:
             actions += [
                 ("Pull", self.pull),


### PR DESCRIPTION
Since 0bcabc7e (Add "fetch"/"push"/"pull" to the graph menu) published
with 2.26.0 (Sep 2020) a user cannot open the actions menu if on a sole
detached HEAD commit.

Generally, the idea of having a sparse dict to represent the line or
commit info makes the handling here brittle and hard to read.  We can
handle that later, for now `info["local_branches"]` can fail and must
be made safe using `.get()`.