### PR TITLE
Iterate on workdir `status`

### DIFF
--- a/common/ui.py
+++ b/common/ui.py
@@ -114,6 +114,12 @@ class Interface():
         """
         pass
 
+    def on_new_dashboard(self):
+        """
+        Hook template method called after the first render.
+        """
+        pass
+
     def render(self, nuke_cursors=False):
         self.clear_regions()
         if hasattr(self, "pre_render"):
@@ -217,12 +223,6 @@ class Interface():
             self.view.sel(),
             valid_ranges=self.get_view_regions(region)
         )
-
-    def on_new_dashboard(self):
-        """
-        Hook template method called after the first render.
-        """
-        pass
 
 
 def partial(key):

--- a/common/ui.py
+++ b/common/ui.py
@@ -24,7 +24,6 @@ EDIT_DEFAULT_HELP_TEXT = "## To finalize your edit, press {super_key}+Enter.  To
 
 class Interface():
     interface_type = ""
-    read_only = True
     syntax_file = ""
 
     template = ""
@@ -90,7 +89,7 @@ class Interface():
         self.view.settings().set("git_savvy.help_hidden", GitSavvySettings().get("hide_help_menu"))
         self.view.set_syntax_file(self.syntax_file)
         self.view.set_scratch(True)
-        self.view.set_read_only(self.read_only)
+        self.view.set_read_only(True)
         util.view.disable_other_plugins(self.view)
         self.after_view_creation(self.view)
 

--- a/common/ui.py
+++ b/common/ui.py
@@ -77,9 +77,6 @@ class Interface():
             self.create_view(repo_path)
             sublime.set_timeout_async(self.on_new_dashboard, 0)
 
-        if hasattr(self, "tab_size"):
-            self.view.settings().set("tab_size", self.tab_size)
-
         interfaces[self.view.id()] = self
 
     def create_view(self, repo_path):

--- a/common/ui.py
+++ b/common/ui.py
@@ -107,6 +107,10 @@ class Interface():
 
         return self.view
 
+    def title(self):
+        # type: () -> str
+        raise NotImplementedError
+
     def after_view_creation(self, view):
         """
         Hook template method called after the view has been created.

--- a/common/ui.py
+++ b/common/ui.py
@@ -124,10 +124,12 @@ class Interface():
         """
         pass
 
+    def pre_render(self):
+        pass
+
     def render(self, nuke_cursors=False):
         self.clear_regions()
-        if hasattr(self, "pre_render"):
-            self.pre_render()
+        self.pre_render()
         rendered = self._render_template()
         self.view.run_command("gs_new_content_and_regions", {
             "content": rendered,

--- a/common/ui.py
+++ b/common/ui.py
@@ -127,6 +127,9 @@ class Interface():
     def pre_render(self):
         pass
 
+    def reset_cursor(self):
+        pass
+
     def render(self, nuke_cursors=False):
         self.clear_regions()
         self.pre_render()
@@ -136,7 +139,7 @@ class Interface():
             "regions": self.regions,
             "nuke_cursors": nuke_cursors
         })
-        if hasattr(self, "reset_cursor") and nuke_cursors:
+        if nuke_cursors:
             self.reset_cursor()
 
     def _render_template(self):

--- a/common/ui.py
+++ b/common/ui.py
@@ -77,6 +77,7 @@ class Interface():
             sublime.set_timeout_async(self.on_new_dashboard, 0)
 
         interfaces[self.view.id()] = self
+        self.on_create()
 
     def create_view(self, repo_path):
         window = sublime.active_window()
@@ -117,6 +118,18 @@ class Interface():
     def on_new_dashboard(self):
         """
         Hook template method called after the first render.
+        """
+        pass
+
+    def on_create(self):
+        """
+        Hook template method called after a new interface object has been created.
+        """
+        pass
+
+    def on_close(self):
+        """
+        Hook template method called after a view has been closed.
         """
         pass
 
@@ -293,12 +306,11 @@ class GsInterfaceCloseCommand(TextCommand):
     """
 
     def run(self, edit):
