### PR TITLE
Implement `git_dir()` and use it

### DIFF
--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -120,7 +120,7 @@ class gs_commit(WindowCommand, GitCommand):
 
     def initialize_view(self, view, amend, initial_text):
         # type: (sublime.View, bool, str) -> None
-        merge_msg_path = os.path.join(self.repo_path, ".git", "MERGE_MSG")
+        merge_msg_path = os.path.join(self.git_dir, "MERGE_MSG")
 
         help_text = (
             COMMIT_HELP_TEXT_ALT

--- a/core/git_mixins/rewrite.py
+++ b/core/git_mixins/rewrite.py
@@ -204,10 +204,11 @@ class RewriteMixin(mixin_base):
 
     @property
     def _rebase_replay_dir(self):
+        # type: () -> str
         """
         A directory to store meta data for `rewrite_active_branch`
         """
-        return os.path.join(self.repo_path, ".git", "rebase-replay")
+        return os.path.join(self.git_dir, "rebase-replay")
 
     def rebase_rewritten(self):
         if self.in_rebase_merge():

--- a/core/git_mixins/status.py
+++ b/core/git_mixins/status.py
@@ -265,11 +265,11 @@ class StatusMixin(mixin_base):
 
     @property
     def _rebase_apply_dir(self):
-        return os.path.join(self.repo_path, ".git", "rebase-apply")
+        return os.path.join(self.git_dir, "rebase-apply")
 
     @property
     def _rebase_merge_dir(self):
-        return os.path.join(self.repo_path, ".git", "rebase-merge")
+        return os.path.join(self.git_dir, "rebase-merge")
 
     @property
     def _rebase_dir(self):
@@ -341,7 +341,7 @@ class StatusMixin(mixin_base):
 
     def _read_git_file(self, fname):
         # type: (str) -> str
-        path = os.path.join(self.repo_path, ".git", fname)
+        path = os.path.join(self.git_dir, fname)
         try:
             with open(path, "r") as f:
                 return f.read().strip()
@@ -350,11 +350,11 @@ class StatusMixin(mixin_base):
 
     def in_merge(self):
         # type: () -> bool
-        return os.path.exists(os.path.join(self.repo_path, ".git", "MERGE_HEAD"))
+        return os.path.exists(os.path.join(self.git_dir, "MERGE_HEAD"))
 
     def merge_head(self):
         # type: () -> str
-        path = os.path.join(self.repo_path, ".git", "MERGE_HEAD")
+        path = os.path.join(self.git_dir, "MERGE_HEAD")
         with open(path, "r") as f:
             commit_hash = f.read().strip()
         return self.get_short_hash(commit_hash)


### PR DESCRIPTION
Fixes #1461

Usually `{repo_path}/.git` is a folder but for workspaces it is a file
pointing to another folder in the main repository.  Introduce
`git_dir()` which returns the resolved, "real" git dir.

We use this where on the command line `git rev-parse --git-path FILE`
would be appropriate.