### PR TITLE
Faster dot colorizer

### DIFF
--- a/core/commands/intra_line_colorizer.py
+++ b/core/commands/intra_line_colorizer.py
@@ -46,7 +46,7 @@ def view_has_changed_factory(view):
     return view_has_changed
 
 
-def block_time_passed_factory(block_time):
+def block_time_passed_factory(block_time=MAX_BLOCK_TIME):
     start_time = time.perf_counter()
 
     def block_time_passed():
@@ -93,7 +93,7 @@ def compute_intra_line_diffs(view, diff):
     yield AWAIT_WORKER
     if view_has_changed():
         return
-    block_time_passed = block_time_passed_factory(MAX_BLOCK_TIME)
+    block_time_passed = block_time_passed_factory()
 
     # Consider some chunks [1, 2, 3, 4] where 3 was *in* the viewport and thus
     # rendered immediately. Now, [1, 2] + [4] await their render. The following

--- a/core/commands/intra_line_colorizer.py
+++ b/core/commands/intra_line_colorizer.py
@@ -111,6 +111,7 @@ def compute_intra_line_diffs(view, diff):
             yield AWAIT_WORKER
             if view_has_changed():
                 return
+            block_time_passed = block_time_passed_factory()
 
     if view_has_changed():
         return

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -64,8 +64,8 @@ __all__ = (
 MYPY = False
 if MYPY:
     from typing import (
-        Callable, Dict, Generic, Iterable, Iterator, List, MutableMapping, Optional, Set,
-        Sequence, Tuple, TypeVar, Union
+        Callable, Dict, Generic, Iterable, Iterator, List, Optional, Set, Sequence, Tuple,
+        TypeVar, Union
     )
     from GitSavvy.core.runtime import HopperR
     T = TypeVar('T')
@@ -1682,7 +1682,6 @@ def dot_from_line(view, line):
 
 
 ACTIVE_COMPUTATION = Cache()
-PATH_CACHE = Cache()  # type: MutableMapping[Tuple[colorizer.Char, str], List[colorizer.Char]]
 
 
 @lru_cache(maxsize=1)
@@ -1710,24 +1709,22 @@ def __colorize_dots(vid, dots):
     uow = []
     for container, direction in ((paths_down, "down"), (paths_up, "up")):
         for dot in dots:
-            cache_key = (dot, direction)
             try:
-                chars = PATH_CACHE[cache_key]
-            except KeyError:
+                chars = colorizer.follow_path_if_cached(dot, direction)  # type: ignore[arg-type]
+            except ValueError:
                 values = []  # type: List[colorizer.Char]
                 container.append(values)
-                uow.append((colorizer._follow_path(dot, direction), values, cache_key))
+                uow.append((colorizer._follow_path(dot, direction), values))  # type: ignore[arg-type]
             else:
                 container.append(chars)
 
     c = 0
     while uow:
         idx = c % len(uow)
-        iterator, values, cache_key = uow[idx]
+        iterator, values = uow[idx]
         try:
             char = next(iterator)
         except StopIteration:
-            PATH_CACHE[cache_key] = values
             uow.pop(idx)
         else:
             values.append(char)

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -1714,7 +1714,7 @@ def __colorize_dots(vid, dots):
             except ValueError:
                 values = []  # type: List[colorizer.Char]
                 container.append(values)
-                uow.append((colorizer._follow_path(dot, direction), values))  # type: ignore[arg-type]
+                uow.append((colorizer.follow_path(dot, direction), values))  # type: ignore[arg-type]
             else:
                 container.append(chars)
 

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -1066,8 +1066,9 @@ class gs_log_graph_navigate_wide(TextCommand):
             )
 
 
-def follow_first_parent_commit(dot, forward):
+def follow_first_parent_commit(dot, forward=True):
     # type: (colorizer.Char, bool) -> Iterator[colorizer.Char]
+    """Follow dot to dot omitting the path chars in between."""
     fn = colorizer.follow_path_down if forward else colorizer.follow_path_up
     while True:
         dot = next(ch for ch in fn(dot) if ch == COMMIT_NODE_CHAR)
@@ -1830,7 +1831,7 @@ def commit_message_from_point(view, pt):
 def find_matching_commit(vid, dot, message):
     # type: (sublime.ViewId, colorizer.Char, str) -> Optional[colorizer.Char]
     view = sublime.View(vid)
-    for dot in islice(follow_dots(dot), 0, 50):
+    for dot in islice(follow_first_parent_commit(dot), 0, 50):
         this_message = commit_message_from_point(view, dot.pt)
         if this_message:
             shorter, longer = sorted((message, this_message.rstrip(".")), key=len)
@@ -1838,14 +1839,6 @@ def find_matching_commit(vid, dot, message):
                 return dot
     else:
         return None
-
-
-def follow_dots(dot):
-    # type: (colorizer.Char) -> Iterator[colorizer.Char]
-    """Follow dot to dot omitting the path chars in between."""
-    while True:
-        dot = next(ch for ch in colorizer.follow_path_down(dot) if ch == COMMIT_NODE_CHAR)
-        yield dot
 
 
 def draw_info_panel(view):

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -1703,7 +1703,7 @@ def __colorize_dots(vid, dots):
     # type: (sublime.ViewId, Tuple[colorizer.Char]) -> HopperR
     view = sublime.View(vid)
 
