### PR TITLE
Streamline push

### DIFF
--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -229,12 +229,6 @@
     "max_items_in_tags_dashboard": -1,
 
     /*
-        When set to `true`, GitSavvy will offer to set the upstream on `git: push`
-        when tracking branch is not configured.
-     */
-    "prompt_for_tracking_branch": true,
-
-    /*
         When set to `true`, GitSavvy will automatically display more info about the
         current commit in a output panel.
      */

--- a/core/base_commands.py
+++ b/core/base_commands.py
@@ -14,9 +14,9 @@ MYPY = False
 if MYPY:
     from typing import Any, Callable, Dict, Iterator, List, TypeVar
     CommandT = TypeVar("CommandT", bound=sublime_plugin.Command)
-    Kont = Callable[[object], None]
-    ArgProvider = Callable[[CommandT, Kont], None]
     Args = Dict[str, Any]
+    Kont = Callable[[object], None]
+    ArgProvider = Callable[[CommandT, Args, Kont], None]
 
 
 class WithProvideWindow:
@@ -63,7 +63,7 @@ class WithInputHandlers:
                     name
                 )
                 with sync_mode.set():
-                    self.defaults[name](self, done)
+                    self.defaults[name](self, args, done)
                 if not done.called:
                     break
         else:
@@ -127,14 +127,14 @@ class GsTextCommand(
     WithProvideWindow,
     sublime_plugin.TextCommand,
 ):
-    defaults = {}  # type: Dict[str, Callable[[GsTextCommand, Kont], None]]
+    defaults = {}  # type: Dict[str, Callable[[GsTextCommand, Args, Kont], None]]
 
 
 class GsWindowCommand(
     WithInputHandlers,
     sublime_plugin.WindowCommand,
 ):
-    defaults = {}  # type: Dict[str, Callable[[GsWindowCommand, Kont], None]]
+    defaults = {}  # type: Dict[str, Callable[[GsWindowCommand, Args, Kont], None]]
 
 
 if MYPY:
@@ -145,8 +145,8 @@ if MYPY:
 # COMMON INPUT HANDLERS
 
 
-def ask_for_local_branch(self, done):
-    # type: (GsCommand, Kont) -> None
+def ask_for_local_branch(self, args, done):
+    # type: (GsCommand, Args, Kont) -> None
     def on_done(branch):
         done(branch)
 

--- a/core/commands/log_graph_rebase_actions.py
+++ b/core/commands/log_graph_rebase_actions.py
@@ -45,7 +45,7 @@ if MYPY:
         Optional,
         Tuple
     )
