### PR TITLE
Iterate "Github: Create Pull Request" and "git: push"

### DIFF
--- a/core/commands/flow.py
+++ b/core/commands/flow.py
@@ -66,14 +66,6 @@ class FlowCommon(WindowCommand, GitCommand):
             selected = selected[2:]
         return selected
 
-    def get_local_branches(self):
-        """
-        Use get_branches  (from BranchesMixin) while filtering
-        out remote branches and returning a list of names
-        """
-        branches = self.get_branches()
-        return [b.name for b in branches if not b.remote]
-
 
 class GsGitFlowInitCommand(FlowCommon):
     """
@@ -108,7 +100,7 @@ class GsGitFlowInitCommand(FlowCommon):
             return
         self.configure_gitflow('origin', value)
 
-        self.branches = self.get_local_branches()
+        self.branches = [b.name for b in self.get_local_branches()]
 
         self._generic_select('Branch for production releases (master)',
                              self.branches, self.on_master_selected)
@@ -128,7 +120,7 @@ class GsGitFlowInitCommand(FlowCommon):
     def create_develop_branch(self, index):
         if index == 1:
             self.git('branch', 'develop')
-            self.branches = self.get_local_branches()
+            self.branches = [b.name for b in self.get_local_branches()]
             self.on_develop_selected(1)
 
     def on_develop_selected(self, index):
@@ -211,9 +203,11 @@ class GenericSelectTargetBranch(object):
             if self.curbranch.startswith(self.prefix):
                 self.cur_name = name = self.curbranch.replace(self.prefix, '')
             else:
-                self.branches = [b.replace(self.prefix, '')
-                                 for b in self.get_local_branches()
-                                 if b.startswith(self.prefix)]
+                self.branches = [
+                    b.name.replace(self.prefix, '')
+                    for b in self.get_local_branches()
+                    if b.name.startswith(self.prefix)
+                ]
                 self._generic_select(
                     self.name_prompt,
                     self.branches,

--- a/core/commands/push.py
+++ b/core/commands/push.py
@@ -36,7 +36,7 @@ class PushBase(WindowCommand, GitCommand):
                 if not sublime.ok_cancel_dialog(CONFIRM_FORCE_PUSH.format("--force")):
                     return
             elif force_with_lease:
-                if not sublime.ok_cancel_dialog(CONFIRM_FORCE_PUSH.format("--force--with-lease")):
+                if not sublime.ok_cancel_dialog(CONFIRM_FORCE_PUSH.format("--force-with-lease")):
                     return
 
         self.window.status_message(START_PUSH_MESSAGE)

--- a/core/commands/push.py
+++ b/core/commands/push.py
@@ -95,12 +95,12 @@ class gs_push(PushBase):
                     "force_with_lease": force_with_lease
                 })
         else:
-            # if `prompt_for_tracking_branch` is false, ask for a remote and perform
+            # If `prompt_for_tracking_branch` is false, ask for a remote and
             # push current branch to a remote branch with the same name
             self.window.run_command("gs_push_to_branch_name", {
                 "local_branch_name": local_branch.name,
                 "branch_name": local_branch.name,
-                "set_upstream": False,
+                "set_upstream": True,
                 "force": force,
                 "force_with_lease": force_with_lease
             })

--- a/core/commands/push.py
+++ b/core/commands/push.py
@@ -61,11 +61,12 @@ class gs_push(PushBase):
         self.force = force
         self.force_with_lease = force_with_lease
         self.local_branch_name = local_branch_name
-        enqueue_on_worker(self.run_async)
+        enqueue_on_worker(self.run_async, local_branch_name, force, force_with_lease)
 
-    def run_async(self):
-        if self.local_branch_name:
-            local_branch = self.get_local_branch(self.local_branch_name)
+    def run_async(self, local_branch_name, force, force_with_lease):
+        # type: (str, bool, bool) -> None
+        if local_branch_name:
+            local_branch = self.get_local_branch(local_branch_name)
             if not local_branch:
                 sublime.message_dialog("'{}' is not a local branch name.")
                 return
@@ -82,16 +83,16 @@ class gs_push(PushBase):
                 remote,
                 local_branch.name,
                 remote_branch=remote_branch,
-                force=self.force,
-                force_with_lease=self.force_with_lease
+                force=force,
+                force_with_lease=force_with_lease
             )
         elif self.savvy_settings.get("prompt_for_tracking_branch"):
             if sublime.ok_cancel_dialog(SET_UPSTREAM_PROMPT):
                 self.window.run_command("gs_push_to_branch_name", {
                     "local_branch_name": local_branch.name,
                     "set_upstream": True,
-                    "force": self.force,
-                    "force_with_lease": self.force_with_lease
+                    "force": force,
+                    "force_with_lease": force_with_lease
                 })
         else:
             # if `prompt_for_tracking_branch` is false, ask for a remote and perform
@@ -100,8 +101,8 @@ class gs_push(PushBase):
                 "local_branch_name": local_branch.name,
                 "branch_name": local_branch.name,
                 "set_upstream": False,
-                "force": self.force,
-                "force_with_lease": self.force_with_lease
+                "force": force,
+                "force_with_lease": force_with_lease
             })
 
 

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -18,19 +18,6 @@ import traceback
 import sublime
 
 from ..common import util
-from .git_mixins.status import StatusMixin
-from .git_mixins.active_branch import ActiveBranchMixin
-from .git_mixins.branches import BranchesMixin
-from .git_mixins.stash import StashMixin
-from .git_mixins.stage_unstage import StageUnstageMixin
-from .git_mixins.checkout_discard import CheckoutDiscardMixin
-from .git_mixins.remotes import RemotesMixin
-from .git_mixins.ignore import IgnoreMixin
-from .git_mixins.tags import TagsMixin
-from .git_mixins.history import HistoryMixin
-from .git_mixins.rewrite import RewriteMixin
-from .git_mixins.merge import MergeMixin
-from .exceptions import GitSavvyError
 from .settings import SettingsMixin
 
 
@@ -105,20 +92,7 @@ class LoggingProcessWrapper(object):
         return self.stdout, self.stderr
 
 
-class GitCommand(StatusMixin,
-                 ActiveBranchMixin,
-                 BranchesMixin,
-                 StashMixin,
-                 StageUnstageMixin,
-                 CheckoutDiscardMixin,
-                 RemotesMixin,
-                 IgnoreMixin,
-                 TagsMixin,
-                 HistoryMixin,
-                 RewriteMixin,
-                 MergeMixin,
-                 SettingsMixin
-                 ):
+class _GitCommand(SettingsMixin):
 
     """
     Base class for all Sublime commands that interact with git.
