### PR TITLE
Enhance `last_remote_used`  

### DIFF
--- a/core/commands/fetch.py
+++ b/core/commands/fetch.py
@@ -1,9 +1,8 @@
-from sublime_plugin import WindowCommand
-
 from ..git_command import GitCommand
 from ..runtime import enqueue_on_worker
 from ...common import util
 from ..ui_mixins.quick_panel import show_remote_panel
+from GitSavvy.core.base_commands import GsWindowCommand
 
 
 __all__ = (
@@ -11,31 +10,37 @@ __all__ = (
 )
 
 
-class gs_fetch(WindowCommand, GitCommand):
+MYPY = False
+if MYPY:
+    from GitSavvy.core.base_commands import Args, Kont
 
+
+def ask_for_remote(cmd, args, done):
+    # type: (GsWindowCommand, Args, Kont) -> None
+    show_remote_panel(done, allow_direct=True, show_option_all=True)
+
+
+class gs_fetch(GsWindowCommand, GitCommand):
     """
     Display a panel of all git remotes for active repository and
     do a `git fetch` asynchronously.
     """
+    defaults = {
+        "remote": ask_for_remote
+    }
 
-    def run(self, remote=None):
-        if remote:
-            return enqueue_on_worker(self.do_fetch, remote)
+    def run(self, remote):
+        # type: (str) -> None
+        enqueue_on_worker(self.do_fetch, remote)
 
-        show_remote_panel(self.on_remote_selection, show_option_all=True, allow_direct=True)
-
-    def on_remote_selection(self, remote):
-        if remote == "<ALL>":
-            enqueue_on_worker(self.do_fetch)
-        else:
-            enqueue_on_worker(self.do_fetch, remote)
-
-    def do_fetch(self, remote=None):
-        if remote is None:
+    def do_fetch(self, remote):
+        # type: (str) -> None
+        fetch_all = remote == "<ALL>"
+        if fetch_all:
             self.window.status_message("Start fetching all remotes...")
         else:
             self.window.status_message("Start fetching {}...".format(remote))
 
-        self.fetch(remote)
+        self.fetch(None if fetch_all else remote)
         self.window.status_message("Fetch complete.")
         util.view.refresh_gitsavvy(self.window.active_view())

--- a/core/commands/fetch.py
+++ b/core/commands/fetch.py
@@ -43,4 +43,4 @@ class gs_fetch(GsWindowCommand, GitCommand):
 
         self.fetch(None if fetch_all else remote)
         self.window.status_message("Fetch complete.")
-        util.view.refresh_gitsavvy(self.window.active_view())
+        util.view.refresh_gitsavvy_interfaces(self.window)

--- a/core/commands/fetch.py
+++ b/core/commands/fetch.py
@@ -25,7 +25,7 @@ class gs_fetch(WindowCommand, GitCommand):
         show_remote_panel(self.on_remote_selection, show_option_all=True, allow_direct=True)
 
     def on_remote_selection(self, remote):
-        if remote is True:
+        if remote == "<ALL>":
             enqueue_on_worker(self.do_fetch)
         else:
             enqueue_on_worker(self.do_fetch, remote)

--- a/core/store.py
+++ b/core/store.py
@@ -13,6 +13,7 @@ if MYPY:
         'RepoStore',
         {
             "last_remote_used": Optional[str],
+            "last_remote_used_with_option_all": Optional[str],
             "short_hash_length": int,
         },
         total=False

--- a/core/ui_mixins/quick_panel.py
+++ b/core/ui_mixins/quick_panel.py
@@ -135,7 +135,7 @@ def show_remote_panel(
     will be passed to `on_done`.
 
     on_done: a callable
-    show_option_all: whether the option "All remotes" should be shown. `True` will
+    show_option_all: whether the option "All remotes" should be shown. `<ALL>` will
                 be passed to `on_done` if the all remotes option is selected.
     """
     rp = RemotePanel(
@@ -207,7 +207,7 @@ class RemotePanel(GitCommand):
             self.on_cancel()
         elif self.show_option_all and len(self.remotes) > 1 and index == 0:
             store.update_state(self.repo_path, {self.storage_key: "<ALL>"})  # type: ignore[misc]
-            self.on_done(True)
+            self.on_done("<ALL>")
         else:
             remote = self.remotes[index]
             store.update_state(self.repo_path, {self.storage_key: remote})  # type: ignore[misc]

--- a/core/ui_mixins/quick_panel.py
+++ b/core/ui_mixins/quick_panel.py
@@ -166,6 +166,11 @@ class RemotePanel(GitCommand):
         self.show_option_all = show_option_all
         self.allow_direct = allow_direct
         self.show_url = show_url
+        self.storage_key = (
+            "last_remote_used_with_option_all"
+            if self.show_option_all
+            else "last_remote_used"
+        )
 
     def show(self):
         # type: () -> None
@@ -183,7 +188,7 @@ class RemotePanel(GitCommand):
         if self.show_option_all and len(self.remotes) > 1:
             self.remotes.insert(0, "All remotes.")
 
-        last_remote_used = store.current_state(self.repo_path).get("last_remote_used")
+        last_remote_used = store.current_state(self.repo_path).get(self.storage_key, "origin")
         if last_remote_used in self.remotes:
             pre_selected_index = self.remotes.index(last_remote_used)
         else:
@@ -201,11 +206,11 @@ class RemotePanel(GitCommand):
         if index == -1:
             self.on_cancel()
         elif self.show_option_all and len(self.remotes) > 1 and index == 0:
-            store.update_state(self.repo_path, {"last_remote_used": None})
+            store.update_state(self.repo_path, {self.storage_key: "<ALL>"})  # type: ignore[misc]
             self.on_done(True)
         else:
             remote = self.remotes[index]
-            store.update_state(self.repo_path, {"last_remote_used": remote})
+            store.update_state(self.repo_path, {self.storage_key: remote})  # type: ignore[misc]
             self.on_done(remote)
 
 


### PR DESCRIPTION
With "show_option_all" the panel gets an imaginary first item, namely
"All...".  We want to make it possible to save this selection, and to
not interfere with all other remote panels which do not set this option.
(Currently, only `gs_fetch` uses it.)

For example, we want to support a user always fetching all but pushing
to (of course) a specific remote.

Enhances #791. We change the initial value back to the common "origin"
in all cases.  Generally, fetching all does not scale, and it is an
edge-case feature.