### PR TITLE
Assume `commit -a` if nothing is staged yet

### DIFF
--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -202,6 +202,10 @@ class gs_prepare_commit_refresh_diff(TextCommand, GitCommand):
 
         if diff_text:
             final_text = ("\n" + diff_text) if shows_diff or shows_stat else ""
+        elif (shows_diff or shows_stat) and not include_unstaged:
+            settings.set("git_savvy.commit_view.include_unstaged", True)
+            view.run_command("gs_prepare_commit_refresh_diff")
+            return
         else:
             final_text = "\nNothing to commit.\n"
 

--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -164,8 +164,8 @@ class gs_prepare_commit_refresh_diff(TextCommand, GitCommand):
         amend = settings.get("git_savvy.commit_view.amend")
         show_commit_diff = self.savvy_settings.get("show_commit_diff")
         # for backward compatibility, check also if show_commit_diff is True
-        shows_diff = show_commit_diff is True or show_commit_diff == "full"
-        shows_stat = (
+        show_patch = show_commit_diff is True or show_commit_diff == "full"
+        show_stat = (
             show_commit_diff == "stat"
             or (show_commit_diff == "full" and self.savvy_settings.get("show_diffstat"))
         )
@@ -174,8 +174,8 @@ class gs_prepare_commit_refresh_diff(TextCommand, GitCommand):
             diff_text = self.git_throwing_silently(
                 "diff",
                 "--no-color",
-                "--patch" if shows_diff else None,
-                "--stat" if shows_stat else None,
+                "--patch" if show_patch else None,
+                "--stat" if show_stat else None,
                 "--cached" if not include_unstaged else None,
                 "HEAD^" if amend
                 else "HEAD" if include_unstaged
@@ -186,8 +186,8 @@ class gs_prepare_commit_refresh_diff(TextCommand, GitCommand):
                 diff_text = self.git(
                     "diff",
                     "--no-color",
-                    "--patch" if shows_diff else None,
-                    "--stat" if shows_stat else None,
+                    "--patch" if show_patch else None,
+                    "--stat" if show_stat else None,
                     "--cached" if not include_unstaged else None,
                     self.the_empty_sha()
                 )
@@ -201,8 +201,8 @@ class gs_prepare_commit_refresh_diff(TextCommand, GitCommand):
                 )
 
         if diff_text:
-            final_text = ("\n" + diff_text) if shows_diff or shows_stat else ""
-        elif (shows_diff or shows_stat) and not include_unstaged:
+            final_text = ("\n" + diff_text) if show_patch or show_stat else ""
+        elif (show_patch or show_stat) and not include_unstaged:
             settings.set("git_savvy.commit_view.include_unstaged", True)
             view.run_command("gs_prepare_commit_refresh_diff")
             return
@@ -218,7 +218,7 @@ class gs_prepare_commit_refresh_diff(TextCommand, GitCommand):
             return
 
         replace_view_content(view, final_text, region)
-        if shows_diff:
+        if show_patch:
             intra_line_colorizer.annotate_intra_line_differences(view, final_text, region.begin())
 
     def the_empty_sha(self):


### PR DESCRIPTION
As quality-of-life hack: If you enter the commit process with nothing
staged, assume `include_unstaged`.

This is transparent as we always commit what's visible in the diff in
the commit message view.  If `-a` is not what you want, the user can
either just close the view, stage something and usually using `[c]` in
some of the views enter the commit process again.  She can also just
switch to a diff view, stage something and hit `[c]`, t.i. without
closing the view, as the view will update.