### PR TITLE
Mark merge commits with an `○`

### DIFF
--- a/syntax/graph.sublime-syntax
+++ b/syntax/graph.sublime-syntax
@@ -7,6 +7,7 @@ hidden: true
 scope: git-savvy.graph
 variables:
   sha: '[0-9a-f]{6,40}'
+  ascii_art: '[| \\/_.-]+'
 contexts:
   main:
     - match: ^
@@ -33,7 +34,15 @@ contexts:
           pop: true
 
   content:
-    - match: '^([| \\/_.-]+)?([*●])?([| \\/_.-]+)?(?= *)'
+    - match: '^({{ascii_art}})?([○])({{ascii_art}})?(?= *)'
+      comment: graph lines
+      scope: meta.graph.branch-art
+      captures:
+        1: punctuation.other.git-savvy.graph.graph-line
+        2: keyword.graph.commit.merge.git-savvy
+        3: punctuation.other.git-savvy.graph.graph-line
+
+    - match: '^({{ascii_art}})?([*●])?({{ascii_art}})?(?= *)'
       comment: graph lines
       scope: meta.graph.branch-art
       captures:


### PR DESCRIPTION
Fixes #1447

For orientation mark merge commits differently from normal commits.
Unfortunately, "git log" does not output all parents when using `%p`
but only the visual drawn parents.  T.i. when we tell git to simplify
the graph it only marks merge commits when the ascii art already
indicates a merge.

Since `%p` is not reliable, do a brute force search for typical merge
commit messages.

Use the scope `keyword.graph.commit.merge.git-savvy` for highlighting.