### PR TITLE
Catch decode errors in the commit message view

### DIFF
--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -208,6 +208,8 @@ class gs_prepare_commit_refresh_diff(TextCommand, GitCommand):
             diff_text, _ = self.try_decode(raw_diff_text, encodings, show_modal_on_error=False)
         except UnicodeDecodeError:
             diff_text = DECODE_ERROR_MESSAGE
+            diff_text += "\n-- Partially decoded output follows; � denotes decoding errors --\n\n"""
+            diff_text += raw_diff_text.decode("utf-8", "replace")
 
         if diff_text:
             final_text = ("\n" + diff_text) if show_patch or show_stat else ""

--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -5,6 +5,7 @@ import sublime
 from sublime_plugin import WindowCommand, TextCommand
 from sublime_plugin import EventListener, ViewEventListener
 
+from .diff import DECODE_ERROR_MESSAGE
 from . import intra_line_colorizer
 from ..git_command import GitCommand, GitSavvyError
 from ..runtime import enqueue_on_worker
@@ -171,7 +172,7 @@ class gs_prepare_commit_refresh_diff(TextCommand, GitCommand):
         )
 
         try:
-            diff_text = self.git_throwing_silently(
+            raw_diff_text = self.git_throwing_silently(
                 "diff",
                 "--no-color",
                 "--patch" if show_patch else None,
@@ -179,17 +180,19 @@ class gs_prepare_commit_refresh_diff(TextCommand, GitCommand):
                 "--cached" if not include_unstaged else None,
                 "HEAD^" if amend
                 else "HEAD" if include_unstaged
-                else None
+                else None,
+                decode=False
             )
         except GitSavvyError as e:
             if (amend or include_unstaged) and "ambiguous argument 'HEAD" in e.stderr:
-                diff_text = self.git(
+                raw_diff_text = self.git(
                     "diff",
                     "--no-color",
                     "--patch" if show_patch else None,
                     "--stat" if show_stat else None,
                     "--cached" if not include_unstaged else None,
-                    self.the_empty_sha()
+                    self.the_empty_sha(),
+                    decode=False
                 )
             else:
                 raise GitSavvyError(
@@ -199,6 +202,12 @@ class gs_prepare_commit_refresh_diff(TextCommand, GitCommand):
                     stderr=e.stderr,
                     show_panel=True,
                 )
+
+        encodings = self.get_encoding_candidates()
+        try:
+            diff_text, _ = self.try_decode(raw_diff_text, encodings, show_modal_on_error=False)
+        except UnicodeDecodeError:
+            diff_text = DECODE_ERROR_MESSAGE
 
         if diff_text:
             final_text = ("\n" + diff_text) if show_patch or show_stat else ""

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -261,6 +261,8 @@ class gs_diff_refresh(TextCommand, GitCommand):
             diff, _ = self.try_decode(raw_diff, encodings, show_modal_on_error=False)
         except UnicodeDecodeError:
             diff = DECODE_ERROR_MESSAGE
+            diff += "\n-- Partially decoded output follows; � denotes decoding errors --\n\n"""
+            diff += raw_diff.decode("utf-8", "replace")
 
         if settings.get("git_savvy.just_committed"):
             if diff:

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -362,7 +362,13 @@ class gs_inline_diff_refresh(TextCommand, GitCommand):
                 decode=False
             )
             encodings = self.get_encoding_candidates()
-            raw_diff, encoding = self.try_decode(raw_diff_output, encodings)
+            try:
+                raw_diff, encoding = self.try_decode(
+                    raw_diff_output, encodings, show_modal_on_error=True
+                )
+            except UnicodeDecodeError:
+                self.view.close()
+                return
             settings.set("git_savvy.inline_diff.encoding", encoding)
 
         try:

--- a/core/exceptions.py
+++ b/core/exceptions.py
@@ -3,7 +3,7 @@ from ..common import util
 
 
 class GitSavvyError(Exception):
-    def __init__(self, msg, *args, cmd=None, stdout=None, stderr=None, **kwargs):
+    def __init__(self, msg, *args, cmd=None, stdout="", stderr="", **kwargs):
         super(GitSavvyError, self).__init__(msg, *args)
         self.message = msg
         self.cmd = cmd

--- a/core/exceptions.py
+++ b/core/exceptions.py
@@ -2,8 +2,14 @@ import sublime
 from ..common import util
 
 
+MYPY = False
+if MYPY:
+    from typing import Sequence
+
+
 class GitSavvyError(Exception):
     def __init__(self, msg, *args, cmd=None, stdout="", stderr="", **kwargs):
+        # type: (str, object, Sequence[str], str, str, object) -> None
         super(GitSavvyError, self).__init__(msg, *args)
         self.message = msg
         self.cmd = cmd

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -141,9 +141,9 @@ class _GitCommand(SettingsMixin):
                 working_dir = self.repo_path
         except RuntimeError as e:
             # do not show panel when the window does not exist
-            raise GitSavvyError(e, show_panel=False)
+            raise GitSavvyError(str(e), show_panel=False)
         except Exception as e:
-            raise GitSavvyError(e, show_panel=show_panel_on_stderr)
+            raise GitSavvyError(str(e), show_panel=show_panel_on_stderr)
 
         try:
             startupinfo = None

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -214,17 +214,7 @@ class _GitCommand(SettingsMixin):
         finally:
             if not just_the_proc:
                 end = time.time()
-                if decode:
-                    util.debug.log_git(args, stdin, stdout, stderr, end - start)
-                else:
-                    util.debug.log_git(
-                        args,
-                        stdin,
-                        self.decode_stdout(stdout),
-                        self.decode_stdout(stderr),
-                        end - start
-                    )
-
+                util.debug.log_git(args, stdin, stdout, stderr, end - start)
                 if show_panel and self.savvy_settings.get("show_time_elapsed_in_output", True):
                     util.log.panel_append("\n[Done in {:.2f}s]".format(end - start))
 

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -271,16 +271,17 @@ class _GitCommand(SettingsMixin):
         decoded, _ = self.try_decode(stdout, encodings)
         return decoded
 
-    def try_decode(self, input, encodings):  # type: ignore  # missing return statement
-        # type: (bytes, Sequence[str]) -> Tuple[str, str]
-        assert encodings
+    def try_decode(self, input, encodings, show_modal_on_error=True):
+        # type: (bytes, Sequence[str], bool) -> Tuple[str, str]
         for n, encoding in enumerate(encodings, start=1):
             try:
                 return input.decode(encoding), encoding
             except UnicodeDecodeError as err:
                 if n == len(encodings):
-                    sublime.error_message(FALLBACK_PARSE_ERROR_MSG)
+                    if show_modal_on_error:
+                        sublime.error_message(FALLBACK_PARSE_ERROR_MSG)
                     raise err
+        assert False  # no silent fall-through
 
     @property
     def encoding(self):

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -68,6 +68,7 @@ class LoggingProcessWrapper(object):
             util.log.panel_append(err, run_async=False)
 
     def communicate(self, stdin):
+        # type: (bytes) -> Tuple[bytes, bytes]
         """
         Emulates Popen.communicate
         Writes stdin (if provided)

--- a/syntax/show_commit.sublime-syntax
+++ b/syntax/show_commit.sublime-syntax
@@ -19,6 +19,8 @@ contexts:
       scope: meta.commit-header-and-stat-splitter
       embed: "scope:git-savvy.diff"
       escape: (?=^commit \h{7,})
+    - match: ^-- .* --$
+      scope: markup.deleted
 
   commit-header:
     - meta_scope: meta.commit-info.header

--- a/tests/test_commit_view.py
+++ b/tests/test_commit_view.py
@@ -89,7 +89,7 @@ class TestExtractCommitMessage(DeferrableTestCase):
         +++ b/bar/test.txt
         @@ -1,14 +1,22 @@
         This is a diff
-        """.rstrip()))
+        """.rstrip()).encode())
 
         self.window.run_command("gs_commit", {"repo_path": "/foo"})
         yield self.window.active_view().name() == "COMMIT: foo"

--- a/tests/test_diff_view.py
+++ b/tests/test_diff_view.py
@@ -499,7 +499,7 @@ class TestZooming(DeferrableTestCase):
 
         view.settings().set('git_savvy.diff_view.context_lines', CONTEXT_LINES)
         cmd = module.gs_diff_refresh(view)
-        when(cmd).git(...).thenReturn('NEW CONTENT')
+        when(cmd).git(...).thenReturn(b'NEW CONTENT')
 
         cmd.run({'unused_edit'})
         verify(cmd).git('diff', None, FLAG, ...)
@@ -591,7 +591,7 @@ class TestDiffView(DeferrableTestCase):
         REPO_PATH = '/not/there'
         DIFF = fixture('diff_1.txt')
 
-        when(gs_diff_refresh).git('diff', ...).thenReturn(DIFF)
+        when(gs_diff_refresh).git('diff', ...).thenReturn(DIFF.encode())
         cmd = gs_diff(self.window)
         when(cmd).get_repo_path().thenReturn(REPO_PATH)
         cmd.run()
@@ -617,7 +617,7 @@ class TestDiffView(DeferrableTestCase):
         REPO_PATH = '/not/there'
         DIFF = fixture('diff_1.txt')
 
-        when(gs_diff_refresh).git('diff', ...).thenReturn(DIFF)
+        when(gs_diff_refresh).git('diff', ...).thenReturn(DIFF.encode())
         cmd = gs_diff(self.window)
         when(cmd).get_repo_path().thenReturn(REPO_PATH)
         cmd.run()


### PR DESCRIPTION
Fixes #1426

Showing the diff is optional in the commit message view.  (It is of
course good to have but a user can commit anyway.)

In the case the diff is not decodable, do not show the error modal
dialog anymore.  Instead print an error message in place of the diff.

- Do the same in the diff view fixing a regression from 4060ae79 (Other: 
improve catching errors, Jul 2017).

- Do not open an inline diff view if the diff is not decodable.  (Just 
show the error modal, as we don't have a view to print the error message.)

- Fix: The implicit logging used the same `decode_stdout` procedure, t.i.
with showing a modal.  Do not do that but use a defensive way so we can 
actually opt-out of automatic decoding. 

- Also decode the "Show Commit" output safely.  Ref #1371 

![image](https://user-images.githubusercontent.com/8558/101036241-43392480-357b-11eb-85f0-9640b4b3f643.png)


