### PR TITLE
Only parse text between "@" markers in the hunk header

### DIFF
--- a/core/parse_diff.py
+++ b/core/parse_diff.py
@@ -219,7 +219,9 @@ class HunkHeader(TextRange):
         """
         return [
             (int(start), int(length or "1"))
-            for start, length in SAFE_PARSE_HUNK_HEADER.findall(self.text)
+            for start, length in SAFE_PARSE_HUNK_HEADER.findall(
+                self.text.lstrip("@").split("@", 1)[0]
+            )
         ]
 
 

--- a/tests/test_hunk_counting.py
+++ b/tests/test_hunk_counting.py
@@ -6,6 +6,7 @@ from GitSavvy.tests.parameterized import parameterized as p
 from GitSavvy.core.fns import accumulate, unzip
 
 import GitSavvy.core.commands.diff as module
+from GitSavvy.core.parse_diff import HunkHeader
 
 
 f1 = """\
@@ -274,4 +275,16 @@ class TestDiffPatchGeneration(DeferrableTestCase):
             else:
                 raise _ExpectedFailure(sys.exc_info())
 
+        self.assertEqual(expected, actual)
+
+
+class HunkHeaderNumberExtraction(DeferrableTestCase):
+    @p.expand([
+        ("@@ -685,8 +686,14 @@ ...", [(685, 8), (686, 14)]),
+        ("@@@ -685,8 -644 +686,14 @@@ ...", [(685, 8), (644, 1), (686, 14)]),
+        ('@@ -7,0 +8 @@ RCall = "6f49c342-dc21-5d91-9882-a32aef131414"', [(7, 0), (8, 1)]),
+        ("@@ -295 +313 @@ docs-main:iai-2.0.0:", [(295, 1), (313, 1)]),
+    ])
+    def test_safely_parse_metadata(self, input, expected):
+        actual = HunkHeader(input).safely_parse_metadata()
         self.assertEqual(expected, actual)


### PR DESCRIPTION
Fixes #1452

We currently parse the whole line which can fail because the text after
the second "@" marker can contain arbitrary context information.

The fix is to parse only the text between the "@" markers.