### PR TITLE
Cleanup quick panels

### DIFF
--- a/core/base_commands.py
+++ b/core/base_commands.py
@@ -148,8 +148,7 @@ if MYPY:
 def ask_for_local_branch(self, done):
     # type: (GsCommand, Kont) -> None
     def on_done(branch):
-        if branch:
-            done(branch)
+        done(branch)
 
     show_branch_panel(
         on_done,

--- a/core/commands/checkout.py
+++ b/core/commands/checkout.py
@@ -51,9 +51,6 @@ class gs_checkout_branch(WindowCommand, GitCommand):
             )
 
     def on_branch_selection(self, branch):
-        if not branch:
-            return
-
         self.git("checkout", branch)
         self._last_branches.append(branch)
         self.window.status_message("Checked out `{}` branch.".format(branch))
@@ -111,9 +108,6 @@ class gs_checkout_remote_branch(WindowCommand, GitCommand):
                 remote_branches_only=True)
 
     def on_branch_selection(self, remote_branch, local_name=None):
-        if not remote_branch:
-            return
-
         self.remote_branch = remote_branch
         if not local_name:
             local_name = remote_branch.split("/", 1)[1]

--- a/core/commands/commit_compare.py
+++ b/core/commands/commit_compare.py
@@ -73,21 +73,21 @@ class gs_compare_against_branch(WindowCommand, GitCommand):
         sublime.set_timeout_async(self.run_async)
 
     def run_async(self):
-        show_branch_panel(self.on_branch_selection)
+        show_branch_panel(self.on_branch_selection, on_cancel=self.recurse)
 
     def on_branch_selection(self, branch):
-        if branch:
-            self.window.run_command("gs_compare_commit", {
-                "file_path": self._file_path,
-                "base_commit": self._base_commit if self._base_commit else branch,
-                "target_commit": self._target_commit if self._target_commit else branch
-            })
-        else:
-            self.window.run_command("gs_compare_against", {
-                "base_commit": self._base_commit,
-                "target_commit": self._target_commit,
-                "file_path": self._file_path
-            })
+        self.window.run_command("gs_compare_commit", {
+            "file_path": self._file_path,
+            "base_commit": self._base_commit if self._base_commit else branch,
+            "target_commit": self._target_commit if self._target_commit else branch
+        })
+
+    def recurse(self):
+        self.window.run_command("gs_compare_against", {
+            "base_commit": self._base_commit,
+            "target_commit": self._target_commit,
+            "file_path": self._file_path
+        })
 
 
 class gs_compare_against(PanelActionMixin, WindowCommand, GitCommand):

--- a/core/commands/fetch.py
+++ b/core/commands/fetch.py
@@ -25,8 +25,6 @@ class gs_fetch(WindowCommand, GitCommand):
         show_remote_panel(self.on_remote_selection, show_option_all=True, allow_direct=True)
 
     def on_remote_selection(self, remote):
-        if not remote:
-            return
         if remote is True:
             enqueue_on_worker(self.do_fetch)
         else:

--- a/core/commands/log.py
+++ b/core/commands/log.py
@@ -131,9 +131,8 @@ class GsLogByBranchCommand(LogMixin, WindowCommand, GitCommand):
         )
 
     def on_branch_selection(self, branch, **kwargs):
-        if branch:
-            self._selected_branch = branch
-            super().run_async(branch=branch, **kwargs)
+        self._selected_branch = branch
+        super().run_async(branch=branch, **kwargs)
 
 
 class GsLogCommand(PanelCommandMixin, WindowCommand, GitCommand):

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -959,14 +959,13 @@ class gs_log_graph_by_branch(WindowCommand, GitCommand):
 
     def run(self, file_path=None):
         def on_select(branch):
-            if branch:
-                self._selected_branch = branch  # remember last selection
-                self.window.run_command('gs_graph', {
-                    'file_path': file_path,
-                    'all': True,
-                    'branches': [branch],
-                    'follow': branch,
-                })
+            self._selected_branch = branch  # remember last selection
+            self.window.run_command('gs_graph', {
+                'file_path': file_path,
+                'all': True,
+                'branches': [branch],
+                'follow': branch,
+            })
 
         show_branch_panel(on_select, selected_branch=self._selected_branch)
 

--- a/core/commands/merge.py
+++ b/core/commands/merge.py
@@ -20,11 +20,10 @@ class GsMergeCommand(WindowCommand, GitCommand):
     def run_async(self):
         show_branch_panel(
             self.on_branch_selection,
-            ignore_current_branch=True)
+            ignore_current_branch=True
+        )
 
     def on_branch_selection(self, branch):
