### PR TITLE
Fix: Respect branch decoration in commit headers

### DIFF
--- a/core/parse_diff.py
+++ b/core/parse_diff.py
@@ -122,7 +122,7 @@ class CommitHeader(TextRange):
         # type: () -> Optional[str]
         first_line = self.text[:self.text.index('\n')]
         if first_line.startswith('commit '):
-            return first_line[7:]
+            return first_line.split(' ')[1]
         return None
 
 

--- a/tests/fixtures/diff_2.txt
+++ b/tests/fixtures/diff_2.txt
@@ -5,6 +5,7 @@ Commit:     Not Herr Kaste <not.herr.kaste@gmail.com>
 CommitDate: Fri Oct 6 13:25:58 2017 -0300
 
     modules ... maybe
+
 ---
  src/{constants.js => constants.mjs}     |  0
  src/{detected.js => detected.mjs}       |  0

--- a/tests/fixtures/diff_2.txt
+++ b/tests/fixtures/diff_2.txt
@@ -1,4 +1,4 @@
-commit 9dd4769f090aec1c6bceee49019680d0dba8108d
+commit 9dd4769f090aec1c6bceee49019680d0dba8108d  (HEAD -> refactor-status-updates)
 Author:     Not Herr Kaste <not.herr.kaste@gmail.com>
 AuthorDate: Fri Oct 6 13:25:58 2017 -0300
 Commit:     Not Herr Kaste <not.herr.kaste@gmail.com>

--- a/tests/test_diff_view.py
+++ b/tests/test_diff_view.py
@@ -671,3 +671,8 @@ class TestDiffView(DeferrableTestCase):
 
         self.assertEqual(diff.commit_for_hunk(diff.hunks[0]), diff.commits[0])
         self.assertEqual(diff.commit_for_hunk(diff.hunks[1]), diff.commits[0])
+
+        self.assertEqual(
+            diff.commits[0].commit_hash(),
+            "9dd4769f090aec1c6bceee49019680d0dba8108d"
+        )


### PR DESCRIPTION
For example, the Line History might yield multiple commits, and git
might put branch decoration (for example "(HEAD -> ...)") on the first
line right after the commit hash.

Rewrite `CommitHeader.commit_hash` to not include them.