### PR TITLE
Search for toplevel git dir without asking git

### DIFF
--- a/common/util/debug.py
+++ b/common/util/debug.py
@@ -47,6 +47,12 @@ def make_log_message(_type, **kwargs):
     return message
 
 
+def dprint(*args, **kwargs):
+    global enabled
+    if enabled:
+        print(*args, **kwargs)
+
+
 def log_git(command, stdin, stdout, stderr, seconds):
     """ Add git command details to debug log """
     global enabled

--- a/common/util/debug.py
+++ b/common/util/debug.py
@@ -6,6 +6,11 @@ import threading
 from ...core.settings import GitSavvySettings
 
 
+MYPY = False
+if MYPY:
+    from typing import Optional, Sequence, Union
+
+
 # Preserve state of `enabled` during hot-reloads
 try:
     enabled
@@ -53,14 +58,32 @@ def dprint(*args, **kwargs):
         print(*args, **kwargs)
 
 
-def log_git(command, stdin, stdout, stderr, seconds):
+@functools.lru_cache(maxsize=1)
+def print_cwd_change(cwd, left_space):
+    # type: (str, int) -> None
+    print('\n', ' ' * left_space, '  [{}]'.format(cwd))
+
+
+def log_git(
+    command,  # type: Sequence[Optional[str]]
+    cwd,      # type: str
+    stdin,    # type: Optional[Union[str, bytes]]
+    stdout,   # type: Optional[Union[str, bytes]]
+    stderr,   # type: Optional[Union[str, bytes]]
+    seconds   # type: float
+):
+    # type: (...) -> None
     """ Add git command details to debug log """
     global enabled
     if enabled:
-        print(' ({thread}) [{runtime:3.0f}ms] $ {cmd}'.format(
+        pre_info = "({thread}) [{runtime:3.0f}ms]".format(
             thread=threading.current_thread().name[0],
-            cmd=' '.join(['git'] + list(filter(None, command))),
             runtime=seconds * 1000,
+        )
+        print_cwd_change(cwd, left_space=len(pre_info))
+        print(' {pre_info} $ {cmd}'.format(
+            pre_info=pre_info,
+            cmd=' '.join(['git'] + list(filter(None, command))),
         ))
 
     message = make_log_message(

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -447,7 +447,7 @@ def log_git_command(fn):
             saved_exception = e
         finally:
             end_time = time.perf_counter()
-            util.debug.log_git(args, None, "<SNIP>", stderr, end_time - start_time)
+            util.debug.log_git(args, self.repo_path, None, "<SNIP>", stderr, end_time - start_time)
             if saved_exception:
                 raise saved_exception from None
     return decorated

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -138,6 +138,11 @@ def search_for_git(folder):
         return None
 
 
+def is_subpath(topfolder, path):
+    # type: (str, str) -> bool
+    return os.path.commonprefix([topfolder, path]) == topfolder
+
+
 class _GitCommand(SettingsMixin):
 
     """
@@ -407,7 +412,11 @@ class _GitCommand(SettingsMixin):
             if window:
                 folders = window.folders()
                 if folders:
-                    yield folders[0]
+                    if (
+                        not file_name
+                        or not is_subpath(resolve_path(folders[0]), resolve_path(file_name))
+                    ):
+                        yield folders[0]
 
         return filter(os.path.isdir, __search_paths())
 

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -252,7 +252,7 @@ class _GitCommand(SettingsMixin):
         finally:
             if not just_the_proc:
                 end = time.time()
-                util.debug.log_git(final_args, stdin, stdout, stderr, end - start)
+                util.debug.log_git(final_args, working_dir, stdin, stdout, stderr, end - start)
                 if show_panel:
                     log("\n[Done in {:.2f}s]".format(end - start))
 

--- a/core/utils.py
+++ b/core/utils.py
@@ -316,6 +316,15 @@ else:
     resolve_path = _resolve_path
 
 
+def paths_upwards(path):
+    # type: (str) -> Iterator[str]
+    while True:
+        yield path
+        path, name = os.path.split(path)
+        if not name or path == "/":
+            break
+
+
 class Cache(OrderedDict):
     def __init__(self, maxsize=128):
         assert maxsize > 0


### PR DESCRIPTION
- Instead of asking `git --show-toplevel` traverse the path upwards looking for a `.git` file/folder.  This is of course significant faster.

- Instead of working with a resolved ("real") repo path, try to use the user visible, non-real path.  

For example, if the user maps a folder to `D:\my-project` and starts `subl` from there,  do **not** show `C:\\Users\foogar\da\dum\my-project` as the "real" top folder.  The "real" folder is a detail the user should not see.

Replaces #1081 