### PR TITLE
Fix: Compare longest with shortest commit message

### DIFF
--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -1772,8 +1772,10 @@ def find_matching_commit(vid, dot, message):
     view = sublime.View(vid)
     for dot in islice(follow_dots(dot), 0, 50):
         this_message = commit_message_from_point(view, dot.pt)
-        if this_message and this_message.startswith(message):
-            return dot
+        if this_message:
+            shorter, longer = sorted((message, this_message.rstrip(".")), key=len)
+            if longer.startswith(shorter):
+                return dot
     else:
         return None
 


### PR DESCRIPTION
We currently work visually here, t.i. on the actual drawn graph, and
have to expect shortened commit messages.  We always worked with a
cleaned original message (see: `message_from_fixup_squash_line`) but
have to do the same (`.rstrip(".")`) when comparing with other messages.

The code also assumed the original message is the truncated one.
This is often but not necessary always true. We therefore sort by length
before comparing with `startswith`.