-        if not branch:
-            return
         try:
             self.git(
                 "merge",

--- a/core/commands/pull.py
+++ b/core/commands/pull.py
@@ -61,12 +61,10 @@ class gs_pull_from_branch(GsPullBase):
     def run_async(self):
         show_branch_panel(
             self.on_branch_selection,
-            ask_remote_first=True)
+            ask_remote_first=True
+        )
 
     def on_branch_selection(self, branch):
-        if not branch:
-            return
-
         selected_remote, selected_remote_branch = branch.split("/", 1)
 
         sublime.set_timeout_async(

--- a/core/commands/push.py
+++ b/core/commands/push.py
@@ -175,10 +175,6 @@ class gs_push_to_branch_name(PushBase):
         """
         After the user selects a remote, prompt the user for a branch name.
         """
-        # If the user pressed `esc` or otherwise cancelled.
-        if not remote:
-            return
-
         self.selected_remote = remote
 
         if self.branch_name:

--- a/core/commands/push.py
+++ b/core/commands/push.py
@@ -132,8 +132,6 @@ class gs_push_to_branch(PushBase):
         show_branch_panel(self.on_branch_selection, ask_remote_first=True)
 
     def on_branch_selection(self, branch):
-        if not branch:
-            return
         current_local_branch = self.get_current_branch_name()
         selected_remote, selected_branch = branch.split("/", 1)
         enqueue_on_worker(

--- a/core/commands/remote.py
+++ b/core/commands/remote.py
@@ -39,16 +39,10 @@ class GsRemoteRemoveCommand(WindowCommand, GitCommand):
     def run(self):
         show_remote_panel(self.on_remote_selection, show_url=True)
 
+    @util.actions.destructive(description="remove a remote")
     def on_remote_selection(self, remote):
-        if not remote:
-            return
-
-        @util.actions.destructive(description="remove a remote")
-        def remove():
-            self.git("remote", "remove", remote)
-            util.view.refresh_gitsavvy_interfaces(self.window, refresh_status_bar=False)
-
-        remove()
+        self.git("remote", "remove", remote)
+        util.view.refresh_gitsavvy_interfaces(self.window, refresh_status_bar=False)
 
 
 class GsRemoteRenameCommand(WindowCommand, GitCommand):
@@ -60,9 +54,6 @@ class GsRemoteRenameCommand(WindowCommand, GitCommand):
         show_remote_panel(self.on_remote_selection, show_url=True)
 
     def on_remote_selection(self, remote):
-        if not remote:
-            return
-
         self.remote = remote
         show_single_line_input_panel("Remote name", remote, self.on_enter_name, None, None)
 

--- a/core/commands/reset.py
+++ b/core/commands/reset.py
@@ -69,8 +69,7 @@ class GsResetBranch(ResetMixin, LogMixin, WindowCommand, GitCommand):
         show_branch_panel(self.on_branch_selection)
 
     def on_branch_selection(self, branch):
-        if branch:
-            self.do_action(branch)
+        self.do_action(branch)
 
 
 class GsResetReflogCommand(ResetMixin, RefLogMixin, WindowCommand, GitCommand):

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -98,8 +98,6 @@ class _GitCommand(SettingsMixin):
     Base class for all Sublime commands that interact with git.
     """
 
-    _last_remotes_used = {}
-
     def git(
         self,
         *args,
@@ -496,22 +494,6 @@ class _GitCommand(SettingsMixin):
             args = global_pre_flags[git_cmd] + args
 
         return args
-
-    @property
-    def last_remote_used(self):
-        """
-        With this getter and setter, keep global track of last remote used
-        for each repo.
-        """
-        return self._last_remotes_used.get(self.repo_path)
-
-    @last_remote_used.setter
-    def last_remote_used(self, value):
-        """
-        Setter for above property.  Saves per-repo information in
-        class attribute dict.
-        """
-        self._last_remotes_used[self.repo_path] = value
 
 
 if MYPY:

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -501,15 +501,9 @@ class _GitCommand(SettingsMixin):
     def last_remote_used(self):
         """
         With this getter and setter, keep global track of last remote used
-        for each repo.  Will return whatever was set last, or active remote
-        if never set. If there is no tracking remote, use "origin".
+        for each repo.
         """
-        remote = self._last_remotes_used.get(self.repo_path)
-        if not remote:
-            remote = self.get_upstream_for_active_branch().split("/")[0]
-        if not remote:
-            remote = "origin"
-        return remote
+        return self._last_remotes_used.get(self.repo_path)
 
     @last_remote_used.setter
     def last_remote_used(self, value):

--- a/core/git_mixins/remotes.py
+++ b/core/git_mixins/remotes.py
@@ -24,24 +24,6 @@ class RemotesMixin():
             branch if not remote_branch else "{}:{}".format(remote_branch, branch)
         )
 
-    def list_remote_branches(self, remote=None):
-        """
-        Return a list of all known branches on all remotes, or a specified remote.
-        """
-        stdout = self.git("branch", "-r", "--no-color")
-        branches = [branch.strip() for branch in stdout.split("\n") if branch]
-
-        if remote:
-            branches = [branch for branch in branches if branch.startswith(remote + "/")]
-
-        # Clean up "origin/HEAD -> origin/master" to "origin/master" if present.
-        for idx, branch_name in enumerate(branches):
-            if "origin/HEAD -> " in branch_name:
-                branches[idx] = branch_name[15:]
-
-        # Remove any duplicate branch names.
-        return [branch for idx, branch in enumerate(branches) if branches.index(branch) == idx]
-
     def pull(self, remote=None, remote_branch=None, rebase=False):
         """
         Pull from the specified remote and branch if provided, otherwise

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -392,9 +392,6 @@ class GsBranchesPushAllCommand(TextCommand, GitCommand):
         show_remote_panel(self.on_remote_selection)
 
     def on_remote_selection(self, remote):
-        # If the user pressed `esc` or otherwise cancelled.
-        if not remote:
-            return
         self.view.window().status_message("Pushing all branches to `{}`...".format(remote))
         self.git("push", remote, "--all")
         self.view.window().status_message("Push successful.")

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -349,13 +349,10 @@ class GsBranchesConfigureTrackingCommand(TextCommand, GitCommand):
         show_branch_panel(
             self.on_branch_selection,
             ask_remote_first=True,
-            selected_branch=branch_name)
+            selected_branch=branch_name
+        )
 
     def on_branch_selection(self, branch):
-        # If the user pressed `esc` or otherwise cancelled.
-        if not branch:
-            return
-
         self.git("branch", "-u", branch, self.local_branch)
         util.view.refresh_gitsavvy(self.view)
 

--- a/core/store.py
+++ b/core/store.py
@@ -6,12 +6,13 @@ from .utils import Cache
 
 MYPY = False
 if MYPY:
-    from typing import Any, DefaultDict, Dict, Tuple, TypedDict
+    from typing import Any, DefaultDict, Dict, Optional, Tuple, TypedDict
 
     RepoPath = str
     RepoStore = TypedDict(
         'RepoStore',
         {
+            "last_remote_used": Optional[str],
             "short_hash_length": int,
         },
         total=False

--- a/core/ui_mixins/quick_panel.py
+++ b/core/ui_mixins/quick_panel.py
@@ -202,12 +202,15 @@ class RemotePanel(GitCommand):
 
 def show_branch_panel(
         on_done,
+        *,
+        on_cancel=lambda: None,
         local_branches_only=False,
         remote_branches_only=False,
         ignore_current_branch=False,
         ask_remote_first=False,
         local_branch=None,
-        selected_branch=None):
+        selected_branch=None
+):
     """
     Show a quick panel with branches. The callback `on_done(branch)` will
     be called when a branch is selected. If the panel is cancelled, `None`
@@ -221,11 +224,13 @@ def show_branch_panel(
     """
     bp = BranchPanel(
         on_done,
+        on_cancel,
         local_branches_only,
         remote_branches_only,
         ignore_current_branch,
         ask_remote_first,
-        selected_branch)
+        selected_branch
+    )
     bp.show()
     return bp
 
