### PR TITLE
Automatically close "used" diff views after commit

### DIFF
--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -427,6 +427,7 @@ class gs_commit_view_do_commit(TextCommand, GitCommand):
             # view and we just probed that it will not get away magically in a split
             # second.
             if v.is_valid():
+                v.settings().set("git_savvy.ignore_next_activated_event", True)
                 break
 
         self.view.close()

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -166,7 +166,9 @@ class gs_diff(WindowCommand, GitCommand):
             diff_view.set_syntax_file("Packages/GitSavvy/syntax/diff_view.sublime-syntax")
 
             diff_view.run_command("gs_handle_vintageous")
-            diff_view.run_command("gs_diff_refresh", {"sync": False})
+            # Assume diffing a single file is very fast and do it
+            # sync because it looks better.
+            diff_view.run_command("gs_diff_refresh", {"sync": bool(file_path)})
 
 
 class gs_diff_refresh(TextCommand, GitCommand):

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -178,6 +178,8 @@ class gs_diff_refresh(TextCommand, GitCommand):
             enqueue_on_worker(self.run_impl, sync)
 
     def run_impl(self, runs_on_ui_thread):
+        if not runs_on_ui_thread and not self.view.is_valid():
+            return
         if self.view.settings().get("git_savvy.disable_diff"):
             return
         repo_path = self.view.settings().get("git_savvy.repo_path")

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -402,7 +402,10 @@ class GsDiffFocusEventListener(EventListener):
     """
 
     def on_activated_async(self, view):
-        if view.settings().get("git_savvy.diff_view") is True:
+        settings = view.settings()
+        if settings.get("git_savvy.ignore_next_activated_event"):
+            settings.set("git_savvy.ignore_next_activated_event", False)
+        elif settings.get("git_savvy.diff_view"):
             view.run_command("gs_diff_refresh", {"sync": False})
 
 

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -228,6 +228,8 @@ class gs_diff_refresh(TextCommand, GitCommand):
         if ignore_whitespace:
             prelude += "  IGNORING WHITESPACE\n"
 
+        prelude += "\n--\n"
+
         try:
             diff = self.git(
                 "diff",
@@ -266,16 +268,13 @@ class gs_diff_refresh(TextCommand, GitCommand):
                     self.view.close()
                 return
 
-        old_diff = self.view.settings().get("git_savvy.diff_view.raw_diff")
-        self.view.settings().set("git_savvy.diff_view.raw_diff", diff)
-        prelude += "\n--\n"
-
+        has_content = self.view.find_by_selector("git-savvy.diff_view git-savvy.diff")
         draw = lambda: _draw(
             self.view,
             ' '.join(title),
             prelude,
             diff,
-            navigate=not old_diff
+            navigate=not has_content
         )
         if runs_on_ui_thread:
             draw()

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -166,6 +166,7 @@ class gs_diff(WindowCommand, GitCommand):
             diff_view.set_syntax_file("Packages/GitSavvy/syntax/diff_view.sublime-syntax")
 
             diff_view.run_command("gs_handle_vintageous")
+            diff_view.run_command("gs_diff_refresh", {"sync": False})
 
 
 class gs_diff_refresh(TextCommand, GitCommand):
@@ -403,7 +404,7 @@ class GsDiffFocusEventListener(EventListener):
     when the view regains focus.
     """
 
-    def on_activated_async(self, view):
+    def on_activated(self, view):
         settings = view.settings()
         if settings.get("git_savvy.ignore_next_activated_event"):
             settings.set("git_savvy.ignore_next_activated_event", False)

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -250,6 +250,17 @@ class gs_diff_refresh(TextCommand, GitCommand):
                 return
             raise err
 
+        if self.view.settings().get("git_savvy.just_committed"):
+            if diff:
+                self.view.settings().set("git_savvy.just_committed", False)
+            else:
+                if in_cached_mode:
+                    self.view.settings().set("git_savvy.diff_view.in_cached_mode", False)
+                    self.view.run_command("gs_diff_refresh")
+                else:
+                    self.view.close()
+                return
+
         old_diff = self.view.settings().get("git_savvy.diff_view.raw_diff")
         self.view.settings().set("git_savvy.diff_view.raw_diff", diff)
         prelude += "\n--\n"

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -246,12 +246,7 @@ class gs_diff_refresh(TextCommand, GitCommand):
             # When the output of the above Git command fails to correctly parse,
             # the expected notification will be displayed to the user.  However,
             # once the userpresses OK, a new refresh event will be triggered on
