### PR TITLE
Fix walking the directory tree using `os.walk`

### DIFF
--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -233,9 +233,7 @@ class TestSublimeResources(unittest.TestCase):
             for filename in fnmatch.filter(filenames, pattern):
                 yield os.path.join(root, filename)
             ignored = ('.git', '.hg', '.svn', '.tox')
-            for dirname in [d for d in dirnames if d not in ignored]:
-                for f in self._get_files(pattern, os.path.join(root, dirname)):
-                    yield f
+            dirnames[:] = [d for d in dirnames if d not in ignored]
 
     def test_json(self):
         print()  # add a new line to console output before printing file names

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -247,11 +247,12 @@ class TestSublimeResources(unittest.TestCase):
             '*.sublime-settings-hints',
             '*.sublime-theme'
         )
-        result = False
+        not_ok = False
         folder = os.path.dirname(os.path.dirname(__file__))
         for pattern in patterns:
             for file in self._get_files(pattern, folder=folder):
                 print('checking %s ... ' % file)
-                result |= CheckJsonFormat(False, True).check_format(file)
+                not_ok |= CheckJsonFormat(False, True).check_format(file)
 
-        self.assertFalse(result, 'At least one JSON file contains errors!')
+        if not_ok:
+            self.fail('At least one JSON file contains errors!')

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -232,7 +232,7 @@ class TestSublimeResources(unittest.TestCase):
         for root, dirnames, filenames in os.walk(folder):
             for filename in fnmatch.filter(filenames, pattern):
                 yield os.path.join(root, filename)
-            ignored = ('.git', '.hg', '.svn', '.tox')
+            ignored = ('.git', '.hg', '.svn', '.tox', '.mypy_cache', '__pycache__')
             dirnames[:] = [d for d in dirnames if d not in ignored]
 
     def test_json(self):


### PR DESCRIPTION
`os.walk` already walks the tree recursively, hence calling
`self._get_files` recursively is not what we want.

For one, it actually does not ignore the dirnames as the outer `walk`
will just walk away, then it emits everything twice.