### PR TITLE
Fix: Ensure rewrite actions run on the worker thread

### DIFF
--- a/core/interfaces/rebase.py
+++ b/core/interfaces/rebase.py
@@ -1,3 +1,4 @@
+from functools import partial
 import os
 import re
 
@@ -12,6 +13,7 @@ from ..git_command import GitCommand
 from ..git_mixins.rebase import NearestBranchMixin
 from ..ui_mixins.quick_panel import PanelActionMixin, show_log_panel, show_branch_panel
 from ..ui_mixins.input_panel import show_single_line_input_panel
+from GitSavvy.core.runtime import enqueue_on_worker
 
 
 COMMIT_NODE_CHAR = "●"
@@ -591,7 +593,7 @@ class GsRebaseSquashCommand(RewriteBase):
             self.do_action(self.interface.entries[squash_idx - 1].long_hash)
         else:
             reversed_logs = list(reversed(self.interface.entries[0:squash_idx]))
-            show_log_panel(reversed_logs, self.do_action)
+            show_log_panel(reversed_logs, partial(enqueue_on_worker, self.do_action))
 
     def do_action(self, target_commit):
         if not target_commit:
@@ -729,7 +731,7 @@ class GsRebaseMoveUpCommand(RewriteBase):
             self.do_action(self.interface.entries[move_idx - 1].long_hash)
         else:
             logs = list(reversed(self.interface.entries[:move_idx]))
-            show_log_panel(logs, self.do_action)
+            show_log_panel(logs, partial(enqueue_on_worker, self.do_action))
 
     def do_action(self, target_commit):
         if not target_commit:
@@ -778,7 +780,7 @@ class GsRebaseMoveDownCommand(RewriteBase):
             self.do_action(self.interface.entries[move_idx + 1].long_hash)
         else:
             logs = self.interface.entries[move_idx + 1:]
-            show_log_panel(logs, self.do_action)
+            show_log_panel(logs, partial(enqueue_on_worker, self.do_action))
 
     def do_action(self, target_commit):
         if not target_commit:


### PR DESCRIPTION
Fixes #1418

Fix a regression introduced by 1e31e247 (Let `LogPanel` continue
synchronous on `enter`).

Commit 1e31e247 introduced that `show_log_panel` continues on the main
thread on `enter`.  Hence actual users of `show_log_panel` must
explicitly opt-in and hop to a different thread if they want to.

Even for the rebase dashboard running on the main thread had the
advantage that the user could not issue different commands *while*
a rewrite was in progress.  Generally though, these rewrites possible
take a long time so it can feel like Sublime freezes.  Running on the
worker might be the better solution here.

The actual bug #1418 describes is a bug in the long distance.  When the
user uses the "live_panel" panel feature for "git commit" commands,
we deadlock for "live_panel_output_timeout" (default: 10s) because the
reader thread used for live logging waits for the main thread to write
to the panel while the git commands - running on the main thread - waits
for the panel to update.

This commit does *not* solve this underlying bug-by-design but just
the problem at hand. This is still the right commit as rewriting on the
main thread can take too long time anyway.