@@ -544,3 +518,42 @@ class GitCommand(StatusMixin,
         class attribute dict.
         """
         self._last_remotes_used[self.repo_path] = value
+
+
+if MYPY:
+    mixin_base = _GitCommand
+else:
+    mixin_base = object
+
+
+from .git_mixins.status import StatusMixin  # noqa: E402
+from .git_mixins.active_branch import ActiveBranchMixin  # noqa: E402
+from .git_mixins.branches import BranchesMixin  # noqa: E402
+from .git_mixins.stash import StashMixin  # noqa: E402
+from .git_mixins.stage_unstage import StageUnstageMixin  # noqa: E402
+from .git_mixins.checkout_discard import CheckoutDiscardMixin  # noqa: E402
+from .git_mixins.remotes import RemotesMixin  # noqa: E402
+from .git_mixins.ignore import IgnoreMixin  # noqa: E402
+from .git_mixins.tags import TagsMixin  # noqa: E402
+from .git_mixins.history import HistoryMixin  # noqa: E402
+from .git_mixins.rewrite import RewriteMixin  # noqa: E402
+from .git_mixins.merge import MergeMixin  # noqa: E402
+from .exceptions import GitSavvyError  # noqa: E402
+
+
+class GitCommand(
+    StatusMixin,
+    ActiveBranchMixin,
+    BranchesMixin,
+    StashMixin,
+    StageUnstageMixin,
+    CheckoutDiscardMixin,
+    RemotesMixin,
+    IgnoreMixin,
+    TagsMixin,
+    HistoryMixin,
+    RewriteMixin,
+    MergeMixin,
+    _GitCommand
+):
+    pass

--- a/core/git_mixins/active_branch.py
+++ b/core/git_mixins/active_branch.py
@@ -179,13 +179,3 @@ class ActiveBranchMixin():
             "branch.{}.remote".format(branch_name),
             throw_on_stderr=False
         ).strip() or None
-
-    def get_active_remote_branch(self):
-        """
-        Return named tuple of the upstream for active branch.
-        """
-        upstream = self.get_upstream_for_active_branch()
-        for branch in self.get_branches():
-            if branch.name_with_remote == upstream:
-                return branch
-        return None

--- a/core/git_mixins/branches.py
+++ b/core/git_mixins/branches.py
@@ -1,6 +1,8 @@
 from collections import namedtuple
 import re
 
+from GitSavvy.core.git_command import mixin_base
+
 
 MYPY = False
 if MYPY:
@@ -21,7 +23,7 @@ Branch = namedtuple("Branch", (
 ))
 
 
-class BranchesMixin():
+class BranchesMixin(mixin_base):
 
     def get_branches(self, sort_by_recent=False, fetch_descriptions=False):
         # type: (bool, bool) -> Iterable[Branch]

--- a/core/git_mixins/branches.py
+++ b/core/git_mixins/branches.py
@@ -25,6 +25,13 @@ Branch = namedtuple("Branch", (
 
 class BranchesMixin(mixin_base):
 
+    def get_current_branch(self):
+        # type: () -> Optional[Branch]
+        for branch in self.get_branches():
+            if branch.active:
+                return branch
+        return None
+
     def get_branches(self, sort_by_recent=False, fetch_descriptions=False):
         # type: (bool, bool) -> Iterable[Branch]
         """

--- a/core/git_mixins/branches.py
+++ b/core/git_mixins/branches.py
@@ -47,7 +47,7 @@ class BranchesMixin(mixin_base):
         return self.get_branches(refs=["refs/heads"])
 
     def get_branches(
-        self,
+        self, *,
         sort_by_recent=False,
         fetch_descriptions=False,
         refs=["refs/heads", "refs/remotes"]

--- a/core/git_mixins/branches.py
+++ b/core/git_mixins/branches.py
@@ -32,6 +32,16 @@ class BranchesMixin(mixin_base):
                 return branch
         return None
 
+    def get_local_branch(self, branch_name):
+        # type: (str) -> Optional[Branch]
+        """
+        Get a local Branch tuple from branch name.
+        """
+        for branch in self.get_branches():
+            if not branch.remote and branch.name == branch_name:
+                return branch
+        return None
+
     def get_branches(self, sort_by_recent=False, fetch_descriptions=False):
         # type: (bool, bool) -> Iterable[Branch]
         """
@@ -112,14 +122,6 @@ class BranchesMixin(mixin_base):
         """
 
         self.git("merge", *branch_names)
-
-    def get_local_branch(self, branch_name):
-        """
-        Get a local Branch tuple from branch name.
-        """
-        for branch in self.get_branches():
-            if not branch.remote and branch.name == branch_name:
-                return branch
 
     def branches_containing_commit(self, commit_hash, local_only=True, remote_only=False):
         """

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -81,7 +81,10 @@ class BranchInterface(ui.Interface, GitCommand):
 
     def pre_render(self):
         sort_by_recent = self.savvy_settings.get("sort_by_recent_in_branch_dashboard")
-        self._branches = tuple(self.get_branches(sort_by_recent, fetch_descriptions=True))
+        self._branches = tuple(self.get_branches(
+            sort_by_recent=sort_by_recent,
+            fetch_descriptions=True
+        ))
 
     def on_new_dashboard(self):
         self.view.run_command("gs_branches_set_cursor")

--- a/github/commands/pull_request.py
+++ b/github/commands/pull_request.py
@@ -14,6 +14,11 @@ from ...core.ui_mixins.input_panel import show_single_line_input_panel
 from ...core.view import replace_view_content
 
 
+MYPY = False
+if MYPY:
+    from GitSavvy.core.git_mixins.branches import Branch
+
+
 PUSH_PROMPT = ("You have not set an upstream for the active branch.  "
                "Would you like to push to a remote?")
 
@@ -194,20 +199,19 @@ class GsGithubCreatePullRequestCommand(WindowCommand, git_mixins.GithubRemotesMi
             )
 
         else:
-            remote, remote_branch = current_branch.tracking.split("/", 1)
-            self.open_comparision_in_browser(
-                remote,
-                remote_branch,
-            )
+            self.open_comparision_in_browser(current_branch)
 
-    def open_comparision_in_browser(self, remote, remote_branch):
-        # type: (str, str) -> None
+    def open_comparision_in_browser(self, current_branch):
+        # type: (Branch) -> None
         remotes = self.get_remotes()
+        remote, remote_branch = current_branch.tracking.split("/", 1)
 
         remote_url = remotes[remote]
         owner = github.parse_remote(remote_url).owner
 
-        base_remote_name = self.get_integrated_remote_name(remotes)
+        base_remote_name = self.get_integrated_remote_name(
+            remotes, current_upstream=current_branch.tracking
+        )
         base_remote_url = remotes[base_remote_name]
         base_remote = github.parse_remote(base_remote_url)
         base_branch = self.get_integrated_branch_name()

--- a/github/commands/pull_request.py
+++ b/github/commands/pull_request.py
@@ -178,9 +178,10 @@ class GsGithubCreatePullRequestCommand(WindowCommand, git_mixins.GithubRemotesMi
 
         if not current_branch.tracking:
             if sublime.ok_cancel_dialog(PUSH_PROMPT):
-                self.window.run_command(
-                    "gs_github_push_and_create_pull_request",
-                    {"set_upstream": True})
+                self.window.run_command("gs_github_push_and_create_pull_request", {
+                    "local_branch_name": current_branch.name,
+                    "set_upstream": True
+                })
 
         else:
             remote, remote_branch = current_branch.tracking.split("/", 1)

--- a/github/commands/pull_request.py
+++ b/github/commands/pull_request.py
@@ -183,19 +183,18 @@ class GsGithubCreatePullRequestCommand(WindowCommand, git_mixins.GithubRemotesMi
                     "set_upstream": True
                 })
 
+        elif (
+            "ahead" in current_branch.tracking_status
+            or "behind" in current_branch.tracking_status
+        ):
+            sublime.message_dialog(
+                "Your current branch is different from '{}'.\n{}".format(
+                    current_branch.tracking, current_branch.tracking_status
+                )
+            )
+
         else:
             remote, remote_branch = current_branch.tracking.split("/", 1)
-            if (
-                "ahead" in current_branch.tracking_status
-                or "behind" in current_branch.tracking_status
-            ):
-                sublime.message_dialog(
-                    "Your current branch is different from '{}'.\n{}".format(
-                        current_branch.tracking, current_branch.tracking_status
-                    )
-                )
-                return
-
             remote_url = self.get_remotes()[remote]
             owner = github.parse_remote(remote_url).owner
             self.open_comparision_in_browser(

--- a/github/commands/pull_request.py
+++ b/github/commands/pull_request.py
@@ -209,12 +209,15 @@ class GsGithubCreatePullRequestCommand(WindowCommand, git_mixins.GithubRemotesMi
         remote_url = remotes[remote]
         owner = github.parse_remote(remote_url).owner
 
+        config = self.read_gitsavvy_config()
         base_remote_name = self.get_integrated_remote_name(
-            remotes, current_upstream=current_branch.tracking
+            remotes,
+            current_upstream=current_branch.tracking,
+            configured_remote_name=config.get("ghremote")
         )
         base_remote_url = remotes[base_remote_name]
         base_remote = github.parse_remote(base_remote_url)
-        base_branch = self.get_integrated_branch_name()
+        base_branch = config.get("ghbranch")
 
         start = (
             "{}:{}...".format(base_remote.owner, urllib.parse.quote_plus(base_branch))

--- a/github/commands/pull_request.py
+++ b/github/commands/pull_request.py
@@ -195,25 +195,30 @@ class GsGithubCreatePullRequestCommand(WindowCommand, git_mixins.GithubRemotesMi
 
         else:
             remote, remote_branch = current_branch.tracking.split("/", 1)
-            remote_url = self.get_remotes()[remote]
-            owner = github.parse_remote(remote_url).owner
             self.open_comparision_in_browser(
-                owner,
-                remote_branch
+                remote,
+                remote_branch,
             )
 
-    def open_comparision_in_browser(self, owner, branch):
-        base_remote = github.parse_remote(self.get_integrated_remote_url())
-        remote_url = base_remote.url
-        base_owner = base_remote.owner
+    def open_comparision_in_browser(self, remote, remote_branch):
+        # type: (str, str) -> None
+        remotes = self.get_remotes()
+
+        remote_url = remotes[remote]
+        owner = github.parse_remote(remote_url).owner
+
+        base_remote_name = self.get_integrated_remote_name(remotes)
+        base_remote_url = remotes[base_remote_name]
+        base_remote = github.parse_remote(base_remote_url)
         base_branch = self.get_integrated_branch_name()
+
         start = (
-            "{}:{}...".format(base_owner, urllib.parse.quote_plus(base_branch))
+            "{}:{}...".format(base_remote.owner, urllib.parse.quote_plus(base_branch))
             if base_branch
             else ""
         )
-        end = "{}:{}".format(owner, urllib.parse.quote_plus(branch))
-        url = "{}/compare/{}{}?expand=1".format(remote_url, start, end)
+        end = "{}:{}".format(owner, urllib.parse.quote_plus(remote_branch))
+        url = "{}/compare/{}{}?expand=1".format(base_remote.url, start, end)
         open_in_browser(url)
 
 

--- a/github/git_mixins/remotes.py
+++ b/github/git_mixins/remotes.py
@@ -22,8 +22,8 @@ class GithubRemotesMixin(base):
             throw_on_stderr=False
         ).strip() or None
 
-    def get_integrated_remote_name(self, remotes):
-        # type: (Dict[name, url]) -> name
+    def get_integrated_remote_name(self, remotes, current_upstream=None):
+        # type: (Dict[name, url], Optional[str]) -> name
         if len(remotes) == 0:
             raise ValueError("GitHub integration will not function when no remotes defined.")
 
@@ -44,7 +44,8 @@ class GithubRemotesMixin(base):
             if name in remotes:
                 return name
 
-        current_upstream = self.get_upstream_for_active_branch()
+        if current_upstream is None:
+            current_upstream = self.get_upstream_for_active_branch()
         if current_upstream:
             return current_upstream.split("/")[0]
 
@@ -61,8 +62,8 @@ class GithubRemotesMixin(base):
         if len(remotes) == 1:
             return list(remotes.keys())[0]
 
-        integrated_remote = self.get_integrated_remote_name(remotes)
         upstream = self.get_upstream_for_active_branch()
+        integrated_remote = self.get_integrated_remote_name(remotes, current_upstream=upstream)
         if upstream:
             tracked_remote = upstream.split("/")[0]
             if tracked_remote != integrated_remote:

--- a/github/github.py
+++ b/github/github.py
@@ -7,7 +7,7 @@ from collections import namedtuple
 from webbrowser import open as open_in_browser
 from functools import partial
 
-from ..common import interwebs, util
+from ..common import interwebs
 from ..core.exceptions import FailedGithubRequest
 from ..core.settings import GitSavvySettings
 
@@ -49,8 +49,7 @@ def remote_to_url(remote):
     elif remote.startswith("http"):
         return remote
     else:
-        util.debug.log_error('Cannot parse remote "%s" to url' % remote)
-        return None
+        raise ValueError('Cannot parse remote "{}" and transform to url'.format(remote))
 
 
 def parse_remote(remote):
@@ -60,14 +59,10 @@ def parse_remote(remote):
     this particular FQDN (if available).
     """
     url = remote_to_url(remote)
-    if not url:
-        return None
 
     match = re.match(r"https?://([a-zA-Z-\.0-9]+)/([a-zA-Z-\._0-9]+)/([a-zA-Z-\._0-9]+)/?", url)
-
     if not match:
-        util.debug.log_error('Invalid github url: %s' % url)
-        return None
+        raise ValueError("Invalid github url: {}".format(url))
 
     fqdn, owner, repo = match.groups()
     token = GitSavvySettings().get("api_tokens", {}).get(fqdn)
@@ -79,9 +74,6 @@ def open_file_in_browser(rel_path, remote, commit_hash, start_line=None, end_lin
     Open the URL corresponding to the provided `rel_path` on `remote`.
     """
     github_repo = parse_remote(remote)
-    if not github_repo:
-        return None
-
     line_numbers = "#L{}-L{}".format(start_line, end_line) if start_line is not None else ""
 
     url = "{repo_url}/blob/{commit_hash}/{path}{lines}".format(
@@ -99,8 +91,6 @@ def open_repo(remote):
     Open the GitHub repo in a new browser window, given the specified remote.
     """
     github_repo = parse_remote(remote)
-    if not github_repo:
-        return None
     open_in_browser(github_repo.url)
 
 
@@ -109,8 +99,6 @@ def open_issues(remote):
     Open the GitHub issues in a new browser window, given the specified remote.
     """
     github_repo = parse_remote(remote)
-    if not github_repo:
-        return None
     open_in_browser("{}/issues".format(github_repo.url))
 
 

--- a/github/github.py
+++ b/github/github.py
@@ -22,10 +22,20 @@ your settings, as described in the documentation:
 https://github.com/timbrel/GitSavvy/blob/master/docs/github.md#setup
 """
 
-GitHubRepo = namedtuple("GitHubRepo", ("url", "fqdn", "owner", "repo", "token"))
+
+MYPY = False
+if MYPY:
+    from typing import NamedTuple
+    GitHubRepo = NamedTuple("GitHubRepo", [
+        ("url", str), ("fqdn", str), ("owner", str), ("repo", str), ("token", str)
+    ])
+    remote_url = str
+else:
+    GitHubRepo = namedtuple("GitHubRepo", ("url", "fqdn", "owner", "repo", "token"))
 
 
 def remote_to_url(remote):
+    # type: (remote_url) -> str
     """
     Parse out a Github HTTP URL from a remote URI:
 
@@ -53,6 +63,7 @@ def remote_to_url(remote):
 
 
 def parse_remote(remote):
+    # type: (remote_url) -> GitHubRepo
     """
     Given a line of output from `git remote -v`, parse the string and return
     an object with original url, FQDN, owner, repo, and the token to use for
@@ -176,7 +187,7 @@ def iteratively_query_github(api_url_template, github_repo):
     while True:
         if response is not None:
             # it means this is not the first iter
-            if "link" not in response.headers:
+            if "link" not in response.headers:  # type: ignore[unreachable]
                 break
 
             # following next link


### PR DESCRIPTION
Fixes #1273 

Continue the work done in #1386.  Reduce side-effects (git calls).

```
Create PR master (before)

 (D) [ 78ms] $ git rev-parse --abbrev-ref --symbolic-full-name @{u}
 (M) [ 85ms] $ git branch --no-color
 (D) [ 67ms] $ git remote -v
 (D) [6052ms] $ git push --set-upstream fork test:test
 (D) [ 78ms] $ git rev-parse --abbrev-ref --symbolic-full-name @{u}
 (D) [ 62ms] $ git rev-parse --abbrev-ref --symbolic-full-name @{u}
 (D) [ 78ms] $ git for-each-ref --format=%(HEAD)%00%(refname)%00%(upstream)%00%(upstream:track)%00%(objectname)%00%(contents:subject) refs/heads refs/remotes
 (D) [ 94ms] $ git status --porcelain -z -b
 (D) [ 66ms] $ git remote -v
 (D) [ 66ms] $ git remote -v
 (D) [ 78ms] $ git config --local --get GitSavvy.ghRemote
 (D) [ 62ms] $ git remote -v
 (D) [ 78ms] $ git config --local --get GitSavvy.ghBranch


Create PR this branch (after)

 (D) [ 68ms] $ git for-each-ref --format=%(HEAD)%00%(refname)%00%(upstream)%00%(upstream:track)%00%(objectname)%00%(contents:subject) refs/heads
 (D) [ 78ms] $ git remote -v
 (D) [5036ms] $ git push --set-upstream fork test:test
 (D) [ 62ms] $ git for-each-ref --format=%(HEAD)%00%(refname)%00%(upstream)%00%(upstream:track)%00%(objectname)%00%(contents:subject) refs/heads
 (D) [ 78ms] $ git remote -v
 (D) [ 62ms] $ git config --get-regex ^gitsavvy\..*
```


There is only one behavioral change, namely that we always set upstream or "tracking" even if `prompt_for_tracking_branch` is `False`.  This is a leftover from https://github.com/timbrel/GitSavvy/pull/569#discussion_r89279892 actually.