-    from GitSavvy.core.base_commands import GsCommand, Kont
+    from GitSavvy.core.base_commands import GsCommand, Args, Kont
 
     RebaseItem = NamedTuple("RebaseItem", [
         ("action", str),
@@ -78,8 +78,8 @@ def commitish_from_info(info):
     )
 
 
-def extract_symbol_from_graph(self, done):
-    # type: (GsCommand, Kont) -> None
+def extract_symbol_from_graph(self, args, done):
+    # type: (GsCommand, Args, Kont) -> None
     view = get_view_for_command(self)
     if not view:
         return
@@ -98,13 +98,13 @@ def extract_symbol_from_graph(self, done):
     done(symbol)
 
 
-def extract_parent_symbol_from_graph(self, done):
-    # type: (GsCommand, Kont) -> None
-    extract_symbol_from_graph(self, lambda symbol: done("{}^".format(symbol)))
+def extract_parent_symbol_from_graph(self, args, done):
+    # type: (GsCommand, Args, Kont) -> None
+    extract_symbol_from_graph(self, args, lambda symbol: done("{}^".format(symbol)))
 
 
-def extract_commit_hash_from_graph(self, done):
-    # type: (GsCommand, Kont) -> None
+def extract_commit_hash_from_graph(self, args, done):
+    # type: (GsCommand, Args, Kont) -> None
     view = get_view_for_command(self)
     if not view:
         return

--- a/core/commands/push.py
+++ b/core/commands/push.py
@@ -60,7 +60,7 @@ class gs_push(PushBase):
     def run(self, local_branch_name=None, force=False, force_with_lease=False):
         # type: (str, bool, bool) -> None
         if local_branch_name:
-            local_branch = self.get_local_branch(local_branch_name)
+            local_branch = self.get_local_branch_by_name(local_branch_name)
             if not local_branch:
                 sublime.message_dialog("'{}' is not a local branch name.")
                 return

--- a/core/commands/push.py
+++ b/core/commands/push.py
@@ -142,6 +142,11 @@ def ask_for_branch_name(caption, initial_text):
     return handler
 
 
+def ask_for_remote_branch(self, args, done):
+    # type: (GsWindowCommand, Args, Kont) -> None
+    show_branch_panel(done, ask_remote_first=True)
+
+
 class gs_push_to_branch_name(PushBase):
     """
     Prompt for remote and remote branch name, then push.
@@ -180,22 +185,17 @@ class gs_push_to_branch(PushBase):
     """
     Through a series of panels, allow the user to push to a specific remote branch.
     """
+    defaults = {
+        "local_branch_name": take_current_branch_name,  # type: ignore[dict-item]
+        "remote_branch": ask_for_remote_branch
+    }
 
-    def run(self):
-        # type: () -> None
-        enqueue_on_worker(self.run_async)
-
-    def run_async(self):
-        # type: () -> None
-        show_branch_panel(self.on_branch_selection, ask_remote_first=True)
-
-    def on_branch_selection(self, branch):
-        # type: (str) -> None
-        current_local_branch = self.get_current_branch_name()
-        selected_remote, selected_branch = branch.split("/", 1)
+    def run(self, local_branch_name, remote_branch):
+        # type: (str, str) -> None
+        remote, branch_name = remote_branch.split("/", 1)
         enqueue_on_worker(
             self.do_push,
-            selected_remote,
-            current_local_branch,
-            remote_branch=selected_branch
+            remote,
+            local_branch_name,
+            remote_branch=branch_name
         )

--- a/core/commands/push.py
+++ b/core/commands/push.py
@@ -106,28 +106,6 @@ class gs_push(PushBase):
             })
 
 
-class gs_push_to_branch(PushBase):
-    """
-    Through a series of panels, allow the user to push to a specific remote branch.
-    """
-
-    def run(self):
-        enqueue_on_worker(self.run_async)
-
-    def run_async(self):
-        show_branch_panel(self.on_branch_selection, ask_remote_first=True)
-
-    def on_branch_selection(self, branch):
-        current_local_branch = self.get_current_branch_name()
-        selected_remote, selected_branch = branch.split("/", 1)
-        enqueue_on_worker(
-            self.do_push,
-            selected_remote,
-            current_local_branch,
-            remote_branch=selected_branch
-        )
-
-
 class gs_push_to_branch_name(PushBase):
     """
     Prompt for remote and remote branch name, then push.
@@ -182,4 +160,26 @@ class gs_push_to_branch_name(PushBase):
             remote_branch=branch,
             force=self.force,
             force_with_lease=self.force_with_lease
+        )
+
+
+class gs_push_to_branch(PushBase):
+    """
+    Through a series of panels, allow the user to push to a specific remote branch.
+    """
+
+    def run(self):
+        enqueue_on_worker(self.run_async)
+
+    def run_async(self):
+        show_branch_panel(self.on_branch_selection, ask_remote_first=True)
+
+    def on_branch_selection(self, branch):
+        current_local_branch = self.get_current_branch_name()
+        selected_remote, selected_branch = branch.split("/", 1)
+        enqueue_on_worker(
+            self.do_push,
+            selected_remote,
+            current_local_branch,
+            remote_branch=selected_branch
         )

--- a/core/commands/push.py
+++ b/core/commands/push.py
@@ -28,6 +28,7 @@ class PushBase(WindowCommand, GitCommand):
     set_upstream = False
 
     def do_push(self, remote, branch, force=False, force_with_lease=False, remote_branch=None):
+        # type: (str, str, bool, bool, str) -> None
         """
         Perform `git push remote branch`.
         """
@@ -119,6 +120,7 @@ class gs_push_to_branch_name(PushBase):
         force=False,
         force_with_lease=False
     ):
+        # type: (str, str, bool, bool, bool) -> None
         if local_branch_name:
             self.local_branch_name = local_branch_name
         else:
@@ -131,9 +133,11 @@ class gs_push_to_branch_name(PushBase):
         enqueue_on_worker(self.run_async)
 
     def run_async(self):
+        # type: () -> None
         show_remote_panel(self.on_remote_selection, allow_direct=True)
 
     def on_remote_selection(self, remote):
+        # type: (str) -> None
         """
         After the user selects a remote, maybe prompt the user for a branch name.
         """
@@ -149,6 +153,7 @@ class gs_push_to_branch_name(PushBase):
             )
 
     def on_entered_branch_name(self, branch):
