### PR TITLE
Always bring hunk into viewport

### DIFF
--- a/core/commands/next_hunk.py
+++ b/core/commands/next_hunk.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from functools import partial
 from itertools import chain, takewhile
 
 import sublime
@@ -7,7 +8,7 @@ import sublime_plugin
 
 from GitSavvy.core.fns import pairwise
 from GitSavvy.core.utils import flash
-from GitSavvy.core.view import line_distance, show_region
+from GitSavvy.core.view import line_distance, show_region, touching_regions
 
 
 __all__ = (
@@ -51,6 +52,9 @@ def jump_to_hunk(view, forwards):
         hunk = hunk_region(view, forwards)
 
     if hunk is None:
+        is_visible = partial(touching_regions, view.visible_region())
+        if not any(filter(is_visible, view.sel())):
+            view.show(view.sel())
         return False
     else:
         mark_and_show_line_start(view, hunk)


### PR DESCRIPTION
For `jump_to_hunk`, if there is no hunk to jump to still bring the
selection, which might be on the only hunk currently available, into
the viewport.

Basically, show the cursor if a "jump" is requested for orientation.