### PR TITLE
Improve staging (et.al) in the diff view

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -635,6 +635,37 @@
         ]
     },
     {
+        "keys": ["s"],
+        "command": "gs_diff_stage_or_reset_hunk",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.diff_view", "operator": "equal", "operand": true },
+            { "key": "setting.git_savvy.diff_view.in_cached_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.diff_view.disable_stage", "operator": "equal", "operand": false }
+        ]
+    },
+    {
+        "keys": ["u"],
+        "command": "gs_diff_stage_or_reset_hunk",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.diff_view", "operator": "equal", "operand": true },
+            { "key": "setting.git_savvy.diff_view.in_cached_mode", "operator": "equal", "operand": true },
+            { "key": "setting.git_savvy.diff_view.disable_stage", "operator": "equal", "operand": false }
+        ]
+    },
+    {
+        "keys": ["d"],
+        "command": "gs_diff_stage_or_reset_hunk",
+        "args": { "reset": true },
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.diff_view", "operator": "equal", "operand": true },
+            { "key": "setting.git_savvy.diff_view.in_cached_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.diff_view.disable_stage", "operator": "equal", "operand": false }
+        ]
+    },
+    {
         "keys": ["S"],
         "command": "gs_diff_stage_or_reset_hunk",
         "args": { "whole_file": true },

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -614,7 +614,6 @@
     // DIFF VIEW //
     ///////////////
 
-    // Per-platform key-mapping for: gs_diff_stage_or_reset_hunk
     {
         "keys": ["h"],
         "command": "gs_diff_stage_or_reset_hunk",
@@ -635,6 +634,40 @@
             { "key": "setting.git_savvy.diff_view.disable_stage", "operator": "equal", "operand": false }
         ]
     },
