### PR TITLE
Refactor getting the repo path

### DIFF
--- a/core/commands/amend.py
+++ b/core/commands/amend.py
@@ -16,6 +16,11 @@ class gs_amend(WindowCommand, GitCommand):
 
 class gs_quick_stage_current_file_and_amend(gs_amend, GitCommand):
     def run(self):
-        self.git("add", "--", self.file_path)
-        self.window.status_message("staged {}".format(self.get_rel_path(self.file_path)))
+        file_path = self.file_path
+        if not file_path:
+            self.window.status_message("Cannot staged unnamed buffer.")
+            return
+
+        self.git("add", "--", file_path)
+        self.window.status_message("staged {}".format(self.get_rel_path(file_path)))
         super().run()

--- a/core/commands/init.py
+++ b/core/commands/init.py
@@ -105,7 +105,7 @@ class GsClone(WindowCommand, GitCommand):
             if not os.path.exists(os.path.join(folder, project, ".git")):
                 return os.path.join(folder, project)
             else:
-                parent = os.path.realpath(os.path.join(folder, ".."))
+                parent = os.path.dirname(folder)
                 return os.path.join(parent, project)
         return ""
 

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -637,12 +637,7 @@ class gs_inline_diff_stage_or_reset_base(TextCommand, GitCommand):
             flash(self.view, "Not on a hunk.")
             return
 
-        rel_path = self.get_rel_path()
-        if os.name == "nt":
-            # Git expects `/`-delimited relative paths in diff.
-            rel_path = rel_path.replace("\\", "/")
-        header = DIFF_HEADER.format(path=rel_path)
-
+        header = DIFF_HEADER.format(path=self.get_rel_path())
         full_diff = header + diff_lines + "\n"
 
         # The three argument combinations below result from the following

--- a/core/commands/mv.py
+++ b/core/commands/mv.py
@@ -35,4 +35,3 @@ class GsMvCurrentFileCommand(WindowCommand, GitCommand):
         v = self.window.find_open_file(file_path)
         if v:
             v.retarget(new_path)
-            v.settings().set("git_savvy.file_path", os.path.realpath(new_path))

--- a/core/commands/status_bar.py
+++ b/core/commands/status_bar.py
@@ -47,10 +47,11 @@ class GsUpdateStatusBarCommand(TextCommand, GitCommand):
         if not self.savvy_settings.get("git_status_in_status_bar"):
             return
 
-        # Ignore all possible errors
         try:
-            self.get_repo_path(offer_init=False)
-            short_status = self.get_branch_status_short()
-            self.view.set_status("gitsavvy-repo-status", short_status)
+            # Explicitly check `find_repo_path` first which does not offer
+            # automatic initialization on failure.
+            repo_path = self.find_repo_path()
+            short_status = self.get_branch_status_short() if repo_path else ""
         except Exception:
-            self.view.erase_status("gitsavvy-repo-status")
+            short_status = ""
+        view.set_status("gitsavvy-repo-status", short_status)

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -419,19 +419,20 @@ class _GitCommand(SettingsMixin):
         # type: (bool) -> str
         view = self._current_view()
         repo_path = view.settings().get("git_savvy.repo_path") if view else None
+        if repo_path and os.path.exists(repo_path):
+            return repo_path
 
-        if not repo_path or not os.path.exists(repo_path):
-            repo_path = self.find_repo_path()
-            if not repo_path:
-                window = self._current_window()
-                if not window:
-                    raise RuntimeError("Window does not exist.")
+        repo_path = self.find_repo_path()
+        if repo_path:
+            return repo_path
 
-                if offer_init and window.folders():
-                    enqueue_on_worker(window.run_command, "gs_offer_init")
-                raise ValueError("Not a git repository.")
+        window = self._current_window()
+        if not window:
+            raise RuntimeError("Window does not exist.")
 
-        return repo_path
+        if offer_init and window.folders():
+            enqueue_on_worker(window.run_command, "gs_offer_init")
+        raise ValueError("Not a git repository.")
 
     @property
     def repo_path(self):

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -377,18 +377,18 @@ class _GitCommand(SettingsMixin):
         if view and view.file_name():
             file_dir = os.path.dirname(view.file_name())
             if os.path.isdir(file_dir):
