### PR TITLE
Fine-tune ref highlighting in the commit message

### DIFF
--- a/syntax/make_commit.sublime-syntax
+++ b/syntax/make_commit.sublime-syntax
@@ -14,9 +14,10 @@ contexts:
       set: commit-subject
 
   references:
-    - match: \@\w*
+    - match: (?:\s)(\@\w+)
       comment: github username
-      scope: constant.other.github-username.git-savvy.make-commit
+      captures:
+        1: constant.other.github-username.git-savvy.make-commit
 
     - match: '(\w+/\w+)?#[0-9]+'
       comment: issue

--- a/syntax/make_commit.sublime-syntax
+++ b/syntax/make_commit.sublime-syntax
@@ -23,9 +23,10 @@ contexts:
       comment: issue
       scope: constant.other.issue-ref.git-savvy.make-commit
 
-    - match: \b\h{7,}\b
+    - match: (?:\s|\w\@)(\h{7,})\b
       comment: sha reference
-      scope: constant.other.commit-sha.git-savvy.make-commit
+      captures:
+        1: constant.other.commit-sha.git-savvy.make-commit
 
   commit-subject:
     - meta_scope: meta.commit.message.subject markup.heading.subject.git.commit

--- a/syntax/test/syntax_test_make_commit.txt
+++ b/syntax/test/syntax_test_make_commit.txt
@@ -6,10 +6,19 @@ Some body
 
 This is for @aziz and close #76 aziz/git#123 aziz/good
 #           ^^^^^ constant.other.github-username.git-savvy.make-commit
+#          ^      - constant.other.github-username.git-savvy.make-commit
+#                ^ - constant.other.github-username.git-savvy.make-commit
 #                           ^^^ constant.other.issue-ref.git-savvy.make-commit
+#                          ^ - constant.other.issue-ref.git-savvy.make-commit
+#                              ^ - constant.other.issue-ref.git-savvy.make-commit
 #                               ^^^^^^^^^^^^ constant.other.issue-ref.git-savvy.make-commit
-This is a ref to a commit 89d6780
+This is a ref to a commit 89d6780.
 #                         ^^^^^^^ constant.other.commit-sha.git-savvy.make-commit
+#                        ^ - constant.other.commit-sha.git-savvy.make-commit
+#                                ^ - constant.other.commit-sha.git-savvy.make-commit
+This is a ref to a commit fue@89d6780
+#                             ^^^^^^^ constant.other.commit-sha.git-savvy.make-commit
+#                         ^^^^ - constant.other.commit-sha.git-savvy.make-commit
 
 
 ## To make a commit, type your commit message and press SUPER-ENTER. To cancel


### PR DESCRIPTION
Fine tune syntax highlighting of references in the commit message

- Do not highlight sole "@" characters. 
- Generally, do not highlight the surrounding spaces.
- Narrow down sha highlighting.  Usually these are surrounded by spaces (not `\b\`) or (seldom) in the form of `master@3fc528c`