+    {
+        "keys": ["S"],
+        "command": "gs_diff_stage_or_reset_hunk",
+        "args": { "whole_file": true },
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.diff_view", "operator": "equal", "operand": true },
+            { "key": "setting.git_savvy.diff_view.in_cached_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.diff_view.disable_stage", "operator": "equal", "operand": false }
+        ]
+    },
+    {
+        "keys": ["U"],
+        "command": "gs_diff_stage_or_reset_hunk",
+        "args": { "whole_file": true },
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.diff_view", "operator": "equal", "operand": true },
+            { "key": "setting.git_savvy.diff_view.in_cached_mode", "operator": "equal", "operand": true },
+            { "key": "setting.git_savvy.diff_view.disable_stage", "operator": "equal", "operand": false }
+        ]
+    },
+    {
+        "keys": ["D"],
+        "command": "gs_diff_stage_or_reset_hunk",
+        "args": { "reset": true, "whole_file": true },
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.diff_view", "operator": "equal", "operand": true },
+            { "key": "setting.git_savvy.diff_view.in_cached_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.diff_view.disable_stage", "operator": "equal", "operand": false }
+        ]
+    },
+
     {
         "keys": ["c"],
         "command": "gs_commit",

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -517,8 +517,7 @@ class gs_diff_stage_or_reset_hunk(TextCommand, GitCommand):
             sublime.error_message("Staging is not supported while ignoring [w]hitespace is on.")
             return None
 
-        # Filter out any cursors that are larger than a single point.
-        cursor_pts = tuple(cursor.a for cursor in self.view.sel() if cursor.a == cursor.b)
+        cursor_pts = [s.a for s in self.view.sel() if s.empty()]
         diff = SplittedDiff.from_view(self.view)
 
         patches = unique(flatten(filter_(diff.head_and_hunk_for_pt(pt) for pt in cursor_pts)))

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -533,6 +533,9 @@ class gs_diff_stage_or_reset_hunk(TextCommand, GitCommand):
 
         if patch:
             self.apply_patch(patch, cursor_pts, reset, zero_diff)
+            first_cursor = self.view.sel()[0].begin()
+            self.view.sel().clear()
+            self.view.sel().add(first_cursor)
         else:
             window = self.view.window()
             if window:

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -13,7 +13,7 @@ from sublime_plugin import WindowCommand, TextCommand, EventListener
 
 from . import intra_line_colorizer
 from .navigate import GsNavigate
-from ..fns import filter_, flatten
+from ..fns import filter_, flatten, unique
 from ..parse_diff import SplittedDiff
 from ..git_command import GitCommand
 from ..runtime import enqueue_on_ui, enqueue_on_worker
@@ -39,7 +39,7 @@ __all__ = (
 MYPY = False
 if MYPY:
     from typing import (
-        Iterable, Iterator, List, NamedTuple, Optional, Set,
+        Iterator, List, NamedTuple, Optional, Set,
         Tuple, TypeVar
     )
     from ..parse_diff import Hunk, HunkLine, TextRange
@@ -827,16 +827,6 @@ def pickle_sel(sel):
 
 def unpickle_sel(pickled_sel):
     return [sublime.Region(a, b) for a, b in pickled_sel]
-
-
-def unique(items):
-    # type: (Iterable[T]) -> List[T]
-    """Remove duplicate entries but remain sorted/ordered."""
-    rv = []  # type: List[T]
-    for item in items:
-        if item not in rv:
-            rv.append(item)
-    return rv
 
 
 def set_and_show_cursor(view, cursors):

--- a/core/commands/stage_hunk.py
+++ b/core/commands/stage_hunk.py
@@ -160,22 +160,6 @@ def hunk_of_removals_only(hunk):
     return hunk.b_length == 0 and hunk.a_length > 0
 
 
-def rewrite_hunks_for_reset(hunks):
-    # type: (List[Hunk]) -> Iterator[Hunk]
-    # Assumes `hunks` are sorted, and from the same file
-    deltas = (hunk.b_length - hunk.a_length for hunk in hunks)
-    offsets = accumulate(deltas, initial=0)
-    for hunk, offset in zip(hunks, offsets):
-        new_a, new_b = hunk.b_start - offset, hunk.a_start
-        if hunk_of_additions_only(hunk):
-            new_a -= 1
-            new_b += 1
-        elif hunk_of_removals_only(hunk):
-            new_a += 1
-            new_b -= 1
-        yield hunk._replace(a_start=new_a, b_start=new_b)
-
-
 def pluralize(word, count):
     # type: (str, int) -> str
     return word if count == 1 else word + "s"

--- a/core/fns.py
+++ b/core/fns.py
@@ -38,6 +38,13 @@ def unique(iterable):
         yield item
 
 
+def peek(iterable):
+    # type: (Iterable[T]) -> Tuple[T, Iterable[T]]
+    it = iter(iterable)
+    head = next(it)
+    return head, chain([head], it)
+
+
 def drop(n, iterable):
     # type: (int, Iterable[T]) -> Iterator[T]
     return islice(iterable, n, None)

--- a/core/fns.py
+++ b/core/fns.py
@@ -5,6 +5,7 @@ MYPY = False
 if MYPY:
     from typing import Callable, Iterable, Iterator, List, Optional, Set, Tuple, TypeVar
     T = TypeVar('T')
+    U = TypeVar('U')
 
 
 filter_ = partial(filter, None)  # type: Callable[[Iterable[Optional[T]]], Iterator[T]]
@@ -45,6 +46,11 @@ def drop(n, iterable):
 def tail(iterable):
     # type: (Iterable[T]) -> Iterator[T]
     return drop(1, iterable)
+
+
+def unzip(zipped):
+    # type: (Iterable[Tuple[T, U]]) -> Tuple[Tuple[T, ...], Tuple[U, ...]]
+    return tuple(zip(*zipped))  # type: ignore
 
 
 # Below functions taken from https://github.com/erikrose/more-itertools

--- a/popups/diff_view.html
+++ b/popups/diff_view.html
@@ -8,8 +8,8 @@
 <h3>Actions</h3>
 <div>
   <div><code><span class="shortcut-key">TAB&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>switch between staged/unstaged area</code></div>
-  <div><code><span class="shortcut-key">h&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>stage hunk, unstage in cached mode</code></div>
-  <div><code><span class="shortcut-key">H&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>reset hunk</code></div>
+  <div><code><span class="shortcut-key">s</span>/<span class="shortcut-key">u</span>/<span class="shortcut-key">d</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stage, unstage, or discard hunk or selection</code></div>
+  <div><code><span class="shortcut-key">S</span>/<span class="shortcut-key">U</span>/<span class="shortcut-key">D</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stage, unstage, or discard complete file</code></div>
   <div><code><span class="shortcut-key">{super_key}-z&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>undo last action</code></div>
   <br />
 

--- a/tests/test_diff_view.py
+++ b/tests/test_diff_view.py
@@ -287,7 +287,7 @@ diff --git a/foxx b/boxx
         self.assertEqual(len(history), 1)
 
         actual = history.pop()
-        expected = [['apply', None, '--cached', None, '-'], HUNK, [CURSOR], IN_CACHED_MODE]
+        expected = [['apply', None, '--cached', '-'], HUNK, [CURSOR], IN_CACHED_MODE]
         self.assertEqual(actual, expected)
 
     HUNK3 = """\
@@ -373,7 +373,7 @@ diff --git a/foxx b/boxx
         self.assertEqual(len(history), 1)
 
         actual = history.pop()
-        expected = [['apply', None, '--cached', None, '-'], PATCH, CURSORS, IN_CACHED_MODE]
+        expected = [['apply', None, '--cached', '-'], PATCH, CURSORS, IN_CACHED_MODE]
         self.assertEqual(actual, expected)
 
     def test_sets_unidiff_zero_if_no_contextual_lines(self):

--- a/tests/test_hunk_counting.py
+++ b/tests/test_hunk_counting.py
@@ -1,9 +1,11 @@
+import sys
+from unittest.case import _ExpectedFailure, _UnexpectedSuccess
 
 from unittesting import DeferrableTestCase
+from GitSavvy.tests.parameterized import parameterized as p
+from GitSavvy.core.fns import accumulate, unzip
 
 import GitSavvy.core.commands.diff as module
-
-from GitSavvy.tests.parameterized import parameterized as p
 
 
 f1 = """\
@@ -63,7 +65,27 @@ class TestDiffRecountingLinesFunctions(DeferrableTestCase):
             f4,
             [383, 384, 385, 385, 386],
             [383, 383, 383, 384, 385]
+        ),
+
+        (
+            "x",
+            """\
+@@ -381,8 +381,7 @@ class gs_diff_zoom(TextCommand):
+         current = settings.get('git_savvy.diff_view.context_lines')
+
+         MINIMUM, DEFAULT, MIN_STEP_SIZE = 1, 3, 5
+-        step_size = max(abs(amount), MIN_STEP_SIZE)
+-        values = chain([MINIMUM, DEFAULT], count(step_size, step_size))
++        values = chain([0, MINIMUM, DEFAULT], count(step_size, step_size))
+         if amount > 0:
+             next_value = next(x for x in values if x > current)
+         else:
+""",
+            [381, 382, 383, 384, 385, 385, 386, 387, 388],
+            [381, 382, 383, 383, 383, 384, 385, 386, 387]
+
         )
+
     ])
     def test_recount_lines_of_hunk(self, _, PATCH, aside, bside):
         diff = module.SplittedDiff.from_string(PATCH)