-        sublime.set_timeout_async(self.run_async, 0)
-
-    def run_async(self):
         view_id = self.view.id()
-        if view_id in interfaces:
-            del interfaces[view_id]
+        interface = get_interface(view_id)
+        if interface:
+            interface.on_close()
+            enqueue_on_worker(lambda: interfaces.pop(view_id))
 
 
 class GsInterfaceRefreshCommand(TextCommand):

--- a/common/util/view.py
+++ b/common/util/view.py
@@ -85,7 +85,7 @@ def refresh_gitsavvy_interfaces(
     if refresh_status_bar:
         av = window.active_view()
         if av:
-            av.run_command("gs_update_status_bar")
+            av.run_command("gs_update_status")
 
     for group in range(window.num_groups()):
         view = window.active_view_in_group(group)
@@ -117,7 +117,7 @@ def refresh_gitsavvy(
         view.run_command("gs_log_graph_refresh")
 
     if view.window() and refresh_status_bar:
-        view.run_command("gs_update_status_bar")
+        view.run_command("gs_update_status")
 
     window = view.window()
     if window and refresh_sidebar:

--- a/core/commands/fixup.py
+++ b/core/commands/fixup.py
@@ -8,20 +8,14 @@ fixup_command = re.compile("^fixup! (.*)")
 
 class GsFixupFromStageCommand(GsLogCurrentBranchCommand):
     def run(self):
-        (staged_entries,
-         unstaged_entries,
-         untracked_entries,
-         conflict_entries) = self.get_working_dir_status()
-
-        if len(unstaged_entries) + len(conflict_entries) > 0:
+        status = self.get_working_dir_status()
+        if status.unstaged_files or status.merge_conflicts:
             sublime.message_dialog(
                 "Unable to perform rebase actions while repo is in unclean state."
             )
             return
-        if len(staged_entries) == 0:
-            sublime.message_dialog(
-                "No staged files."
-            )
+        if not status.staged_files:
+            sublime.message_dialog("No staged files.")
             return
         super().run()
 

--- a/core/commands/quick_stage.py
+++ b/core/commands/quick_stage.py
@@ -97,22 +97,13 @@ class GsQuickStageCommand(WindowCommand, GitCommand):
         Determine the git status of the current working directory, and return
         a list of menu options for each file that is shown.
         """
-        (staged_entries,
-         unstaged_entries,
-         untracked_entries,
-         conflict_entries) = self.get_working_dir_status()
-
-        if not (
-            staged_entries
-            or unstaged_entries
-            or untracked_entries
-            or conflict_entries
-        ):
+        status = self.get_working_dir_status()
+        if status.clean:
             return [MenuOption(False, CLEAN_WORKING_DIR, None, None)]
 
         menu_options = []
 
-        for entry in unstaged_entries:
+        for entry in status.unstaged_files:
             filename = (
                 entry.path + " <- " + entry.path_alt
                 if entry.path_alt
@@ -121,19 +112,19 @@ class GsQuickStageCommand(WindowCommand, GitCommand):
             menu_text = "[{0}] {1}".format(entry.working_status, filename)
             menu_options.append(MenuOption(True, menu_text, filename, False))
 
-        for entry in untracked_entries:
+        for entry in status.untracked_files:
             menu_text = "[{0}] {1}".format(entry.working_status, entry.path)
             menu_options.append(MenuOption(True, menu_text, entry.path, True))
 
-        for entry in conflict_entries:
+        for entry in status.merge_conflicts:
             menu_text = "[{0}] {1}".format(entry.working_status, entry.path)
             menu_options.append(MenuOption(True, menu_text, entry.path, False))
 
-        if unstaged_entries:
+        if status.unstaged_files:
             menu_options.append(MenuOption(True, ADD_ALL_UNSTAGED_FILES, None, None))
             menu_options.append(MenuOption(True, ADD_ALL_FILES, None, None))
 
-        staged_count = len(staged_entries)
+        staged_count = len(status.staged_files)
         if staged_count > 0:
             menu_options.append(MenuOption(False, STAGED.format(staged_count), None, None))
             menu_options.append(MenuOption(True, COMMIT, None, None))

--- a/core/commands/status_bar.py
+++ b/core/commands/status_bar.py
@@ -14,32 +14,11 @@ class GsStatusBarEventListener(EventListener):
         view.run_command("gs_update_status")
 
 
-def view_is_transient(view):
-    """Return whether a view can be considered 'transient'.
-
-    We especially want to exclude widgets and preview views.
-    """
-
-    # 'Detached' (already closed) views and previews don't have
-    # a window.
-    window = view.window()
-    if not window:
-        return True
-
-    if view.settings().get('is_widget'):
-        return True
-
-    return False
-
-
 class gs_update_status(TextCommand, GitCommand):
     def run(self, edit):
         enqueue_on_worker(throttled(self.run_impl, self.view))
 
     def run_impl(self, view):
-        if view_is_transient(view):
-            return
-
         repo_path = self.find_repo_path()
         if repo_path:
             try:

--- a/core/commands/status_bar.py
+++ b/core/commands/status_bar.py
@@ -51,7 +51,7 @@ class GsUpdateStatusBarCommand(TextCommand, GitCommand):
             # Explicitly check `find_repo_path` first which does not offer
             # automatic initialization on failure.
             repo_path = self.find_repo_path()
-            short_status = self.get_branch_status_short() if repo_path else ""
+            short_status = self.get_working_dir_status().short_status if repo_path else ""
         except Exception:
             short_status = ""
         view.set_status("gitsavvy-repo-status", short_status)

--- a/core/commands/status_bar.py
+++ b/core/commands/status_bar.py
@@ -22,7 +22,7 @@ class gs_update_status(TextCommand, GitCommand):
         repo_path = self.find_repo_path()
         if repo_path:
             try:
-                self.get_working_dir_status()
+                self.update_working_dir_status()
             except RuntimeError:
                 # Although with `if repo_path` we have enough to make the
                 # status call to git safe, the processing of the status

--- a/core/commands/status_bar.py
+++ b/core/commands/status_bar.py
@@ -7,9 +7,8 @@ from GitSavvy.core import store
 
 
 class GsStatusBarEventListener(EventListener):
-    # Note: `on_activated` is registered in global_events.py
-    def on_new(self, view):
-        view.run_command("gs_update_status")
+    def on_activated(self, view):
+        view.run_command("gs_draw_status_bar")
 
     def on_post_save(self, view):
         view.run_command("gs_update_status")
@@ -60,11 +59,22 @@ class gs_draw_status_bar(TextCommand, GitCommand):
     Update the short Git status in the Sublime status bar.
     """
 
-    def run(self, edit, repo_path):
+    def run(self, edit, repo_path=None):
         if not self.savvy_settings.get("git_status_in_status_bar"):
             return
-        if self.find_repo_path() == repo_path:
+
+        if not repo_path:
+            repo_path = self.find_repo_path()
+            if not repo_path:
+                return
+        elif repo_path != self.find_repo_path():
+            return
+
+        try:
             short_status = store.current_state(repo_path)["status"].short_status
+        except Exception:
+            ...
+        else:
             self.view.set_status("gitsavvy-repo-status", short_status)
 
 

--- a/core/git_mixins/status.py
+++ b/core/git_mixins/status.py
@@ -38,7 +38,7 @@ if MYPY:
         ("index_status", str),
         ("working_status", Optional[str]),
     ])