@@ -233,10 +238,18 @@ def show_branch_panel(
 class BranchPanel(GitCommand):
 
     def __init__(
-            self, on_done, local_branches_only=False, remote_branches_only=False,
-            ignore_current_branch=False, ask_remote_first=False, selected_branch=None):
+            self,
+            on_done,
+            on_cancel,
+            local_branches_only=False,
+            remote_branches_only=False,
+            ignore_current_branch=False,
+            ask_remote_first=False,
+            selected_branch=None
+    ):
         self.window = sublime.active_window()
         self.on_done = on_done
+        self.on_cancel = on_cancel
         self.local_branches_only = local_branches_only
         self.remote_branches_only = True if ask_remote_first else remote_branches_only
         self.ignore_current_branch = ignore_current_branch
@@ -299,11 +312,9 @@ class BranchPanel(GitCommand):
 
     def on_branch_selection(self, index):
         if index == -1:
-            self.branch = None
+            self.on_cancel()
         else:
-            self.branch = self.all_branches[index]
-
-        self.on_done(self.branch)
+            self.on_done(self.all_branches[index])
 
 
 def show_paginated_panel(items, on_done, **kwargs):

--- a/core/ui_mixins/quick_panel.py
+++ b/core/ui_mixins/quick_panel.py
@@ -178,9 +178,7 @@ class RemotePanel(GitCommand):
         if self.show_option_all and len(self.remotes) > 1:
             self.remotes.insert(0, "All remotes.")
 