@@ -83,3 +105,173 @@ class TestDiffRecountingLinesFunctions(DeferrableTestCase):
         hunk = diff.hunks[0]
         actual = module.recount_lines_for_jump_to_file(hunk)
         self.assertEqual(EXPECTED, [line.b for line in actual])
+
+
+header = """\
+diff --git a/core/commands/diff.py b/core/commands/diff.py
+index 5b91be74..f1925fb2 100644
+--- a/core/commands/diff.py
++++ b/core/commands/diff.py
+"""
+
+
+class TestDiffPatchGeneration(DeferrableTestCase):
+    @p.expand([
+        (
+            "modification",
+            """\
+ @@ -383,3 +383,3 @@ class gs_diff_zoom(TextCommand):
+          step_size = max(abs(amount), MIN_STEP_SIZE)
+|-        values = chain([MINIMUM, DEFAULT], count(step_size, step_size))
+|+        values = chain([0, MINIMUM, DEFAULT], count(step_size, step_size))
+          if amount > 0:
+""",
+            """\
+@@ -384,1 +384,1 @@
+-        values = chain([MINIMUM, DEFAULT], count(step_size, step_size))
++        values = chain([0, MINIMUM, DEFAULT], count(step_size, step_size))
+"""
+        ),
+
+        (
+            "first line of modification",
+            """\
+ @@ -383,3 +383,3 @@ class gs_diff_zoom(TextCommand):
+          step_size = max(abs(amount), MIN_STEP_SIZE)
+|-        values = chain([MINIMUM, DEFAULT], count(step_size, step_size))
+ +        values = chain([0, MINIMUM, DEFAULT], count(step_size, step_size))
+          if amount > 0:
+""",
+            """\
+@@ -384,1 +383,0 @@
+-        values = chain([MINIMUM, DEFAULT], count(step_size, step_size))
+"""
+        ),
+        (
+            "single deletion",
+            """\
+ @@ -383,3 +383,2 @@ class gs_diff_zoom(TextCommand):
+          step_size = max(abs(amount), MIN_STEP_SIZE)
+|-        values = chain([MINIMUM, DEFAULT], count(step_size, step_size))
+          if amount > 0:
+""",
+            """\
+@@ -384,1 +383,0 @@
+-        values = chain([MINIMUM, DEFAULT], count(step_size, step_size))
+"""
+        ),
+
+        # Note how A and B stage "the" line after "383 step_size" differently!
+        # In (A) the line comes still *after* the deletion line.
+        (
+            "second line of modification (A)",
+            """\
+ @@ -383,3 +383,3 @@ class gs_diff_zoom(TextCommand):
+          step_size = max(abs(amount), MIN_STEP_SIZE)
+ -        values = chain([MINIMUM, DEFAULT], count(step_size, step_size))
+|+        values = chain([0, MINIMUM, DEFAULT], count(step_size, step_size))
+          if amount > 0:
+""",
+            """\
+@@ -384,0 +385,1 @@
++        values = chain([0, MINIMUM, DEFAULT], count(step_size, step_size))
+"""
+        ),
+        (
+            "single addition             (B)",
+
+            """\
+ @@ -383,2 +383,3 @@ class gs_diff_zoom(TextCommand):
+          step_size = max(abs(amount), MIN_STEP_SIZE)
+|+        values
+          values = chain([MINIMUM, DEFAULT], count(step_size, step_size))
+""",
+            """\
+@@ -383,0 +384,1 @@
++        values
+"""
+        ),
+
+
+        # 3-line modification;
+        # first line being a deletion, 2nd and 3rd a symmetric modification.
+
+        (
+            "stage 3rd line",
+            """\
+ @@ -383,4 +383,3 @@ class gs_diff_zoom(TextCommand):
+          MINIMUM, DEFAULT, MIN_STEP_SIZE = 1, 3, 5
+ -        step_size = max(abs(amount), MIN_STEP_SIZE)
+ -        values = chain([MINIMUM, DEFAULT], count(step_size, step_size))
+|+        values = chain([0, MINIMUM, DEFAULT], count(step_size, step_size))
+          if amount > 0:
+""",
+            """\
+@@ -385,0 +386,1 @@
++        values = chain([0, MINIMUM, DEFAULT], count(step_size, step_size))
+"""
+        ),
+        (
+            "then stage 2nd line",
+            """\
+ @@ -383,4 +383,2 @@ class gs_diff_zoom(TextCommand):
+          MINIMUM, DEFAULT, MIN_STEP_SIZE = 1, 3, 5
+ -        step_size = max(abs(amount), MIN_STEP_SIZE)
+|-        values = chain([MINIMUM, DEFAULT], count(step_size, step_size))
+          values = chain([0, MINIMUM, DEFAULT], count(step_size, step_size))
+""",
+            """\
+@@ -385,1 +384,0 @@
+-        values = chain([MINIMUM, DEFAULT], count(step_size, step_size))
+"""
+        ),
+
+        #
+        (
+            "First stage 2nd line",
+            """\
+ @@ -383,4 +383,3 @@ class gs_diff_zoom(TextCommand):
+          MINIMUM, DEFAULT, MIN_STEP_SIZE = 1, 3, 5
+ -        step_size = max(abs(amount), MIN_STEP_SIZE)
+|-        values = chain([MINIMUM, DEFAULT], count(step_size, step_size))
+ +        values = chain([0, MINIMUM, DEFAULT], count(step_size, step_size))
+          if amount > 0:
+""",
+            """\
+@@ -385,1 +384,0 @@
+-        values = chain([MINIMUM, DEFAULT], count(step_size, step_size))
+"""
+        ),
+        (
+            "Then stage 3rd line",
+            """\
+ @@ -383,3 +383,3 @@ class gs_diff_zoom(TextCommand):
+          MINIMUM, DEFAULT, MIN_STEP_SIZE = 1, 3, 5
+ -        step_size = max(abs(amount), MIN_STEP_SIZE)
+|+        values = chain([0, MINIMUM, DEFAULT], count(step_size, step_size))
+          if amount > 0:
+""",
+            """\
+@@ -384,0 +385,1 @@
++        values = chain([0, MINIMUM, DEFAULT], count(step_size, step_size))
+"""
+        ),
+
+
+
+    ])
+    def test_patch_generation(self, _, input, patch):
+        marker, content = unzip((line[0], line[1:] or "\n") for line in input.splitlines(keepends=True))
+        all_line_starts = list(accumulate(map(len, content), initial=len(header)))
+        line_starts = {all_line_starts[i] for i, m in enumerate(marker) if m.strip()}
+        diff_text = header + "".join(content)
+        diff = module.SplittedDiff.from_string(diff_text)
+        actual = module.compute_patch_for_sel(diff, line_starts, reverse=False)
+        expected = header + patch
+        if _.startswith("_"):
+            if expected == actual:
+                raise _UnexpectedSuccess
+            else:
+                raise _ExpectedFailure(sys.exc_info())
+
+        self.assertEqual(expected, actual)