-    WorkingDirState = NamedTuple("WorkingDirState", [
+    _WorkingDirState = NamedTuple("_WorkingDirState", [
         ("staged_files", List[FileStatus]),
         ("unstaged_files", List[FileStatus]),
         ("untracked_files", List[FileStatus]),
@@ -48,10 +48,22 @@ if MYPY:
 else:
     HeadState = namedtuple("HeadState", "detached branch remote clean ahead behind gone")
     FileStatus = namedtuple("FileStatus", "path path_alt index_status working_status")
-    WorkingDirState = namedtuple(
-        "WorkingDirState",
+    _WorkingDirState = namedtuple(
+        "_WorkingDirState",
         "staged_files unstaged_files untracked_files merge_conflicts"
     )
+
+
+class WorkingDirState(_WorkingDirState):
+    @property
+    def clean(self):
+        # type: () -> bool
+        return not (
+            self.staged_files
+            or self.unstaged_files
+            or self.untracked_files
+            or self.merge_conflicts
+        )
 
 
 MERGE_CONFLICT_PORCELAIN_STATUSES = (

--- a/core/git_mixins/status.py
+++ b/core/git_mixins/status.py
@@ -98,6 +98,10 @@ class StatusMixin(mixin_base):
             custom_environ={"GIT_OPTIONAL_LOCKS": "0"}
         ).rstrip("\x00").split("\x00")
 
+    def update_working_dir_status(self):
+        # type: () -> None
+        self.get_working_dir_status()
+
     def get_working_dir_status(self):
         # type: () -> WorkingDirState
         lines = self._get_status()

--- a/core/git_mixins/status.py
+++ b/core/git_mixins/status.py
@@ -153,13 +153,6 @@ class StatusMixin(mixin_base):
 
     def get_branch_status_short(self):
         # type: () -> str
-        if self.in_rebase():
-            rebase_progress = self._rebase_progress()
-            return "(no branch, rebasing {}{})".format(
-                self.rebase_branch_name(),
-                " {}".format(rebase_progress) if rebase_progress else ""
-            )
-
         lines = self._get_status()
         branch_status = self._get_branch_status_components(lines)
         return self._format_branch_status_short(branch_status)
@@ -248,6 +241,13 @@ class StatusMixin(mixin_base):
 
     def _format_branch_status_short(self, branch_status):
         # type: (HeadState) -> str
+        if self.in_rebase():
+            rebase_progress = self._rebase_progress()
+            return "(no branch, rebasing {}{})".format(
+                self.rebase_branch_name(),
+                " {}".format(rebase_progress) if rebase_progress else ""
+            )
+
         detached, branch, remote, clean, ahead, behind, gone = branch_status
 
         dirty = "" if clean else "*"

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -30,7 +30,6 @@ class BranchInterface(ui.Interface, GitCommand):
 
     interface_type = "branch"
     syntax_file = "Packages/GitSavvy/syntax/branch.sublime-syntax"
-    word_wrap = False
 
     show_remotes = None
 

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -29,7 +29,6 @@ class BranchInterface(ui.Interface, GitCommand):
     """
 
     interface_type = "branch"
-    read_only = True
     syntax_file = "Packages/GitSavvy/syntax/branch.sublime-syntax"
     word_wrap = False
 

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -32,7 +32,6 @@ class BranchInterface(ui.Interface, GitCommand):
     read_only = True
     syntax_file = "Packages/GitSavvy/syntax/branch.sublime-syntax"
     word_wrap = False
-    tab_size = 2
 
     show_remotes = None
 

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -94,7 +94,7 @@ class BranchInterface(ui.Interface, GitCommand):
 
     @ui.partial("branch_status")
     def render_branch_status(self):
-        return self.get_branch_status()
+        return self.get_working_dir_status().long_status
 
     @ui.partial("git_root")
     def render_git_root(self):

--- a/core/interfaces/rebase.py
+++ b/core/interfaces/rebase.py
@@ -57,7 +57,6 @@ class RebaseInterface(ui.Interface, NearestBranchMixin, GitCommand):
 
     interface_type = "rebase"
     syntax_file = "Packages/GitSavvy/syntax/rebase.sublime-syntax"
-    word_wrap = False
 
     CARET = "▸"
     SUCCESS = "✔"

--- a/core/interfaces/rebase.py
+++ b/core/interfaces/rebase.py
@@ -56,7 +56,6 @@ class RebaseInterface(ui.Interface, NearestBranchMixin, GitCommand):
     """
 
     interface_type = "rebase"
-    read_only = True
     syntax_file = "Packages/GitSavvy/syntax/rebase.sublime-syntax"
     word_wrap = False
 

--- a/core/interfaces/rebase.py
+++ b/core/interfaces/rebase.py
@@ -487,13 +487,9 @@ class RewriteBase(TextCommand, GitCommand):
 
     def run(self, edit):
         self.interface = ui.get_interface(self.view.id())
+        status = self.get_working_dir_status()
 
-        (staged_entries,
-         unstaged_entries,
-         untracked_entries,
-         conflict_entries) = self.get_working_dir_status()
-
-        if len(unstaged_entries) + len(conflict_entries) > 0:
+        if status.unstaged_files or status.merge_conflicts:
             sublime.message_dialog(
                 "Unable to manipulate commits while repo is in unclean state."
             )

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -213,7 +213,7 @@ class StatusInterface(ui.Interface, GitCommand):
                 partial(self.update_state, thunk, then=self.just_render)
             )
 
-        sublime.set_timeout_async(self.fetch_repo_status)
+        self.view.run_command("gs_update_status")
         # These are cheap to compute, so we just do it!
         status = store.current_state(self.repo_path).get("status")
         if status:
@@ -273,9 +273,6 @@ class StatusInterface(ui.Interface, GitCommand):
         if not on_special_symbol:
             self.view.run_command("gs_status_navigate_goto")
 
-    def fetch_repo_status(self):
-        self.get_working_dir_status()
-
     def on_status_update(self, _repo_path, state):
         self.update_state(state["status"]._asdict(), then=self.just_render)
 
@@ -286,7 +283,7 @@ class StatusInterface(ui.Interface, GitCommand):
         So instead of calling `render` it is a good optimization to just
         ask this method if appropriate.
         """
-        self.fetch_repo_status()
+        self.get_working_dir_status()
 
     def after_view_creation(self, view):
         view.settings().set("result_file_regex", EXTRACT_FILENAME_RE)

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -244,7 +244,7 @@ class StatusInterface(ui.Interface, GitCommand):
         self.refresh_view_state()
         self.just_render(nuke_cursors)
 
-        if hasattr(self, "reset_cursor") and nuke_cursors:
+        if nuke_cursors:
             self.reset_cursor()
 
     @distinct_until_state_changed

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -79,7 +79,6 @@ class StatusInterface(ui.Interface, GitCommand):
 
     interface_type = "status"
     syntax_file = "Packages/GitSavvy/syntax/status.sublime-syntax"
-    word_wrap = False
 
     template = """\
 

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -185,7 +185,7 @@ class StatusInterface(ui.Interface, GitCommand):
             'untracked_files': [],
             'merge_conflicts': [],
             'clean': True,
-            'branch_status': '',
+            'long_status': '',
             'git_root': '',
             'show_help': True,
             'head': '',
@@ -277,7 +277,7 @@ class StatusInterface(ui.Interface, GitCommand):
             'untracked_files': status.untracked_files,
             'merge_conflicts': status.merge_conflicts,
             'clean': status.clean,
-            'branch_status': status.long_status
+            'long_status': status.long_status
         }
 
     def refresh_repo_status_and_render(self):
@@ -295,7 +295,7 @@ class StatusInterface(ui.Interface, GitCommand):
 
     @ui.partial("branch_status")
     def render_branch_status(self):
-        return self.state['branch_status']
+        return self.state['long_status']
 
     @ui.partial("git_root")
     def render_git_root(self):

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -81,7 +81,6 @@ class StatusInterface(ui.Interface, GitCommand):
     read_only = True
     syntax_file = "Packages/GitSavvy/syntax/status.sublime-syntax"
     word_wrap = False
-    tab_size = 2
 
     template = """\
 

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -11,6 +11,7 @@ from ..commands import GsNavigate
 from ...common import ui
 from ..git_command import GitCommand
 from ...common import util
+from GitSavvy.core import store
 
 flatten = chain.from_iterable
 
@@ -214,6 +215,9 @@ class StatusInterface(ui.Interface, GitCommand):
             )
 
         # These are cheap to compute, so we just do it!
+        status = store.current_state(self.repo_path).get("status")
+        if status:
+            self.update_state(status._asdict())
         self.update_state({
             'git_root': self.short_repo_path,
             'show_help': not self.view.settings().get("git_savvy.help_hidden")
@@ -270,15 +274,7 @@ class StatusInterface(ui.Interface, GitCommand):
             self.view.run_command("gs_status_navigate_goto")
 
     def fetch_repo_status(self):
-        status = self.get_working_dir_status()
-        return {
-            'staged_files': status.staged_files,
-            'unstaged_files': status.unstaged_files,
-            'untracked_files': status.untracked_files,
-            'merge_conflicts': status.merge_conflicts,
-            'clean': status.clean,
-            'long_status': status.long_status
-        }
+        return self.get_working_dir_status()._asdict()
 
     def refresh_repo_status_and_render(self):
         """Refresh `git status` state and render.

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -187,6 +187,7 @@ class StatusInterface(ui.Interface, GitCommand):
             'unstaged_files': [],
             'untracked_files': [],
             'merge_conflicts': [],
+            'clean': True,
             'branch_status': '',
             'git_root': '',
             'show_help': True,
@@ -272,22 +273,14 @@ class StatusInterface(ui.Interface, GitCommand):
             self.view.run_command("gs_status_navigate_goto")
 
     def fetch_repo_status(self):
-        lines = self._get_status()
-        files_statuses = self._parse_status_for_file_statuses(lines)
-        branch_info = self._get_branch_status_components(lines)
-
-        (staged_files,
-         unstaged_files,
-         untracked_files,
-         merge_conflicts) = self._group_status_entries(files_statuses)
-        branch_status = self._format_branch_status(branch_info)
-
+        status = self.get_working_dir_status()
         return {
-            'staged_files': staged_files,
-            'unstaged_files': unstaged_files,
-            'untracked_files': untracked_files,
-            'merge_conflicts': merge_conflicts,
-            'branch_status': branch_status
+            'staged_files': status.staged_files,
+            'unstaged_files': status.unstaged_files,
+            'untracked_files': status.untracked_files,
+            'merge_conflicts': status.merge_conflicts,
+            'clean': status.clean,
+            'branch_status': status.long_status
         }
 
     def refresh_repo_status_and_render(self):
@@ -366,12 +359,11 @@ class StatusInterface(ui.Interface, GitCommand):
 
     @ui.partial("no_status_message")
     def render_no_status_message(self):
-        return ("\n    Your working directory is clean.\n"
-                if not (self.state['staged_files'] or
-                        self.state['unstaged_files'] or
-                        self.state['untracked_files'] or
-                        self.state['merge_conflicts'])
-                else "")
+        return (
+            "\n    Your working directory is clean.\n"
+            if self.state['clean']
+            else ""
+        )
 
     @ui.partial("stashes")
     def render_stashes(self):

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -283,7 +283,7 @@ class StatusInterface(ui.Interface, GitCommand):
         So instead of calling `render` it is a good optimization to just
         ask this method if appropriate.
         """
-        self.get_working_dir_status()
+        self.update_working_dir_status()
 
     def after_view_creation(self, view):
         view.settings().set("result_file_regex", EXTRACT_FILENAME_RE)

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -78,7 +78,6 @@ class StatusInterface(ui.Interface, GitCommand):
     """
 
     interface_type = "status"
-    read_only = True
     syntax_file = "Packages/GitSavvy/syntax/status.sublime-syntax"
     word_wrap = False
 

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -49,7 +49,6 @@ class TagsInterface(ui.Interface, GitCommand):
     read_only = True
     syntax_file = "Packages/GitSavvy/syntax/tags.sublime-syntax"
     word_wrap = False
-    tab_size = 2
 
     show_remotes = None
     remotes = None

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -46,7 +46,6 @@ class TagsInterface(ui.Interface, GitCommand):
     """
 
     interface_type = "tags"
-    read_only = True
     syntax_file = "Packages/GitSavvy/syntax/tags.sublime-syntax"
     word_wrap = False
 

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -103,7 +103,7 @@ class TagsInterface(ui.Interface, GitCommand):
 
     @ui.partial("branch_status")
     def render_branch_status(self):
-        return self.get_branch_status()
+        return self.get_working_dir_status().long_status
 
     @ui.partial("repo_root")
     def render_repo_root(self):

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -47,7 +47,6 @@ class TagsInterface(ui.Interface, GitCommand):
 
     interface_type = "tags"
     syntax_file = "Packages/GitSavvy/syntax/tags.sublime-syntax"
-    word_wrap = False
 
     show_remotes = None
     remotes = None

--- a/core/store.py
+++ b/core/store.py
@@ -1,12 +1,14 @@
 from collections import defaultdict
+from functools import partial
 import threading
+import uuid
 
+from .utils import eat_but_log_errors, Cache
 
-from .utils import Cache
 
 MYPY = False
 if MYPY:
-    from typing import Any, DefaultDict, Dict, Optional, Tuple, TypedDict
+    from typing import AbstractSet, Any, Callable, DefaultDict, Dict, Optional, Tuple, TypedDict
     from GitSavvy.core.git_mixins.status import WorkingDirState
 
     RepoPath = str
@@ -20,10 +22,12 @@ if MYPY:
         },
         total=False
     )
+    SubscriberKey = str
+    Keys = AbstractSet[str]
 
 state = defaultdict(lambda: {})  # type: DefaultDict[RepoPath, RepoStore]
 cache = Cache(maxsize=512)  # type: Dict[Tuple, Any]
-
+subscribers = {}  # type: Dict[SubscriberKey, Tuple[RepoPath, Keys, Callable]]
 
 lock = threading.Lock()
 
@@ -32,8 +36,32 @@ def update_state(repo_path, partial_state):
     # type: (RepoPath, RepoStore) -> None
     with lock:
         state[repo_path].update(partial_state)
+    notify_all(repo_path, partial_state.keys(), state[repo_path])
+
+
+def notify_all(repo_path, updated_keys, current_state):
+    # type: (RepoPath, Keys, RepoStore) -> None
+    for (subscribed_repo_path, keys, fn) in subscribers.values():
+        if (
+            subscribed_repo_path in {repo_path, "*"}
+            and updated_keys & keys
+        ):
+            with eat_but_log_errors():
+                fn(repo_path, current_state)
 
 
 def current_state(repo_path):
     # type: (RepoPath) -> RepoStore
     return state[repo_path]
+
+
+def subscribe(repo_path, keys, fn):
+    # type: (RepoPath, Keys, Callable) -> Callable[[], None]
+    key = uuid.uuid4().hex
+    subscribers[key] = (repo_path, keys, fn)
+    return partial(_unsubscribe, key)
+
+
+def _unsubscribe(key):
+    # type: (SubscriberKey) -> None
+    subscribers.pop(key, None)

--- a/core/store.py
+++ b/core/store.py
@@ -7,11 +7,13 @@ from .utils import Cache
 MYPY = False
 if MYPY:
     from typing import Any, DefaultDict, Dict, Optional, Tuple, TypedDict
+    from GitSavvy.core.git_mixins.status import WorkingDirState
 
     RepoPath = str
     RepoStore = TypedDict(
         'RepoStore',
         {
+            "status": WorkingDirState,
             "last_remote_used": Optional[str],
             "last_remote_used_with_option_all": Optional[str],
             "short_hash_length": int,

--- a/mypy.ini
+++ b/mypy.ini
@@ -10,6 +10,12 @@ sqlite_cache = True
 [mypy-tests]
 ignore_errors = True
 
+[mypy-GitSavvy.tests.mockito]
+ignore_missing_imports = True
+
+[mypy-GitSavvy.tests.parameterized]
+ignore_missing_imports = True
+
 [mypy-unittesting]
 ignore_missing_imports = True
 

--- a/tests/test_git/common.py
+++ b/tests/test_git/common.py
@@ -16,14 +16,20 @@ if os.name == "nt":
 
 class AssertionsMixin:
 
-    def assert_git_status(self, status):
+    def assert_git_status(self, expected_status):
         """
         Assertion of the current git status. `status` should be a list of 4 intergers:
         The lengths of the staged, unstaged, untracked and conflicted entries.
         """
+        status = self.get_working_dir_status()
         self.assertEqual(
-            [len(x) for x in self.get_working_dir_status()],
-            status)
+            [
+                len(status.staged_files),
+                len(status.unstaged_files),
+                len(status.untracked_files),
+                len(status.merge_conflicts)
+            ],
+            expected_status)
 
 
 class GitRepoTestCase(TempDirectoryTestCase, AssertionsMixin):

--- a/tests/test_graph_view.py
+++ b/tests/test_graph_view.py
@@ -9,9 +9,11 @@ from GitSavvy.tests.mockito import unstub, when
 from GitSavvy.core.commands.log_graph import (
     gs_log_graph_refresh,
     extract_commit_hash,
-    navigate_to_symbol
+    navigate_to_symbol,
+    GitCommand
 )
 from GitSavvy.core.commands.show_commit_info import gs_show_commit_info
+from GitSavvy.core.git_mixins.status import WorkingDirState
 from GitSavvy.core.settings import GitSavvySettings
 
 
@@ -32,6 +34,7 @@ else:
 THIS_DIRNAME = os.path.dirname(os.path.realpath(__file__))
 COMMIT_1 = 'This is commit fec0aca'
 COMMIT_2 = 'This is commit f461ea1'
+CLEAN_WORKING_DIR = WorkingDirState([], [], [], [], '', '')
 
 
 def fixture(name):
@@ -155,6 +158,7 @@ class TestGraphViewInteractionWithCommitInfoPanel(DeferrableTestCase):
         exists = os.path.exists
         when(os.path).exists(...).thenAnswer(exists)
         when(os.path).exists(repo_path).thenReturn(True)
+        when(GitCommand).get_working_dir_status().thenReturn(CLEAN_WORKING_DIR)
         self.window.run_command('gs_graph', {'repo_path': repo_path})
         yield lambda: self.window.active_view().settings().get('git_savvy.log_graph_view') is True
         log_view = self.window.active_view()

--- a/tests/test_graph_view.py
+++ b/tests/test_graph_view.py
@@ -4,7 +4,7 @@ import sublime
 
 from unittesting import DeferrableTestCase, expectedFailure
 from GitSavvy.tests.parameterized import parameterized as p
-from GitSavvy.tests.mockito import unstub, when
+from GitSavvy.tests.mockito import spy2, unstub, when
 
 from GitSavvy.core.commands.log_graph import (
     gs_log_graph_refresh,
@@ -155,8 +155,7 @@ class TestGraphViewInteractionWithCommitInfoPanel(DeferrableTestCase):
         when(gs_log_graph_refresh).read_graph(...).thenReturn(log.splitlines(keepends=True))
         # `GitCommand.get_repo_path` "validates" a given repo using
         # `os.path.exists`.
-        exists = os.path.exists
-        when(os.path).exists(...).thenAnswer(exists)
+        spy2('os.path.exists')
         when(os.path).exists(repo_path).thenReturn(True)
         when(GitCommand).get_working_dir_status().thenReturn(CLEAN_WORKING_DIR)
         self.window.run_command('gs_graph', {'repo_path': repo_path})


### PR DESCRIPTION
Fixes #1095
Fixes #1102
Replaces #1151 

Store `git status` information in `store["status"]`.  Implement a triangle where we fetch the status of a workdir, update the store, and in turn notify subscribers.  Note that `get_working_dir_status()` still returns the state for ease of use after notifying interested subscribers.

Whenever we fetch an update of the current status, the status bar view and for now the status bar dashboard react and redraw itself.  This replaces #1151 which did really the same thing in an earlier state of the repo.  Thus it does not reduce status calls anymore as this has been implemented already but use the information of status calls more efficiently. 

Also has some refactorings, basically simplifying outdated code (for example see `reset_cursor`, `tab_size` etc.) for the dashboards.

Still not implemented: `store.status` should have all the information necessary to compute a formatted current state.  For example it should also store the rebase or "in-merge" information so that formatting, as in `_format_branch_status_short`, for the views becomes a pure function on the collected data.  