### PR TITLE
Fix live logging feature

### DIFF
--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -120,14 +120,6 @@
     "live_panel_output": false,
 
     /*
-        Command will exit if on the timeout if the timeout reached.
-        You may want to increase this if you have a slow disk or a very
-        large repository. If you think there is something GitSavvy can do
-        to prevent this long running git command, open an issue.
-    */
-    "live_panel_output_timeout": 10000,
-
-    /*
         https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#Commit-Guidelines
         Add a distinct style guide for the commit messages:
 

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -7,7 +7,6 @@ Define a base command class that:
 """
 
 from collections import deque
-from concurrent.futures import Future
 from functools import partial
 import io
 from itertools import chain, repeat
@@ -17,19 +16,18 @@ import subprocess
 import shutil
 import re
 import time
-import threading
 import traceback
 
 import sublime
 
 from ..common import util
 from .settings import SettingsMixin
+from GitSavvy.core.runtime import run_as_future
 
 
 MYPY = False
 if MYPY:
-    from typing import Callable, Deque, Iterator, Sequence, Tuple, TypeVar
-    T = TypeVar("T")
+    from typing import Callable, Deque, Iterator, Sequence, Tuple
 
 
 git_path = None
@@ -44,22 +42,6 @@ FALLBACK_PARSE_ERROR_MSG = (
 
 MIN_GIT_VERSION = (2, 16, 0)
 GIT_TOO_OLD_MSG = "Your Git version is too old. GitSavvy requires {:d}.{:d}.{:d} or above."
-
-
-def run_as_future(fn, *args, **kwargs):
-    # type: (Callable[..., T], object, object) -> Future[T]
-    fut = Future()  # type: Future[T]
-
-    def task():
-        fut.set_running_or_notify_cancel()
-        try:
-            rv = fn(*args, **kwargs)
-        except Exception as e:
-            fut.set_exception(e)
-        else:
-            fut.set_result(rv)
-    threading.Thread(target=task).start()
-    return fut
 
 
 def communicate_and_log(proc, stdin, log):


### PR DESCRIPTION
Fixes #1437

For the live logging feature we basically implement `communicate` on our
own.  `communicate` generally works with three threads, two *reader*
threads, one for stdout, one for stderr, and one fan-in or *join*
thread.

Let's make the reader threads short reading loops over the buffer io
streams.  Zip both streams `out` and `err` to keep the order of output
close to the original order.  Use no-op classes `Out(bytes)` and
`Err(bytes)` to tag the output messages for later processing.

The fan-in thread is the thread which initiated the git call, it is in
a busy loop.  Log while unzipping the input lines.

Since the fan-in thread is already busy looping we cannot deadlock with
`M`.  Note that we basically do *not* log *live* if the initiating
thread is actually `M` because we cannot *force* Sublime to draw.
In that case, Sublime will wait for the main task to be finished and
draw once.

Remove the now superfluous `live_panel_output_timeout` setting.