-    block_time_passed = block_time_passed_factory(17)
+    block_time_passed = block_time_passed_factory()
     paths_down = []  # type: List[List[colorizer.Char]]
     paths_up = []  # type: List[List[colorizer.Char]]
 
@@ -1738,7 +1738,7 @@ def __colorize_dots(vid, dots):
             yield "AWAIT_UI_THREAD"
             if ACTIVE_COMPUTATION.get(vid) != dots:
                 return
-            block_time_passed = block_time_passed_factory(17)
+            block_time_passed = block_time_passed_factory()
 
     if ACTIVE_COMPUTATION[vid] == dots:
         ACTIVE_COMPUTATION.pop(vid, None)

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -1027,7 +1027,7 @@ class gs_log_graph_navigate_wide(TextCommand):
             view.run_command("gs_log_graph_navigate", {"forward": forward})
             return
 
-        next_dots = follow_first_parent_commit(cur_dot, forward)
+        next_dots = follow_first_parent(cur_dot, forward)
         try:
             next_dot = next(next_dots)
         except StopIteration:
@@ -1066,7 +1066,7 @@ class gs_log_graph_navigate_wide(TextCommand):
             )
 
 
-def follow_first_parent_commit(dot, forward=True):
+def follow_first_parent(dot, forward=True):
     # type: (colorizer.Char, bool) -> Iterator[colorizer.Char]
     """Follow dot to dot omitting the path chars in between."""
     fn = colorizer.follow_path_down if forward else colorizer.follow_path_up
@@ -1831,7 +1831,7 @@ def commit_message_from_point(view, pt):
 def find_matching_commit(vid, dot, message):
     # type: (sublime.ViewId, colorizer.Char, str) -> Optional[colorizer.Char]
     view = sublime.View(vid)
-    for dot in islice(follow_first_parent_commit(dot), 0, 50):
+    for dot in islice(follow_first_parent(dot), 0, 50):
         this_message = commit_message_from_point(view, dot.pt)
         if this_message:
             shorter, longer = sorted((message, this_message.rstrip(".")), key=len)

--- a/core/commands/log_graph_colorizer.py
+++ b/core/commands/log_graph_colorizer.py
@@ -1,3 +1,4 @@
+from collections import deque
 from functools import lru_cache
 
 import sublime
@@ -179,11 +180,12 @@ def follow_path_up(dot):
 
 def _follow_path(dot, direction):
     # type: (Char, Direction) -> Iterator[Char]
-    for c in follow_char(dot, direction):
-        # print('{} -> {}'.format(dot, c))
+    stack = deque(follow_char(dot, direction))
+    while stack:
+        c = stack.popleft()
         yield c
         if c != COMMIT_NODE_CHAR:
-            yield from _follow_path(c, direction)
+            stack.extendleft(reversed(list(follow_char(c, direction))))
 
 
 def follow_char(char, direction):

--- a/core/commands/log_graph_colorizer.py
+++ b/core/commands/log_graph_colorizer.py
@@ -179,13 +179,13 @@ def follow(ch, direction):
 
 
 def follow_path_down(dot):
-    # type: (Char) -> List[Char]
-    return list(follow_path(dot, "down"))
+    # type: (Char) -> Iterator[Char]
+    return follow_path(dot, "down")
 
 
 def follow_path_up(dot):
-    # type: (Char) -> List[Char]
-    return list(follow_path(dot, "up"))
+    # type: (Char) -> Iterator[Char]
+    return follow_path(dot, "up")
 
 
 def follow_path_if_cached(dot, direction):

--- a/core/commands/log_graph_colorizer.py
+++ b/core/commands/log_graph_colorizer.py
@@ -180,12 +180,12 @@ def follow(ch, direction):
 
 def follow_path_down(dot):
     # type: (Char) -> List[Char]
-    return list(_follow_path(dot, "down"))
+    return list(follow_path(dot, "down"))
 
 
 def follow_path_up(dot):
     # type: (Char) -> List[Char]
-    return list(_follow_path(dot, "up"))
+    return list(follow_path(dot, "up"))
 
 
 def follow_path_if_cached(dot, direction):
@@ -197,7 +197,7 @@ def follow_path_if_cached(dot, direction):
         raise ValueError from None
 
 
-def _follow_path(dot, direction):
+def follow_path(dot, direction):
     # type: (Char, Direction) -> Iterator[Char]
     cache_key = (dot, direction)
     try:


### PR DESCRIPTION
- Switch to iterative (instead of recursive) depth first traversal.

In Sublime Text/Python we have a recursion depth of 1000 after that we crash.  
The recursion algorithm is also very slow for deep or long paths.

- Use cooperative thread hopping

Since we need to run on the UI thread (because of excessive queries 
against the view) slice the work into 17ms so that Sublime doesn't
freeze on long paths. 

Tested with paths 3000-5000 commits deep.  The recursion algorithm throws
after for example 1.5s.  The iterative algorithm runs in a fraction of time,
for example 350-500ms but obviously blocking too long.  Using thread hopping
we basically draw the viewport immediately, and thus give the illusion of
immediacy we actually don't have. 