--- a/tests/test_hunk_counting.py
+++ b/tests/test_hunk_counting.py
@@ -1,0 +1,85 @@
+
+from unittesting import DeferrableTestCase
+
+import GitSavvy.core.commands.diff as module
+
+from GitSavvy.tests.parameterized import parameterized as p
+
+
+f1 = """\
+@@ -383,3 +383,3 @@ class gs_diff_zoom(TextCommand):
+         step_size = max(abs(amount), MIN_STEP_SIZE)
+-        values = chain([MINIMUM, DEFAULT], count(step_size, step_size))
++        values = chain([0, MINIMUM, DEFAULT], count(step_size, step_size))
+         if amount > 0:
+"""
+
+f2 = """\
+@@ -383,2 +383,3 @@ class gs_diff_zoom(TextCommand):
+         step_size = max(abs(amount), MIN_STEP_SIZE)
++        values
+         values = chain([MINIMUM, DEFAULT], count(step_size, step_size))
+"""
+
+f3 = """\
+@@ -383,3 +383,2 @@ class gs_diff_zoom(TextCommand):
+         step_size = max(abs(amount), MIN_STEP_SIZE)
+-        values = chain([MINIMUM, DEFAULT], count(step_size, step_size))
+         if amount > 0:
+"""
+
+f4 = """\
+@@ -383,4 +383,3 @@ class gs_diff_zoom(TextCommand):
+         step_size = max(abs(amount), MIN_STEP_SIZE)
+-        values = chain([MINIMUM, DEFAULT], count(step_size, step_size))
+-        if amount > 0:
++        zif amount > 0:
+             next_value = next(x for x in values if x > current)
+"""
+
+
+class TestDiffRecountingLinesFunctions(DeferrableTestCase):
+    @p.expand([
+        (
+            "sym modification",
+            f1,
+            [383, 384, 384, 385],
+            [383, 383, 384, 385]
+        ),
+        (
+            "addition",
+            f2,
+            [383, 383, 384],
+            [383, 384, 385]
+        ),
+        (
+            "deletion",
+            f3,
+            [383, 384, 385],
+            [383, 383, 384]
+        ),
+        (
+            "asym modification",
+            f4,
+            [383, 384, 385, 385, 386],
+            [383, 383, 383, 384, 385]
+        )
+    ])
+    def test_recount_lines_of_hunk(self, _, PATCH, aside, bside):
+        diff = module.SplittedDiff.from_string(PATCH)
+        hunk = diff.hunks[0]
+        actual = module.recount_lines(hunk)
+        EXPECTED = list(zip(aside, bside))
+        self.assertEqual(EXPECTED, [a_b for line, a_b in actual])
+
+    @p.expand([
+        ("sym modification", f1, [383, 384, 384, 385]),
+        ("addition", f2, [383, 384, 385]),
+        ("deletion", f3, [383, 384, 384]),
+        ("asym modification", f4, [383, 384, 384, 384, 385])
+    ])
+    def test_recount_for_jump_to_file(self, _, PATCH, EXPECTED):
+        diff = module.SplittedDiff.from_string(PATCH)
+        hunk = diff.hunks[0]
+        actual = module.recount_lines_for_jump_to_file(hunk)
+        self.assertEqual(EXPECTED, [line.b for line in actual])