-                repo_path = self.find_git_toplevel(file_dir)
+                repo_path = self._find_git_toplevel(file_dir)
 
         # fallback: use the first folder if the current file is not inside a git repo
         if not repo_path:
             if window:
                 folders = window.folders()
                 if folders and os.path.isdir(folders[0]):
-                    repo_path = self.find_git_toplevel(folders[0])
+                    repo_path = self._find_git_toplevel(folders[0])
 
         return os.path.realpath(repo_path) if repo_path else None
 
-    def find_git_toplevel(self, folder):
+    def _find_git_toplevel(self, folder):
         # type: (str) -> Optional[str]
         repo_path = self.git(
             "rev-parse",

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -477,7 +477,10 @@ class _GitCommand(SettingsMixin):
         """
         file_path = self.file_path if abs_path is NOT_SET else os.path.realpath(abs_path)
         assert file_path
-        return os.path.relpath(file_path, start=self.repo_path)
+        rel_path = os.path.relpath(file_path, start=self.repo_path)
+        if os.name == "nt":
+            return rel_path.replace("\\", "/")
+        return rel_path
 
     def _add_global_flags(self, git_cmd, args):
         # type: (str, List[str]) -> List[str]

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -346,6 +346,13 @@ class _GitCommand(SettingsMixin):
 
         return git_path
 
+    def _current_window(self):
+        # type: () -> Optional[sublime.Window]
+        try:
+            return self.window  # type: ignore[attr-defined]
+        except AttributeError:
+            return self.view.window()  # type: ignore[attr-defined]
+
     def _current_view(self):
         # type: () -> Optional[sublime.View]
         try:
@@ -413,7 +420,7 @@ class _GitCommand(SettingsMixin):
         if not repo_path or not os.path.exists(repo_path):
             repo_path = self.find_repo_path()
             if not repo_path:
-                window = view.window()
+                window = self._current_window()
                 if not window:
                     raise RuntimeError("Window does not exist.")
 

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -28,7 +28,7 @@ from GitSavvy.core.runtime import run_as_future
 
 MYPY = False
 if MYPY:
-    from typing import Callable, Deque, Iterator, List, Sequence, Tuple, Union
+    from typing import Callable, Deque, Iterator, List, Optional, Sequence, Tuple, Union
 
 
 git_path = None
@@ -347,6 +347,7 @@ class _GitCommand(SettingsMixin):
         return git_path
 
     def find_working_dir(self):
+        # type: () -> Optional[str]
         view = self.window.active_view() if hasattr(self, "window") else self.view
         window = view.window() if view else None
 
@@ -363,6 +364,7 @@ class _GitCommand(SettingsMixin):
         return None
 
     def find_repo_path(self):
+        # type: () -> Optional[str]
         """
         Similar to find_working_dir, except that it does not stop on the first
         directory found, rather on the first git repository found.
@@ -388,6 +390,7 @@ class _GitCommand(SettingsMixin):
         return os.path.realpath(repo_path) if repo_path else None
 
     def find_git_toplevel(self, folder, throw_on_error):
+        # type: (str, bool) -> Optional[str]
         stdout = self.git(
             "rev-parse",
             "--show-toplevel",
@@ -398,6 +401,7 @@ class _GitCommand(SettingsMixin):
         return os.path.realpath(repo) if repo else None
 
     def get_repo_path(self, offer_init=True):
+        # type: (bool) -> str
         # The below condition will be true if run from a WindowCommand and false
         # from a TextCommand.
         view = self.window.active_view() if hasattr(self, "window") else self.view

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -377,25 +377,24 @@ class _GitCommand(SettingsMixin):
         if view and view.file_name():
             file_dir = os.path.dirname(view.file_name())
             if os.path.isdir(file_dir):
-                repo_path = self.find_git_toplevel(file_dir, throw_on_error=False)
+                repo_path = self.find_git_toplevel(file_dir)
 
         # fallback: use the first folder if the current file is not inside a git repo
         if not repo_path:
             if window:
                 folders = window.folders()
                 if folders and os.path.isdir(folders[0]):
-                    repo_path = self.find_git_toplevel(
-                        folders[0], throw_on_error=False)
+                    repo_path = self.find_git_toplevel(folders[0])
 
         return os.path.realpath(repo_path) if repo_path else None
 
-    def find_git_toplevel(self, folder, throw_on_error):
-        # type: (str, bool) -> Optional[str]
+    def find_git_toplevel(self, folder):
+        # type: (str) -> Optional[str]
         stdout = self.git(
             "rev-parse",
             "--show-toplevel",
             working_dir=folder,
-            throw_on_error=throw_on_error
+            throw_on_error=False
         )
         repo = stdout.strip()
         return os.path.realpath(repo) if repo else None

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -454,6 +454,7 @@ class _GitCommand(SettingsMixin):
 
     @property
     def file_path(self):
+        # type: () -> Optional[str]
         """
         Return the absolute path to the file this view interacts with. In most
         cases, this will be the open file.  However, for views with special
@@ -461,6 +462,9 @@ class _GitCommand(SettingsMixin):
         view's `git_savvy.file_path` setting.
         """
         view = self._current_view()
+        if not view:
+            return None
+
         fpath = view.settings().get("git_savvy.file_path")
 
         if not fpath:

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -397,6 +397,11 @@ class _GitCommand(SettingsMixin):
         Similar to find_working_dir, except that it does not stop on the first
         directory found, rather on the first git repository found.
         """
+        view = self._current_view()
+        repo_path = view.settings().get("git_savvy.repo_path") if view else None
+        if repo_path and os.path.exists(repo_path):
+            return repo_path
+
         return next(filter_(map(self._find_git_toplevel, self._search_paths())), None)
 
     def _find_git_toplevel(self, folder):
@@ -417,11 +422,6 @@ class _GitCommand(SettingsMixin):
 
     def get_repo_path(self, offer_init=True):
         # type: (bool) -> str
-        view = self._current_view()
-        repo_path = view.settings().get("git_savvy.repo_path") if view else None
-        if repo_path and os.path.exists(repo_path):
-            return repo_path
-
         repo_path = self.find_repo_path()
         if repo_path:
             return repo_path

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -420,8 +420,8 @@ class _GitCommand(SettingsMixin):
                 repo_paths[folder] = repo_path
             return repo_path
 
-    def get_repo_path(self, offer_init=True):
-        # type: (bool) -> str
+    def get_repo_path(self):
+        # type: () -> str
         repo_path = self.find_repo_path()
         if repo_path:
             return repo_path
@@ -430,7 +430,7 @@ class _GitCommand(SettingsMixin):
         if not window:
             raise RuntimeError("Window does not exist.")
 
-        if offer_init and window.folders():
+        if window.folders():
             enqueue_on_worker(window.run_command, "gs_offer_init")
         raise ValueError("Not a git repository.")
 

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -24,6 +24,7 @@ from ..common import util
 from .settings import SettingsMixin
 from GitSavvy.core.fns import filter_
 from GitSavvy.core.runtime import enqueue_on_worker, run_as_future
+from GitSavvy.core.utils import resolve_path
 
 
 MYPY = False
@@ -462,14 +463,14 @@ class _GitCommand(SettingsMixin):
             return None
 
         fpath = view.settings().get("git_savvy.file_path") or view.file_name()
-        return os.path.realpath(fpath) if fpath else fpath
+        return resolve_path(fpath) if fpath else fpath
 
     def get_rel_path(self, abs_path=NOT_SET):
         # type: (str) -> str
         """
         Return the file path relative to the repo root.
         """
-        file_path = self.file_path if abs_path is NOT_SET else os.path.realpath(abs_path)
+        file_path = self.file_path if abs_path is NOT_SET else resolve_path(abs_path)
         assert file_path
         rel_path = os.path.relpath(file_path, start=self.repo_path)
         if os.name == "nt":

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -45,6 +45,8 @@ encoded files.  In the latter case use the 'fallback_encoding' setting.
 MIN_GIT_VERSION = (2, 16, 0)
 GIT_TOO_OLD_MSG = "Your Git version is too old. GitSavvy requires {:d}.{:d}.{:d} or above."
 
+NOT_SET = "<NOT_SET>"
+
 
 def communicate_and_log(proc, stdin, log):
     # type: (subprocess.Popen, bytes, Callable[[bytes], None]) -> Tuple[bytes, bytes]
@@ -468,12 +470,14 @@ class _GitCommand(SettingsMixin):
         fpath = view.settings().get("git_savvy.file_path") or view.file_name()
         return os.path.realpath(fpath) if fpath else fpath
 
-    def get_rel_path(self, abs_path=None):
+    def get_rel_path(self, abs_path=NOT_SET):
+        # type: (str) -> str
         """
         Return the file path relative to the repo root.
         """
-        path = abs_path or self.file_path
-        return os.path.relpath(os.path.realpath(path), start=self.repo_path)
+        file_path = self.file_path if abs_path is NOT_SET else os.path.realpath(abs_path)
+        assert file_path
+        return os.path.relpath(file_path, start=self.repo_path)
 
     def _add_global_flags(self, git_cmd, args):
         # type: (str, List[str]) -> List[str]

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -417,7 +417,7 @@ class _GitCommand(SettingsMixin):
                 if window:
                     if offer_init and window.folders():
                         sublime.set_timeout_async(
-                            lambda: sublime.active_window().run_command("gs_offer_init"))
+                            lambda: window.run_command("gs_offer_init"))
                     raise ValueError("Not a git repository.")
                 else:
                     raise RuntimeError("Window does not exist.")

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -427,7 +427,7 @@ class _GitCommand(SettingsMixin):
                 if file_name and os.path.realpath(file_name).startswith(repo_path + os.path.sep):
                     view.settings().set("git_savvy.repo_path", repo_path)
 
-        return os.path.realpath(repo_path)
+        return repo_path
 
     @property
     def repo_path(self):

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -371,17 +371,19 @@ class _GitCommand(SettingsMixin):
 
     def _search_paths(self):
         # type: () -> Iterator[str]
-        file_name = self._current_filename()
-        if file_name:
-            file_dir = os.path.dirname(file_name)
-            if os.path.isdir(file_dir):
-                yield file_dir
+        def __search_paths():
+            # type: () -> Iterator[str]
+            file_name = self._current_filename()
+            if file_name:
+                yield os.path.dirname(file_name)
 
-        window = self._current_window()
-        if window:
-            folders = window.folders()
-            if folders and os.path.isdir(folders[0]):
-                yield folders[0]
+            window = self._current_window()
+            if window:
+                folders = window.folders()
+                if folders:
+                    yield folders[0]
+
+        return filter(os.path.isdir, __search_paths())
 
     def find_working_dir(self):
         # type: () -> Optional[str]

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -465,13 +465,7 @@ class _GitCommand(SettingsMixin):
         if not view:
             return None
 
-        fpath = view.settings().get("git_savvy.file_path")
-
-        if not fpath:
-            fpath = view.file_name()
-            if fpath:
-                view.settings().set("git_savvy.file_path", os.path.realpath(fpath))
-
+        fpath = view.settings().get("git_savvy.file_path") or view.file_name()
         return os.path.realpath(fpath) if fpath else fpath
 
     def get_rel_path(self, abs_path=None):

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -346,9 +346,16 @@ class _GitCommand(SettingsMixin):
 
         return git_path
 
+    def _current_view(self):
+        # type: () -> Optional[sublime.View]
+        try:
+            return self.view  # type: ignore[attr-defined]
+        except AttributeError:
+            return self.window.active_view()  # type: ignore[attr-defined]
+
     def find_working_dir(self):
         # type: () -> Optional[str]
-        view = self.window.active_view() if hasattr(self, "window") else self.view
+        view = self._current_view()
         window = view.window() if view else None
 
         if view and view.file_name():
@@ -369,7 +376,7 @@ class _GitCommand(SettingsMixin):
         Similar to find_working_dir, except that it does not stop on the first
         directory found, rather on the first git repository found.
         """
-        view = self.window.active_view() if hasattr(self, "window") else self.view
+        view = self._current_view()
         window = view.window() if view else None
         repo_path = None
 
@@ -400,9 +407,7 @@ class _GitCommand(SettingsMixin):
 
     def get_repo_path(self, offer_init=True):
         # type: (bool) -> str
-        # The below condition will be true if run from a WindowCommand and false
-        # from a TextCommand.
-        view = self.window.active_view() if hasattr(self, "window") else self.view
+        view = self._current_view()
         repo_path = view.settings().get("git_savvy.repo_path") if view else None
 
         if not repo_path or not os.path.exists(repo_path):
@@ -453,9 +458,7 @@ class _GitCommand(SettingsMixin):
         functionality, this default behavior can be overridden by setting the
         view's `git_savvy.file_path` setting.
         """
-        # The below condition will be true if run from a WindowCommand and false
-        # from a TextCommand.
-        view = self.window.active_view() if hasattr(self, "window") else self.view
+        view = self._current_view()
         fpath = view.settings().get("git_savvy.file_path")
 
         if not fpath:

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -371,15 +371,13 @@ class _GitCommand(SettingsMixin):
 
     def find_working_dir(self):
         # type: () -> Optional[str]
-        view = self._current_view()
-        window = view.window() if view else None
-
         file_name = self._current_filename()
         if file_name:
             file_dir = os.path.dirname(file_name)
             if os.path.isdir(file_dir):
                 return file_dir
 
+        window = self._current_window()
         if window:
             folders = window.folders()
             if folders and os.path.isdir(folders[0]):
@@ -393,8 +391,6 @@ class _GitCommand(SettingsMixin):
         Similar to find_working_dir, except that it does not stop on the first
         directory found, rather on the first git repository found.
         """
-        view = self._current_view()
-        window = view.window() if view else None
         repo_path = None
 
         file_name = self._current_filename()
@@ -405,6 +401,7 @@ class _GitCommand(SettingsMixin):
 
         # fallback: use the first folder if the current file is not inside a git repo
         if not repo_path:
+            window = self._current_window()
             if window:
                 folders = window.folders()
                 if folders and os.path.isdir(folders[0]):

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -430,12 +430,6 @@ class _GitCommand(SettingsMixin):
                     enqueue_on_worker(window.run_command, "gs_offer_init")
                 raise ValueError("Not a git repository.")
 
-            if view:
-                file_name = view.file_name()
-                # only set "git_savvy.repo_path" when the current file is in repo_path
-                if file_name and os.path.realpath(file_name).startswith(repo_path + os.path.sep):
-                    view.settings().set("git_savvy.repo_path", repo_path)
-
         return repo_path
 
     @property

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -362,13 +362,21 @@ class _GitCommand(SettingsMixin):
         except AttributeError:
             return self.window.active_view()  # type: ignore[attr-defined]
 
+    def _current_filename(self):
+        # type: () -> Optional[str]
+        try:
+            return self.view.file_name()  # type: ignore[attr-defined]
+        except AttributeError:
+            return self.window.extract_variables().get("file")  # type: ignore[attr-defined]
+
     def find_working_dir(self):
         # type: () -> Optional[str]
         view = self._current_view()
         window = view.window() if view else None
 
-        if view and view.file_name():
-            file_dir = os.path.dirname(view.file_name())
+        file_name = self._current_filename()
+        if file_name:
+            file_dir = os.path.dirname(file_name)
             if os.path.isdir(file_dir):
                 return file_dir
 
@@ -389,9 +397,9 @@ class _GitCommand(SettingsMixin):
         window = view.window() if view else None
         repo_path = None
 
-        # try the current file first
-        if view and view.file_name():
-            file_dir = os.path.dirname(view.file_name())
+        file_name = self._current_filename()
+        if file_name:
+            file_dir = os.path.dirname(file_name)
             if os.path.isdir(file_dir):
                 repo_path = self._find_git_toplevel(file_dir)
 

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -414,12 +414,12 @@ class _GitCommand(SettingsMixin):
             repo_path = self.find_repo_path()
             if not repo_path:
                 window = view.window()
-                if window:
-                    if offer_init and window.folders():
-                        enqueue_on_worker(window.run_command, "gs_offer_init")
-                    raise ValueError("Not a git repository.")
-                else:
+                if not window:
                     raise RuntimeError("Window does not exist.")
+
+                if offer_init and window.folders():
+                    enqueue_on_worker(window.run_command, "gs_offer_init")
+                raise ValueError("Not a git repository.")
 
             if view:
                 file_name = view.file_name()

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -23,7 +23,7 @@ import sublime
 from ..common import util
 from .settings import SettingsMixin
 from GitSavvy.core.fns import filter_
-from GitSavvy.core.runtime import run_as_future
+from GitSavvy.core.runtime import enqueue_on_worker, run_as_future
 
 
 MYPY = False
@@ -416,8 +416,7 @@ class _GitCommand(SettingsMixin):
                 window = view.window()
                 if window:
                     if offer_init and window.folders():
-                        sublime.set_timeout_async(
-                            lambda: window.run_command("gs_offer_init"))
+                        enqueue_on_worker(window.run_command, "gs_offer_init")
                     raise ValueError("Not a git repository.")
                 else:
                     raise RuntimeError("Window does not exist.")

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -390,14 +390,13 @@ class _GitCommand(SettingsMixin):
 
     def find_git_toplevel(self, folder):
         # type: (str) -> Optional[str]
-        stdout = self.git(
+        repo_path = self.git(
             "rev-parse",
             "--show-toplevel",
             working_dir=folder,
             throw_on_error=False
-        )
-        repo = stdout.strip()
-        return os.path.realpath(repo) if repo else None
+        ).strip() or None
+        return os.path.normpath(repo_path) if repo_path else None
 
     def get_repo_path(self, offer_init=True):
         # type: (bool) -> str

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -415,14 +415,10 @@ class _GitCommand(SettingsMixin):
             if not repo_path:
                 window = view.window()
                 if window:
-                    if window.folders():
-                        # offer initialization
-                        if offer_init:
-                            sublime.set_timeout_async(
-                                lambda: sublime.active_window().run_command("gs_offer_init"))
-                        raise ValueError("Not a git repository.")
-                    else:
-                        raise ValueError("Unable to determine Git repo path.")
+                    if offer_init and window.folders():
+                        sublime.set_timeout_async(
+                            lambda: sublime.active_window().run_command("gs_offer_init"))
+                    raise ValueError("Not a git repository.")
                 else:
                     raise RuntimeError("Window does not exist.")
 

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -410,7 +410,7 @@ class _GitCommand(SettingsMixin):
                 if folders and os.path.isdir(folders[0]):
                     repo_path = self._find_git_toplevel(folders[0])
 
-        return os.path.realpath(repo_path) if repo_path else None
+        return repo_path
 
     def _find_git_toplevel(self, folder):
         # type: (str) -> Optional[str]

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -427,7 +427,7 @@ class _GitCommand(SettingsMixin):
                 if file_name and os.path.realpath(file_name).startswith(repo_path + os.path.sep):
                     view.settings().set("git_savvy.repo_path", repo_path)
 
-        return os.path.realpath(repo_path) if repo_path else repo_path
+        return os.path.realpath(repo_path)
 
     @property
     def repo_path(self):

--- a/core/git_mixins/history.py
+++ b/core/git_mixins/history.py
@@ -213,7 +213,6 @@ class HistoryMixin(mixin_base):
     def _get_file_content_at_commit(self, filename, commit_hash):
         # type: (str, Optional[str]) -> str
         filename = self.get_rel_path(filename)
-        filename = filename.replace('\\', '/')
         return self.git("show", "{}:{}".format(commit_hash or "", filename))
 
     def find_matching_lineno(self, base_commit="HEAD", target_commit="HEAD", line=1, file_path=None):

--- a/tests/test_status_dashboard.py
+++ b/tests/test_status_dashboard.py
@@ -10,16 +10,6 @@ from GitSavvy.tests.parameterized import parameterized as p
 from GitSavvy.core.interfaces.status import StatusInterface, get_selected_subjects, GitCommand
 
 
-if os.name == 'nt':
-    # On Windows, `find_all_results` returns pseudo linux paths
-    # E.g. `/C/not/here/README.md`
-    def cleanup_fpath(fpath):
-        return fpath[2:]
-else:
-    def cleanup_fpath(fpath):
-        return fpath
-
-
 class TestStatusDashboard(DeferrableTestCase):
     @classmethod
     def setUpClass(cls):
@@ -97,7 +87,7 @@ class TestStatusDashboard(DeferrableTestCase):
         yield lambda: view.find('fix-1048', 0, sublime.LITERAL)
 
         results = view.find_all_results()
-        actual = [cleanup_fpath(fpath) for fpath, _, _ in results]
+        actual = [fpath for fpath, _, _ in results]
         expected = [
             '/not/here/modified_file',
             '/not/here/staged_and_unstaged_changes',


### PR DESCRIPTION
This is mostly a boring refactoring around `self.repo_path`.  Some guidance:

* Make the dependencies more clear.  Do we need a *view*, or a *window*, or a *filename*?   
* Avoid repeated "realpath" calls.  On Windows we never had this functionality anyway, it was a noop.  But also `git --show-toplevel` already returns the resolved path.
* Implement `resolve_path` (as a primitive `realpath`) for all OSes.  (We still need this for `file_path` as `repo_path` is always resolved.)
* Do not cache the `file_path` nor the `repo_path` on the view.  