### PR TITLE
Add "Make fixup commit" to the rebase menu

### DIFF
--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -82,7 +82,7 @@ class gs_commit(WindowCommand, GitCommand):
     message area with the previous commit message.
     """
 
-    def run(self, repo_path=None, include_unstaged=False, amend=False):
+    def run(self, repo_path=None, include_unstaged=False, amend=False, initial_text=""):
         repo_path = repo_path or self.repo_path
 
         this_id = (
@@ -113,10 +113,10 @@ class gs_commit(WindowCommand, GitCommand):
             title = COMMIT_TITLE.format(os.path.basename(repo_path))
             view.set_name(title)
             view.set_scratch(True)  # ignore dirty on actual commit
-            self.initialize_view(view, include_unstaged, amend)
+            self.initialize_view(view, include_unstaged, amend, initial_text)
 
-    def initialize_view(self, view, include_unstaged, amend):
-        # type: (sublime.View, bool, bool) -> None
+    def initialize_view(self, view, include_unstaged, amend, initial_text):
+        # type: (sublime.View, bool, bool, str) -> None
         merge_msg_path = os.path.join(self.repo_path, ".git", "MERGE_MSG")
 
         help_text = (
@@ -125,7 +125,9 @@ class gs_commit(WindowCommand, GitCommand):
             else COMMIT_HELP_TEXT
         )
 
-        if amend:
+        if initial_text:
+            initial_text += help_text
+        elif amend:
             last_commit_message = self.git("log", "-1", "--pretty=%B").strip()
             initial_text = last_commit_message + help_text
         elif os.path.exists(merge_msg_path):

--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -113,10 +113,10 @@ class gs_commit(WindowCommand, GitCommand):
             title = COMMIT_TITLE.format(os.path.basename(repo_path))
             view.set_name(title)
             view.set_scratch(True)  # ignore dirty on actual commit
-            self.initialize_view(view, include_unstaged, amend, initial_text)
+            self.initialize_view(view, amend, initial_text)
 
-    def initialize_view(self, view, include_unstaged, amend, initial_text):
-        # type: (sublime.View, bool, bool, str) -> None
+    def initialize_view(self, view, amend, initial_text):
+        # type: (sublime.View, bool, str) -> None
         merge_msg_path = os.path.join(self.repo_path, ".git", "MERGE_MSG")
 
         help_text = (

--- a/core/commands/log_graph_rebase_actions.py
+++ b/core/commands/log_graph_rebase_actions.py
@@ -189,6 +189,10 @@ class gs_rebase_action(GsWindowCommand, GitCommand):
                 "Drop commit",
                 partial(self.drop, view, commit_hash)
             ),
+            (
+                "Make fixup commit for {}".format(commit_hash),
+                partial(self.create_fixup_commit, commit_hash)
+            ),
             SEPARATOR,
         ]
 
@@ -237,6 +241,12 @@ class gs_rebase_action(GsWindowCommand, GitCommand):
             flags=sublime.MONOSPACE_FONT,
             selected_index=self.selected_index,
         )
+
+    def create_fixup_commit(self, commit_hash):
+        commit_message = self.git("log", "-1", "--pretty=format:%s", commit_hash).strip()
+        self.window.run_command("gs_commit", {
+            "initial_text": "fixup! {}".format(commit_message)
+        })
 
     def apply_fixup(self, view, base_commit, fixup_commits):
         view.run_command("gs_rebase_apply_fixup", {


### PR DESCRIPTION
Fixes #1355

As suggested in #1355, add a menu entry to "create" a fixup commit from the Repo History.  

In reality, we don't actually "create" the commit but rather prepare the commit message and then open the commit view.  Another `ctrl+enter` will then create the commit. 

This need some discipline as a user might select the option here prior editing, saving and staging the wanted change.  It totally feels like a very useful, "correct" option though here in this menu.  Maybe further tweaking is necessary.   