### PR DESCRIPTION
Ref #1435 

- For consistency with the status dashboard, bind `sud` to stage, unstage, or discard.
- Allow to act on arbitrary selections, t.i. allow partially staging a hunk or multiple hunks, for example a single line.
- Bind `SUD` to stage, unstage, discard the complete file under the cursor.

Staging single lines or generally parts of a hunk usually comes with some complications as to where to apply these lines, t.i. basically which starting lines we compute for them.  Both our inline-diff and for example `git gui` apply some heuristics and maybe artificially move a `+` to a (maybe, hopefully) desired line.  We don't do this here but instead expect that the user indicates making *multiple* selections which lines do belong together.  E.g.:

![image](https://user-images.githubusercontent.com/8558/104463504-277d6100-55b2-11eb-9f61-fa3d45843718.png)

As there are two lines selected, we handle them as a "symmetric" modification, and it will just work as intended.  (In contrast to git gui, first staging the single "+  1environ" line and then the "-   environ" line will **not** work as expected.)   

Note that these heuristics used elsewhere, often don't work.  For example, "git gui" is optimized for 2/2 symmetric modifications.  It doesn't work for 3 lines/3 lines symmetric modifications.  They usually also fail for asymmetric changes, like 1-/2+.

In contrast to "git gui", we construct `-U0` patches and compute correct hunk headers (starting lines).  