### PR TITLE
Safely access `THROTTLED_CACHE` dict

### DIFF
--- a/core/runtime.py
+++ b/core/runtime.py
@@ -158,7 +158,7 @@ def throttled(fn, *args, **kwargs):
 
     def task():
         with THROTTLED_LOCK:
-            ok = THROTTLED_CACHE[token] == action
+            ok = THROTTLED_CACHE.get(token) == action
         if ok:
             action()
 


### PR DESCRIPTION
Reading `THROTTLED_CACHE` seems safe as we never pop items from it.
Unless we hot-reload.  Then we evict everything, and the code can
possibly throw.

Just choose the safe `.get()` variant.