### PR TITLE
Move "Fetch" to the top of the actions menu

### DIFF
--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -2144,9 +2144,9 @@ class gs_log_graph_action(WindowCommand, GitCommand):
         on_checked_out_branch = "HEAD" in info and info["HEAD"] in info.get("local_branches", [])
         if on_checked_out_branch:
             actions += [
+                ("Fetch", partial(self.fetch, info["HEAD"])),
                 ("Pull", self.pull),
                 ("Push", partial(self.push, info["HEAD"])),
-                ("Fetch", partial(self.fetch, info["HEAD"])),
                 ("-" * 75, self.noop),
             ]
 


### PR DESCRIPTION
We switch to the order "fetch/pull/push" as fetch is used to often,
basically to preview the upstream changes.