### PR TITLE
Traverse dots in visual order

### DIFF
--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -1852,7 +1852,7 @@ def commit_message_from_point(view, pt):
 def find_matching_commit(vid, dot, message):
     # type: (sublime.ViewId, colorizer.Char, str) -> Optional[colorizer.Char]
     view = sublime.View(vid)
-    for dot in islice(follow_dots(dot), 0, 50):
+    for dot in islice(follow_dots(dot), 0, 100):
         this_message = commit_message_from_point(view, dot.pt)
         if this_message:
             shorter, longer = sorted((message, this_message.rstrip(".")), key=len)

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -1076,14 +1076,17 @@ def follow_first_parent(dot, forward=True):
 def follow_dots(dot, forward=True):
     # type: (colorizer.Char, bool) -> Iterator[colorizer.Char]
     """Breadth first traverse dot to dot."""
-    stack = deque(dots_after_dot(dot, forward))
+    # Always sort by `dot.pt` to keep the order exactly like the visual
+    # order in the view.
+    stack = sorted(dots_after_dot(dot, forward), key=lambda dot: dot.pt)
     seen = set()
     while stack:
-        dot = stack.popleft()
+        dot = stack.pop(0)
         if dot not in seen:
             yield dot
             seen.add(dot)
             stack.extend(dots_after_dot(dot, forward))
+            stack.sort(key=lambda dot: dot.pt)
 
 
 def dots_after_dot(dot, forward=True):


### PR DESCRIPTION
Especially with feature branches of different lengths it happens that
we already see commits from the main line while other branches are
still running.

Although not an error per se it is confusing and often wasteful.  Sort
the dots by `dot.pt` to restrain exact visual order.