### PR TITLE
Suggest remote branch when creating a PR

### DIFF
--- a/core/base_commands.py
+++ b/core/base_commands.py
@@ -12,10 +12,14 @@ from GitSavvy.core.ui_mixins.quick_panel import show_branch_panel
 
 MYPY = False
 if MYPY:
-    from typing import Any, Callable, Dict, Iterator, List, TypeVar
+    from typing import Any, Callable, Dict, Iterator, List, Protocol, TypeVar
     CommandT = TypeVar("CommandT", bound=sublime_plugin.Command)
     Args = Dict[str, Any]
-    Kont = Callable[[object], None]
+
+    class Kont(Protocol):
+        def __call__(self, val: object, **kw: object) -> None:
+            pass
+
     ArgProvider = Callable[[CommandT, Args, Kont], None]
 
 
@@ -99,9 +103,10 @@ class Flag:
 
 
 def make_on_done_fn(kont, args, name):
-    def on_done(value):
+    def on_done(value, **kwargs):
         on_done.called = True  # type: ignore[attr-defined]
         args[name] = value
+        args.update(kwargs)
         kont()
     on_done.called = False  # type: ignore[attr-defined]
     return on_done

--- a/core/git_mixins/remotes.py
+++ b/core/git_mixins/remotes.py
@@ -3,10 +3,13 @@ from collections import OrderedDict
 
 MYPY = False
 if MYPY:
+    from typing import Dict
     from GitSavvy.core.git_command import (
         BranchesMixin,
         _GitCommand,
     )
+    name = str
+    url = str
 
     class mixin_base(
         BranchesMixin,
@@ -21,6 +24,7 @@ else:
 class RemotesMixin(mixin_base):
 
     def get_remotes(self):
+        # type: () -> Dict[name, url]
         """
         Get a list of remotes, provided as tuples of remote name and remote
         url/resource.

--- a/core/store.py
+++ b/core/store.py
@@ -17,6 +17,7 @@ if MYPY:
         {
             "status": WorkingDirState,
             "last_remote_used": Optional[str],
+            "last_remote_used_for_push": Optional[str],
             "last_remote_used_with_option_all": Optional[str],
             "short_hash_length": int,
         },

--- a/core/utils.py
+++ b/core/utils.py
@@ -225,8 +225,8 @@ def show_panel(
     )
 
 
-def show_actions_panel(window, actions):
-    # type: (sublime.Window, Sequence[ActionType]) -> None
+def show_actions_panel(window, actions, select=-1):
+    # type: (sublime.Window, Sequence[ActionType], int) -> None
     def on_selection(idx):
         # type: (int) -> None
         description, action = actions[idx]
@@ -235,7 +235,8 @@ def show_actions_panel(window, actions):
     show_panel(
         window,
         (action[0] for action in actions),
-        on_selection
+        on_selection,
+        selected_index=select
     )
 
 


### PR DESCRIPTION
Instead of always offering the remote/branch-name wizard suggest
a `remote/local_branch_name`.  This keeps the eye at the top of the
view on the Command Palette for the normal case.

For the remote branch name, always suggest the local name.  For the
remote name, respect the values `gitsavvy.pushdefault` and
`remote.pushdefault` from the config, and fallback to "fork", origin",
and then any other known name.

Always use an in memory cache `last_remote_used_for_push` which stores
the last used value.  This key is now distinct from `last_remote_used`.
Automatically persist a used remote in `gitsavvy.pushdefault` if the
suggestion was overriden by the user so it will be suggested the next
time; even after restarts.  Persist after the comlete wizard has been
finished, just before pushing, t.i. cancelling via `ESC` has no further
side effects and will not change the suggestion.

Note that we use `.pushdefault` as key suffix to get all values in one
"git config" call.

Replaces #1462 

![image](https://user-images.githubusercontent.com/8558/119797719-c4de8f00-beda-11eb-9e5c-7b4ceefc9e43.png)
