### PR TITLE
Revert "Add newline after the commit message in a fixture"

### DIFF
--- a/tests/fixtures/diff_2.txt
+++ b/tests/fixtures/diff_2.txt
@@ -5,7 +5,6 @@ Commit:     Not Herr Kaste <not.herr.kaste@gmail.com>
 CommitDate: Fri Oct 6 13:25:58 2017 -0300
 
     modules ... maybe
-
 ---
  src/{constants.js => constants.mjs}     |  0
  src/{detected.js => detected.mjs}       |  0


### PR DESCRIPTION
This reverts commit cc4cb033795f58f83852de91a825ec5024df8685.

There is actually no newline in the git show-commit output, so the
the change was non-sense and we revert.