### PR TITLE
Use `allow_direct=True` for more commands

### DIFF
--- a/core/commands/push.py
+++ b/core/commands/push.py
@@ -167,7 +167,7 @@ class gs_push_to_branch_name(PushBase):
         enqueue_on_worker(self.run_async)
 
     def run_async(self):
-        show_remote_panel(self.on_remote_selection)
+        show_remote_panel(self.on_remote_selection, allow_direct=True)
 
     def on_remote_selection(self, remote):
         """

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -386,7 +386,7 @@ class GsBranchesPushAllCommand(TextCommand, GitCommand):
         sublime.set_timeout_async(self.run_async)
 
     def run_async(self):
-        show_remote_panel(self.on_remote_selection)
+        show_remote_panel(self.on_remote_selection, allow_direct=True)
 
     def on_remote_selection(self, remote):
         self.view.window().status_message("Pushing all branches to `{}`...".format(remote))

--- a/core/ui_mixins/quick_panel.py
+++ b/core/ui_mixins/quick_panel.py
@@ -257,7 +257,7 @@ class BranchPanel(GitCommand):
 
     def show(self):
         if self.ask_remote_first:
-            show_remote_panel(self.select_branch)
+            show_remote_panel(self.select_branch, allow_direct=True)
         else:
             self.select_branch(remote=None)
 

--- a/github/commands/open_on_remote.py
+++ b/github/commands/open_on_remote.py
@@ -41,7 +41,7 @@ class GsGithubOpenFileOnRemoteCommand(TextCommand, git_mixins.GithubRemotesMixin
         if remote:
             self.open_file_on_remote(remote)
         else:
-            show_remote_panel(self.open_file_on_remote)
+            show_remote_panel(self.open_file_on_remote, allow_direct=True)
 
     def open_file_on_remote(self, remote):
         fpath = self.fpath
@@ -120,7 +120,7 @@ class GsGithubOpenRepoCommand(TextCommand, git_mixins.GithubRemotesMixin, GitCom
         if remote:
             open_repo(self.remotes[remote])
         else:
-            show_remote_panel(self.on_remote_selection)
+            show_remote_panel(self.on_remote_selection, allow_direct=True)
 
     def on_remote_selection(self, remote):
         open_repo(self.remotes[remote])

--- a/gitlab/commands/open_on_remote.py
+++ b/gitlab/commands/open_on_remote.py
@@ -40,7 +40,7 @@ class GsGitlabOpenFileOnRemoteCommand(TextCommand, GitCommand, GitLabRemotesMixi
         if remote:
             self.open_file_on_remote(remote)
         else:
-            show_remote_panel(self.open_file_on_remote)
+            show_remote_panel(self.open_file_on_remote, allow_direct=True)
 
     def open_file_on_remote(self, remote):
         fpath = self.fpath
@@ -116,7 +116,7 @@ class GsGitlabOpenRepoCommand(TextCommand, GitCommand, GitLabRemotesMixin):
         if remote:
             open_repo(self.remotes[remote])
         else:
-            show_remote_panel(self.on_remote_selection)
+            show_remote_panel(self.on_remote_selection, allow_direct=True)
 
     def on_remote_selection(self, remote):
         open_repo(self.remotes[remote])


### PR DESCRIPTION
`allow_direct` has been introduced by #791.  If `True` we will not ask
the user for a remote if there is only one configured.

We hereby turn this on for more commands, actually as suggested in
https://github.com/timbrel/GitSavvy/pull/791#issuecomment-338007502

See also the recent #1411