+        # type: (str) -> None
         """
         Push to the remote that was previously selected and provided branch
         name.
@@ -169,12 +174,15 @@ class gs_push_to_branch(PushBase):
     """
 
     def run(self):
+        # type: () -> None
         enqueue_on_worker(self.run_async)
 
     def run_async(self):
+        # type: () -> None
         show_branch_panel(self.on_branch_selection, ask_remote_first=True)
 
     def on_branch_selection(self, branch):
+        # type: (str) -> None
         current_local_branch = self.get_current_branch_name()
         selected_remote, selected_branch = branch.split("/", 1)
         enqueue_on_worker(

--- a/core/commands/push.py
+++ b/core/commands/push.py
@@ -18,7 +18,6 @@ __all__ = (
 )
 
 
-START_PUSH_MESSAGE = "Starting push..."
 END_PUSH_MESSAGE = "Push complete."
 CONFIRM_FORCE_PUSH = ("You are about to `git push {}`. Would you  "
                       "like to proceed?")
@@ -40,7 +39,7 @@ class PushBase(WindowCommand, GitCommand):
                 if not sublime.ok_cancel_dialog(CONFIRM_FORCE_PUSH.format("--force-with-lease")):
                     return
 
-        self.window.status_message(START_PUSH_MESSAGE)
+        self.window.status_message("Pushing {} to {}...".format(branch, remote))
         self.push(
             remote,
             branch,

--- a/core/commands/push.py
+++ b/core/commands/push.py
@@ -49,10 +49,10 @@ class PushBase(WindowCommand, GitCommand):
         self.push(
             remote,
             branch,
-            set_upstream=self.set_upstream,
+            remote_branch=remote_branch,
             force=force,
             force_with_lease=force_with_lease,
-            remote_branch=remote_branch
+            set_upstream=set_upstream
         )
         self.window.status_message(END_PUSH_MESSAGE)
         util.view.refresh_gitsavvy(self.window.active_view())

--- a/core/commands/push.py
+++ b/core/commands/push.py
@@ -55,7 +55,7 @@ class PushBase(WindowCommand, GitCommand):
             set_upstream=set_upstream
         )
         self.window.status_message(END_PUSH_MESSAGE)
-        util.view.refresh_gitsavvy(self.window.active_view())
+        util.view.refresh_gitsavvy_interfaces(self.window)
 
 
 class gs_push(PushBase):

--- a/core/commands/push.py
+++ b/core/commands/push.py
@@ -20,8 +20,6 @@ __all__ = (
 
 START_PUSH_MESSAGE = "Starting push..."
 END_PUSH_MESSAGE = "Push complete."
-SET_UPSTREAM_PROMPT = ("You have not set an upstream for the active branch.  "
-                       "Would you like to set one?")
 CONFIRM_FORCE_PUSH = ("You are about to `git push {}`. Would you  "
                       "like to proceed?")
 
@@ -99,10 +97,7 @@ class gs_push(PushBase):
             else:
                 kont()
 
-        elif (
-            not self.savvy_settings.get("prompt_for_tracking_branch") or
-            sublime.ok_cancel_dialog(SET_UPSTREAM_PROMPT)
-        ):
+        else:
             self.window.run_command("gs_push_to_branch_name", {
                 "local_branch_name": local_branch.name,
                 "set_upstream": True,

--- a/core/commands/push.py
+++ b/core/commands/push.py
@@ -24,10 +24,16 @@ CONFIRM_FORCE_PUSH = ("You are about to `git push {}`. Would you  "
 
 
 class PushBase(WindowCommand, GitCommand):
-    set_upstream = False
-
-    def do_push(self, remote, branch, force=False, force_with_lease=False, remote_branch=None):
-        # type: (str, str, bool, bool, str) -> None
+    def do_push(
+        self,
+        remote,
+        branch,
+        force=False,
+        force_with_lease=False,
+        remote_branch=None,
+        set_upstream=False
+    ):
+        # type: (str, str, bool, bool, str, bool) -> None
         """
         Perform `git push remote branch`.
         """
@@ -163,7 +169,8 @@ class gs_push_to_branch_name(PushBase):
             self.local_branch_name,
             remote_branch=branch,
             force=self.force,
-            force_with_lease=self.force_with_lease
+            force_with_lease=self.force_with_lease,
+            set_upstream=self.set_upstream
         )
 
 

--- a/core/commands/push.py
+++ b/core/commands/push.py
@@ -100,20 +100,12 @@ class gs_push(PushBase):
             else:
                 kont()
 
-        elif self.savvy_settings.get("prompt_for_tracking_branch"):
-            if sublime.ok_cancel_dialog(SET_UPSTREAM_PROMPT):
-                self.window.run_command("gs_push_to_branch_name", {
-                    "local_branch_name": local_branch.name,
-                    "set_upstream": True,
-                    "force": force,
-                    "force_with_lease": force_with_lease
-                })
-        else:
-            # If `prompt_for_tracking_branch` is false, ask for a remote and
-            # push current branch to a remote branch with the same name
+        elif (
+            not self.savvy_settings.get("prompt_for_tracking_branch") or
+            sublime.ok_cancel_dialog(SET_UPSTREAM_PROMPT)
+        ):
             self.window.run_command("gs_push_to_branch_name", {
                 "local_branch_name": local_branch.name,
-                "branch_name": local_branch.name,
                 "set_upstream": True,
                 "force": force,
                 "force_with_lease": force_with_lease

--- a/core/commands/push.py
+++ b/core/commands/push.py
@@ -20,7 +20,6 @@ __all__ = (
 
 START_PUSH_MESSAGE = "Starting push..."
 END_PUSH_MESSAGE = "Push complete."
-PUSH_TO_BRANCH_NAME_PROMPT = "Enter remote branch name:"
 SET_UPSTREAM_PROMPT = ("You have not set an upstream for the active branch.  "
                        "Would you like to set one?")
 CONFIRM_FORCE_PUSH = ("You are about to `git push {}`. Would you  "
@@ -163,7 +162,7 @@ class gs_push_to_branch_name(PushBase):
 
     def on_remote_selection(self, remote):
         """
-        After the user selects a remote, prompt the user for a branch name.
+        After the user selects a remote, maybe prompt the user for a branch name.
         """
         self.selected_remote = remote
 
@@ -171,7 +170,7 @@ class gs_push_to_branch_name(PushBase):
             self.on_entered_branch_name(self.branch_name)
         else:
             show_single_line_input_panel(
-                PUSH_TO_BRANCH_NAME_PROMPT,
+                "Push to {}/".format(remote),
                 self.local_branch_name,
                 self.on_entered_branch_name
             )

--- a/core/git_mixins/branches.py
+++ b/core/git_mixins/branches.py
@@ -32,7 +32,7 @@ class BranchesMixin(mixin_base):
                 return branch
         return None
 
-    def get_local_branch(self, branch_name):
+    def get_local_branch_by_name(self, branch_name):
         # type: (str) -> Optional[Branch]
         """
         Get a local Branch tuple from branch name.

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -432,7 +432,7 @@ class GsBranchesFetchAndMergeCommand(TextCommand, GitCommand):
         for branch in branches:
             if branch[0] is None:
                 # update local branches which have tracking remote
-                local_branch = self.get_local_branch(branch[1])
+                local_branch = self.get_local_branch_by_name(branch[1])
                 if local_branch.tracking:
                     remote, remote_branch = local_branch.tracking.split("/", 1)
                     self.fetch(remote=remote, branch=branch[1], remote_branch=remote_branch)

--- a/core/ui_mixins/quick_panel.py
+++ b/core/ui_mixins/quick_panel.py
@@ -6,6 +6,11 @@ from GitSavvy.core.fns import filter_
 from GitSavvy.core import store
 
 
+MYPY = False
+if MYPY:
+    from typing import Callable
+
+
 class PanelActionMixin(object):
     """
     Use this mixin to initially display a quick panel, select from pre-defined
@@ -116,13 +121,14 @@ class PanelCommandMixin(PanelActionMixin):
 
 
 def show_remote_panel(
-    on_done,
+    on_done,  # type: Callable[[str], None]
     *,
-    on_cancel=lambda: None,
-    show_option_all=False,
-    allow_direct=False,
-    show_url=False
+    on_cancel=lambda: None,  # type: Callable[[], None]
+    show_option_all=False,  # type: bool
+    allow_direct=False,  # type: bool
+    show_url=False  # type: bool
 ):
+    # type: (...) -> RemotePanel
     """
     Show a quick panel with remotes. The callback `on_done(remote)` will
     be called when a remote is selected. If the panel is cancelled, `None`
@@ -147,12 +153,13 @@ class RemotePanel(GitCommand):
 
     def __init__(
         self,
-        on_done,
-        on_cancel=lambda: None,
-        show_option_all=False,
-        allow_direct=False,
-        show_url=False
+        on_done,  # type: Callable[[str], None]
+        on_cancel=lambda: None,  # type: Callable[[], None]
+        show_option_all=False,  # type: bool
+        allow_direct=False,  # type: bool
+        show_url=False  # type: bool
     ):
+        # type: (...) -> None
         self.window = sublime.active_window()
         self.on_done = on_done
         self.on_cancel = on_cancel
@@ -161,6 +168,7 @@ class RemotePanel(GitCommand):
         self.show_url = show_url
 
     def show(self):
+        # type: () -> None
         _remotes = self.get_remotes()
         self.remotes = list(_remotes.keys())
 
@@ -189,6 +197,7 @@ class RemotePanel(GitCommand):
         )
 
     def on_remote_selection(self, index):
+        # type: (int) -> None
         if index == -1:
             self.on_cancel()
         elif self.show_option_all and len(self.remotes) > 1 and index == 0:

--- a/docs/remotes.md
+++ b/docs/remotes.md
@@ -31,7 +31,7 @@ Like `git: pull from branch`, but rebasing on the remote branch instead of mergi
 
 ## `git: push`
 
-This command will push current branch to the tracking branch. If the tracking branch is not set, you will be asked to configure it unless `prompt_for_tracking_branch` is set to `false`. In that case, you will be prompted for a remote, then the current branch will be pushed to a remote branch with the same name.
+This command will push current branch to the tracking branch. If the tracking branch is not set, you will be prompted for a remote and a branch name.
 
 ## `git: push to branch`
 

--- a/github/commands/pull_request.py
+++ b/github/commands/pull_request.py
@@ -182,7 +182,10 @@ class GsGithubCreatePullRequestCommand(WindowCommand, git_mixins.GithubRemotesMi
             return
 
         if not current_branch.tracking:
-            if sublime.ok_cancel_dialog(PUSH_PROMPT):
+            if (
+                not self.savvy_settings.get("prompt_for_tracking_branch")
+                or sublime.ok_cancel_dialog(PUSH_PROMPT)
+            ):
                 self.window.run_command("gs_github_push_and_create_pull_request", {
                     "local_branch_name": current_branch.name,
                     "set_upstream": True

--- a/github/commands/pull_request.py
+++ b/github/commands/pull_request.py
@@ -19,10 +19,6 @@ if MYPY:
     from GitSavvy.core.git_mixins.branches import Branch
 
 
-PUSH_PROMPT = ("You have not set an upstream for the active branch.  "
-               "Would you like to push to a remote?")
-
-
 class GsGithubPullRequestCommand(WindowCommand, git_mixins.GithubRemotesMixin, GitCommand):
 
     """
@@ -182,14 +178,10 @@ class GsGithubCreatePullRequestCommand(WindowCommand, git_mixins.GithubRemotesMi
             return
 
         if not current_branch.tracking:
-            if (
-                not self.savvy_settings.get("prompt_for_tracking_branch")
-                or sublime.ok_cancel_dialog(PUSH_PROMPT)
-            ):
-                self.window.run_command("gs_github_push_and_create_pull_request", {
-                    "local_branch_name": current_branch.name,
-                    "set_upstream": True
-                })
+            self.window.run_command("gs_github_push_and_create_pull_request", {
+                "local_branch_name": current_branch.name,
+                "set_upstream": True
+            })
 
         elif (
             "ahead" in current_branch.tracking_status


### PR DESCRIPTION
Fixes #1411 

- Remove setting "prompt_for_tracking_branch". 

a) If there is only one remote, take it.  Ask for the remote branch name, but the input handler is prefilled with the name of the current branch.  That essentially leads to one `<enter>` to push. 

b) With more remotes, we first ask for the remote, then for the branch name, again prefilled with the name of the current branch.  Ideally, coming down to two `<enter>`s.  

At any time `ESC` aborts the process.  `-u` is always set. 

If we'd just take the local branch name for granted, we could go to no question, t.i. an immediate push, if there is only one remote.  I don't think that this is a good idea. 

For b) we came down from two to one question because we would pause the process with the remote question.  But the flow would be a bit inconsistent, and it's harder to code.

See https://github.com/timbrel/GitSavvy/issues/1411#issuecomment-723199764 for a different workflow idea. 


~We could leave the setting and just flip its default for a trial.~ Angsthasensetting

- Further refactor `push.py` and use the new default handlers that comes with `GsWindowCommand`.   