### PR TITLE
Rewrite throttler for the status bar

### DIFF
--- a/common/global_events.py
+++ b/common/global_events.py
@@ -9,6 +9,7 @@ from ..core.utils import focus_view
 
 
 IGNORE_NEXT_ACTIVATE = False
+SEEN = set()
 
 
 class GsInterfaceFocusEventListener(EventListener):
@@ -30,16 +31,18 @@ class GsInterfaceFocusEventListener(EventListener):
 
     def on_activated(self, view):
         global IGNORE_NEXT_ACTIVATE
-        if IGNORE_NEXT_ACTIVATE:
+        vid = view.id()
+        if vid in SEEN and IGNORE_NEXT_ACTIVATE:
             return
 
         if view.settings().get("is_widget"):
             return
 
-        # status bar is handled by GsStatusBarEventListener
-        util.view.refresh_gitsavvy(view, refresh_status_bar=False)
+        SEEN.add(vid)
+        util.view.refresh_gitsavvy(view)
 
     def on_close(self, view):
+        SEEN.discard(view.id())
         util.view.handle_closed_view(view)
 
 

--- a/common/util/debug.py
+++ b/common/util/debug.py
@@ -1,4 +1,3 @@
-from contextlib import contextmanager
 import functools
 import json
 import pprint as _pprint
@@ -27,17 +26,6 @@ def start_logging():
 def stop_logging():
     global enabled
     enabled = False
-
-
-@contextmanager
-def disable_logging():
-    global enabled
-    previous_state = enabled
-    enabled = False
-    try:
-        yield
-    finally:
-        enabled = previous_state
 
 
 def get_log():

--- a/core/commands/status_bar.py
+++ b/core/commands/status_bar.py
@@ -6,10 +6,8 @@ from ..git_command import GitCommand
 
 
 class GsStatusBarEventListener(EventListener):
+    # Note: `on_activated` is registered in global_events.py
     def on_new_async(self, view):
-        view.run_command("gs_update_status_bar")
-
-    def on_activated_async(self, view):
         view.run_command("gs_update_status_bar")
 
     def on_post_save(self, view):

--- a/core/commands/status_bar.py
+++ b/core/commands/status_bar.py
@@ -1,21 +1,16 @@
-import time
-import sublime
 from sublime_plugin import TextCommand, EventListener
 
 from ..git_command import GitCommand
+from ..runtime import enqueue_on_worker, throttled
 
 
 class GsStatusBarEventListener(EventListener):
     # Note: `on_activated` is registered in global_events.py
-    def on_new_async(self, view):
+    def on_new(self, view):
         view.run_command("gs_update_status_bar")
 
     def on_post_save(self, view):
         view.run_command("gs_update_status_bar")
-
-
-last_execution = 0
-update_status_bar_soon = False
 
 
 def view_is_transient(view):
@@ -43,30 +38,15 @@ class GsUpdateStatusBarCommand(TextCommand, GitCommand):
     """
 
     def run(self, edit):
-        if view_is_transient(self.view):
+        enqueue_on_worker(throttled(self.run_impl, self.view))
+
+    def run_impl(self, view):
+        if view_is_transient(view):
             return
 
-        global last_execution, update_status_bar_soon
-        if self.savvy_settings.get("git_status_in_status_bar"):
+        if not self.savvy_settings.get("git_status_in_status_bar"):
+            return
 
-            millisec = int(round(time.time() * 1000))
-            # If we updated to less then 100 ms we don't need to update now but
-            # should update in 100 ms in case of current file change.
-            #
-            # So if this get called 4 timer with 20 ms in between each call
-            # it will only update twice. Once at time 0 and one at time 100
-            # even if it got called at 0, 20, 40, 60 and 80.
-
-            if millisec - 100 > last_execution:
-                sublime.set_timeout_async(self.run_async, 0)
-            else:
-                if not update_status_bar_soon:
-                    update_status_bar_soon = True
-                    sublime.set_timeout_async(self.run_async, 100)
-
-            last_execution = int(round(time.time() * 1000))
-
-    def run_async(self):
         # Ignore all possible errors
         try:
             self.get_repo_path(offer_init=False)
@@ -74,6 +54,3 @@ class GsUpdateStatusBarCommand(TextCommand, GitCommand):
             self.view.set_status("gitsavvy-repo-status", short_status)
         except Exception:
             self.view.erase_status("gitsavvy-repo-status")
-
-        global update_status_bar_soon
-        update_status_bar_soon = False

--- a/core/commands/status_bar.py
+++ b/core/commands/status_bar.py
@@ -3,7 +3,6 @@ import sublime
 from sublime_plugin import TextCommand, EventListener
 
 from ..git_command import GitCommand
-from ...common.util import debug
 
 
 class GsStatusBarEventListener(EventListener):
@@ -70,15 +69,13 @@ class GsUpdateStatusBarCommand(TextCommand, GitCommand):
             last_execution = int(round(time.time() * 1000))
 
     def run_async(self):
-        # disable logging and git raise error
-        with debug.disable_logging():
-            # ignore all other possible errors
-            try:
-                self.get_repo_path(offer_init=False)  # check for ValueError
-                short_status = self.get_branch_status_short()
-                self.view.set_status("gitsavvy-repo-status", short_status)
-            except Exception:
-                self.view.erase_status("gitsavvy-repo-status")
+        # Ignore all possible errors
+        try:
+            self.get_repo_path(offer_init=False)
+            short_status = self.get_branch_status_short()
+            self.view.set_status("gitsavvy-repo-status", short_status)
+        except Exception:
+            self.view.erase_status("gitsavvy-repo-status")
 
         global update_status_bar_soon
         update_status_bar_soon = False


### PR DESCRIPTION
Fixes #1094

The old throttler had a 100ms wait time but this is not a functionality
we need here. E.g. if you create a new view, Sublime puts two events on
the queue, namely 'on_new' and 'on_activated'.

By using the `runtime.throttler` we ensure that only one task on the
worker wins and gets executed.

Note that the implementation does not differentiate between different
views, windows, or repo paths. So there is a risk to undercall now.
Although it is very unlikely to get multiple triggers from different
sources in exactly one task, we capture and merge such events until the
worker thread is ready again which can be at any time in the future.
Note though that the *last* event wins in such cases.

This is not the best we can do, merely a baby step.  #1151 was ahead of this 
approach actually.  It is the better code however, and we save some needless
`git status` calls already.