-        # We don't use the GitCommand.last_remote_used property because we don't want default values
-        last_remote_used = self._last_remotes_used.get(self.repo_path)
-
+        last_remote_used = self.last_remote_used
         if last_remote_used in self.remotes:
             pre_selected_index = self.remotes.index(last_remote_used)
         else:

--- a/core/ui_mixins/quick_panel.py
+++ b/core/ui_mixins/quick_panel.py
@@ -208,7 +208,6 @@ def show_branch_panel(
         remote_branches_only=False,
         ignore_current_branch=False,
         ask_remote_first=False,
-        local_branch=None,
         selected_branch=None
 ):
     """

--- a/core/ui_mixins/quick_panel.py
+++ b/core/ui_mixins/quick_panel.py
@@ -252,19 +252,19 @@ class BranchPanel(GitCommand):
             self.select_branch(remote=None)
 
     def select_branch(self, remote=None):
-
+        branches = list(self.get_branches())
         if self.local_branches_only:
-            self.all_branches = [b.name_with_remote for b in self.get_branches() if not b.remote]
+            self.all_branches = [b.name_with_remote for b in branches if not b.remote]
         elif self.remote_branches_only:
-            self.all_branches = [b.name_with_remote for b in self.get_branches() if b.remote]
+            self.all_branches = [b.name_with_remote for b in branches if b.remote]
         else:
-            self.all_branches = [b.name_with_remote for b in self.get_branches()]
+            self.all_branches = [b.name_with_remote for b in branches]
 
+        current_branch = next((b.name for b in branches if b.active), None)
         if self.ignore_current_branch:
-            current_branch = self.get_current_branch_name()
             self.all_branches = [b for b in self.all_branches if b != current_branch]
         elif self.selected_branch is None and not self.remote_branches_only:
-            self.selected_branch = self.get_current_branch_name()
+            self.selected_branch = current_branch
 
         if remote:
             self.all_branches = [b for b in self.all_branches if b.startswith(remote + "/")]

--- a/core/ui_mixins/quick_panel.py
+++ b/core/ui_mixins/quick_panel.py
@@ -3,6 +3,7 @@ import sublime
 from ...common import util
 from ..git_command import GitCommand
 from GitSavvy.core.fns import filter_
+from GitSavvy.core import store
 
 
 class PanelActionMixin(object):
@@ -178,7 +179,7 @@ class RemotePanel(GitCommand):
         if self.show_option_all and len(self.remotes) > 1:
             self.remotes.insert(0, "All remotes.")
 
-        last_remote_used = self.last_remote_used
+        last_remote_used = store.current_state(self.repo_path).get("last_remote_used")
         if last_remote_used in self.remotes:
             pre_selected_index = self.remotes.index(last_remote_used)
         else:
@@ -195,12 +196,12 @@ class RemotePanel(GitCommand):
         if index == -1:
             self.on_cancel()
         elif self.show_option_all and len(self.remotes) > 1 and index == 0:
-            self.last_remote_used = None
+            store.update_state(self.repo_path, {"last_remote_used": None})
             self.on_done(True)
         else:
-            self.remote = self.remotes[index]
-            self.last_remote_used = self.remote
-            self.on_done(self.remote)
+            remote = self.remotes[index]
+            store.update_state(self.repo_path, {"last_remote_used": remote})
+            self.on_done(remote)
 
 
 def show_branch_panel(

--- a/core/ui_mixins/quick_panel.py
+++ b/core/ui_mixins/quick_panel.py
@@ -245,9 +245,7 @@ class BranchPanel(GitCommand):
 
     def show(self):
         if self.ask_remote_first:
-            show_remote_panel(
-                lambda remote: sublime.set_timeout_async(
-                    lambda: self.select_branch(remote), 100))
+            show_remote_panel(self.select_branch)
         else:
             self.select_branch(remote=None)
 

--- a/core/ui_mixins/quick_panel.py
+++ b/core/ui_mixins/quick_panel.py
@@ -120,7 +120,6 @@ def show_remote_panel(
     *,
     on_cancel=lambda: None,
     show_option_all=False,
-    selected_remote=None,
     allow_direct=False,
     show_url=False
 ):
@@ -137,7 +136,6 @@ def show_remote_panel(
         on_done,
         on_cancel,
         show_option_all,
-        selected_remote,
         allow_direct,
         show_url
     )
@@ -152,14 +150,12 @@ class RemotePanel(GitCommand):
         on_done,
         on_cancel=lambda: None,
         show_option_all=False,
-        selected_remote=None,
         allow_direct=False,
         show_url=False
     ):
         self.window = sublime.active_window()
         self.on_done = on_done
         self.on_cancel = on_cancel
-        self.selected_remote = selected_remote
         self.show_option_all = show_option_all
         self.allow_direct = allow_direct
         self.show_url = show_url

--- a/github/commands/configure.py
+++ b/github/commands/configure.py
@@ -15,15 +15,13 @@ class GsGithubConfigureRemoteCommand(WindowCommand, GithubRemotesMixin, GitComma
         show_branch_panel(
             self.on_branch_selection,
             ask_remote_first=True,
-            selected_branch=self.get_integrated_branch_name())
+            selected_branch=self.get_integrated_branch_name()
+        )
 
     def on_branch_selection(self, branch):
         """
         After the user selects a branch, configure integrated remote branch.
         """
-        if not branch:
-            return
-
         remote, remote_branch = branch.split("/", 1)
 
         self.git("config", "--local", "--unset-all", "GitSavvy.ghRemote", throw_on_stderr=False)

--- a/github/commands/open_on_remote.py
+++ b/github/commands/open_on_remote.py
@@ -44,9 +44,6 @@ class GsGithubOpenFileOnRemoteCommand(TextCommand, git_mixins.GithubRemotesMixin
             show_remote_panel(self.open_file_on_remote)
 
     def open_file_on_remote(self, remote):
-        if not remote:
-            return
-
         fpath = self.fpath
         if isinstance(fpath, str):
             fpath = [fpath]
@@ -126,8 +123,6 @@ class GsGithubOpenRepoCommand(TextCommand, git_mixins.GithubRemotesMixin, GitCom
             show_remote_panel(self.on_remote_selection)
 
     def on_remote_selection(self, remote):
-        if not remote:
-            return
         open_repo(self.remotes[remote])
 
 

--- a/gitlab/commands/configure.py
+++ b/gitlab/commands/configure.py
@@ -15,15 +15,13 @@ class GsGitlabConfigureRemoteCommand(WindowCommand, GitLabRemotesMixin, GitComma
         show_branch_panel(
             self.on_branch_selection,
             ask_remote_first=True,
-            selected_branch=self.get_integrated_branch_name())
+            selected_branch=self.get_integrated_branch_name()
+        )
 
     def on_branch_selection(self, branch):
         """
         After the user selects a branch, configure integrated remote branch.
         """
-        if not branch:
-            return
-
         remote, remote_branch = branch.split("/", 1)
 
         self.git("config", "--local", "--unset-all", "GitSavvy.glRemote", throw_on_stderr=False)

--- a/gitlab/commands/open_on_remote.py
+++ b/gitlab/commands/open_on_remote.py
@@ -43,9 +43,6 @@ class GsGitlabOpenFileOnRemoteCommand(TextCommand, GitCommand, GitLabRemotesMixi
             show_remote_panel(self.open_file_on_remote)
 
     def open_file_on_remote(self, remote):
-        if not remote:
-            return
-
         fpath = self.fpath
         if isinstance(fpath, str):
             fpath = [fpath]
@@ -122,8 +119,6 @@ class GsGitlabOpenRepoCommand(TextCommand, GitCommand, GitLabRemotesMixin):
             show_remote_panel(self.on_remote_selection)
 
     def on_remote_selection(self, remote):
-        if not remote:
-            return
         open_repo(self.remotes[remote])
 
 

--- a/stubs/sublime.pyi
+++ b/stubs/sublime.pyi
@@ -177,7 +177,7 @@ class Window:
     def show_quick_panel(
         self,
         items: List[Any],
-        on_select: Callable[[int], None],
+        on_select: Optional[Callable[[int], None]],
         flags: int = ...,
         selected_index: int = ...,
         on_highlight: Optional[Callable[[int], None]] = ...,


### PR DESCRIPTION
- For both, `show_remote_panel` and `show_branch_panel` implement a separate `on_cancel` callback.  We usually abort on cancel (value `-1`) which makes all our usages simpler. 

- We had a property `last_remote_used` very visible on `GitCommand` but its getter was never used actually because the caller didn't liked its side-effects.  Remove that and use the `store` for it. 

- Save another git call: `show_branch_panel` used a separate git call to get the current branch name.  Don't do that. Because `get_branches()` returns rich information we already have what we want *if* we don't reduce the info to `.name_with_remote` straight.