### PR TITLE
Add detailed rebase info to the status

### DIFF
--- a/syntax/dashboard.sublime-syntax
+++ b/syntax/dashboard.sublime-syntax
@@ -42,6 +42,12 @@ contexts:
             1: comment.git-savvy.summary-header.title.head
             2: constant.other.git-savvy.sha1
 
+        - match: ^\s+(Stopped at[:])(?:\s+([0-9a-f]{7,40}) .+)?
+          captures:
+            1: keyword.git-savvy.summary-header.rebase.current
+            2: constant.other.git-savvy.sha1
+
+
     - match: "^  (#{3,})"
       comment: Key-bindings menu
       captures:


### PR DESCRIPTION
Let's read out more detailed rebase status info when rebasing halts.


The status bar shows the progress `(n/m)`

![image](https://user-images.githubusercontent.com/8558/104474225-15092480-55be-11eb-8159-4f9231fab777.png)

The dashboards show which todo item we're currently trying:

![image](https://user-images.githubusercontent.com/8558/104474256-1c303280-55be-11eb-83b7-37226de496f0.png)