-            # the view.
-            #
-            # This causes an infinite loop of increasingly frustrating error
-            # messages, ultimately resulting in psychosis and serious medical
-            # bills.  This is a better, though somewhat cludgy, alternative.
-            #
+            # the view. Prevent refreshing again by setting a flag.
             if err.args and type(err.args[0]) == UnicodeDecodeError:
                 self.view.settings().set("git_savvy.disable_diff", True)
                 return

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -181,19 +181,22 @@ class gs_diff_refresh(TextCommand, GitCommand):
             enqueue_on_worker(self.run_impl, sync)
 
     def run_impl(self, runs_on_ui_thread):
-        if not runs_on_ui_thread and not self.view.is_valid():
+        view = self.view
+        if not runs_on_ui_thread and not view.is_valid():
             return
-        if self.view.settings().get("git_savvy.disable_diff"):
+
+        settings = view.settings()
+        if settings.get("git_savvy.disable_diff"):
             return
-        repo_path = self.view.settings().get("git_savvy.repo_path")
-        file_path = self.view.settings().get("git_savvy.file_path")
-        in_cached_mode = self.view.settings().get("git_savvy.diff_view.in_cached_mode")
-        ignore_whitespace = self.view.settings().get("git_savvy.diff_view.ignore_whitespace")
-        base_commit = self.view.settings().get("git_savvy.diff_view.base_commit")
-        target_commit = self.view.settings().get("git_savvy.diff_view.target_commit")
-        show_diffstat = self.view.settings().get("git_savvy.diff_view.show_diffstat")
-        disable_stage = self.view.settings().get("git_savvy.diff_view.disable_stage")
-        context_lines = self.view.settings().get('git_savvy.diff_view.context_lines')
+        repo_path = settings.get("git_savvy.repo_path")
+        file_path = settings.get("git_savvy.file_path")
+        in_cached_mode = settings.get("git_savvy.diff_view.in_cached_mode")
+        ignore_whitespace = settings.get("git_savvy.diff_view.ignore_whitespace")
+        base_commit = settings.get("git_savvy.diff_view.base_commit")
+        target_commit = settings.get("git_savvy.diff_view.target_commit")
+        show_diffstat = settings.get("git_savvy.diff_view.show_diffstat")
+        disable_stage = settings.get("git_savvy.diff_view.disable_stage")
+        context_lines = settings.get('git_savvy.diff_view.context_lines')
 
         prelude = "\n"
         title = ["DIFF:"]
@@ -248,24 +251,24 @@ class gs_diff_refresh(TextCommand, GitCommand):
             # once the userpresses OK, a new refresh event will be triggered on
             # the view. Prevent refreshing again by setting a flag.
             if err.args and type(err.args[0]) == UnicodeDecodeError:
-                self.view.settings().set("git_savvy.disable_diff", True)
+                settings.set("git_savvy.disable_diff", True)
                 return
             raise err
 
-        if self.view.settings().get("git_savvy.just_committed"):
+        if settings.get("git_savvy.just_committed"):
             if diff:
-                self.view.settings().set("git_savvy.just_committed", False)
+                settings.set("git_savvy.just_committed", False)
             else:
                 if in_cached_mode:
-                    self.view.settings().set("git_savvy.diff_view.in_cached_mode", False)
-                    self.view.run_command("gs_diff_refresh")
+                    settings.set("git_savvy.diff_view.in_cached_mode", False)
+                    view.run_command("gs_diff_refresh")
                 else:
-                    self.view.close()
+                    view.close()
                 return
 
-        has_content = self.view.find_by_selector("git-savvy.diff_view git-savvy.diff")
+        has_content = view.find_by_selector("git-savvy.diff_view git-savvy.diff")
         draw = lambda: _draw(
-            self.view,
+            view,
             ' '.join(title),
             prelude,
             diff,

--- a/syntax/diff_view.sublime-syntax
+++ b/syntax/diff_view.sublime-syntax
@@ -6,14 +6,10 @@ hidden: true
 scope: git-savvy.diff_view
 contexts:
   main:
-    - match: .
+    - match: ^
       push: header
 
   header:
-    - match: '^--$'
-      scope: comment
-      push:
-        - include: 'scope:git-savvy.diff'
-
-    - match: .*
-      scope: comment
+    - meta_scope: comment.header.git_savvy
+    - match: '^--$\n'
+      set: 'scope:git-savvy.diff'


### PR DESCRIPTION
After committing, we often land on an empty diff view, close these views automatically.

