### PR TITLE
Open issue at hand on `[o]` or via popup on hover

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -2212,5 +2212,15 @@
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.stash_view", "operator": "equal", "operand": true }
         ]
+    },
+
+    // COMMON
+
+    {
+        "keys": ["o"],
+        "command": "gs_github_open_issue_at_cursor",
+        "context": [
+            { "key": "selector", "operand": "constant.other.issue-ref.git-savvy, string.other.issue.git-savvy" }
+        ]
     }
 ]

--- a/github/commands/__init__.py
+++ b/github/commands/__init__.py
@@ -4,3 +4,4 @@ from .configure import *
 from .create_fork import *
 from .add_fork_as_remote import *
 from .pull_request import *
+from .open_issue import *

--- a/github/commands/open_issue.py
+++ b/github/commands/open_issue.py
@@ -1,6 +1,7 @@
 from webbrowser import open as open_in_browser
 
-from sublime_plugin import TextCommand
+import sublime
+from sublime_plugin import EventListener, TextCommand
 
 from GitSavvy.core.utils import flash
 from GitSavvy.core.git_command import GitCommand
@@ -9,6 +10,7 @@ from .. import github, git_mixins
 
 __all__ = (
     "gs_github_open_issue_at_cursor",
+    "gs_github_hover_on_issues_controller",
 )
 
 
@@ -16,18 +18,48 @@ ISSUE_SCOPES = "constant.other.issue-ref.git-savvy, string.other.issue.git-savvy
 
 
 class gs_github_open_issue_at_cursor(TextCommand, git_mixins.GithubRemotesMixin, GitCommand):
-    def run(self, edit):
+    def run(self, edit, point=None, open_popup=False):
         view = self.view
-        cursor = view.sel()[0].begin()
-        if not view.match_selector(cursor, ISSUE_SCOPES):
+        if point is None:
+            point = view.sel()[0].begin()
+
+        if not view.match_selector(point, ISSUE_SCOPES):
             flash(view, "Not on an issue or pr name.")
             return
 
-        issue_nr = view.substr(view.extract_scope(cursor))[1:]
+        def on_navigate(href: str):
+            open_in_browser(href)
 
+        issue_nr = view.substr(view.extract_scope(point))[1:]
+        url = self.url_for_issue(issue_nr)
+
+        if open_popup:
+            view.show_popup(
+                '<a href="{url}">{url}</a>'.format(url=url),
+                flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY,
+                location=point,
+                max_width=1000,
+                on_navigate=on_navigate
+            )
+        else:
+            open_in_browser(url)
+
+    def url_for_issue(self, issue_nr: str) -> str:
         remotes = self.get_remotes()
         base_remote_name = self.get_integrated_remote_name(remotes)
         base_remote_url = remotes[base_remote_name]
         base_remote = github.parse_remote(base_remote_url)
-        url = "{}/issues/{}".format(base_remote.url, issue_nr)
-        open_in_browser(url)
+        return "{}/issues/{}".format(base_remote.url, issue_nr)
+
+
+class gs_github_hover_on_issues_controller(EventListener):
+    def on_hover(self, view, point, hover_zone):
+        # type: (sublime.View, int, int) -> None
+        if (
+            hover_zone == sublime.HOVER_TEXT
+            and view.match_selector(point, ISSUE_SCOPES)
+        ):
+            view.run_command("gs_github_open_issue_at_cursor", {
+                "point": point,
+                "open_popup": True
+            })

--- a/github/commands/open_issue.py
+++ b/github/commands/open_issue.py
@@ -1,0 +1,33 @@
+from webbrowser import open as open_in_browser
+
+from sublime_plugin import TextCommand
+
+from GitSavvy.core.utils import flash
+from GitSavvy.core.git_command import GitCommand
+from .. import github, git_mixins
+
+
+__all__ = (
+    "gs_github_open_issue_at_cursor",
+)
+
+
+ISSUE_SCOPES = "constant.other.issue-ref.git-savvy, string.other.issue.git-savvy"
+
+
+class gs_github_open_issue_at_cursor(TextCommand, git_mixins.GithubRemotesMixin, GitCommand):
+    def run(self, edit):
+        view = self.view
+        cursor = view.sel()[0].begin()
+        if not view.match_selector(cursor, ISSUE_SCOPES):
+            flash(view, "Not on an issue or pr name.")
+            return
+
+        issue_nr = view.substr(view.extract_scope(cursor))[1:]
+
+        remotes = self.get_remotes()
+        base_remote_name = self.get_integrated_remote_name(remotes)
+        base_remote_url = remotes[base_remote_name]
+        base_remote = github.parse_remote(base_remote_url)
+        url = "{}/issues/{}".format(base_remote.url, issue_nr)
+        open_in_browser(url)

--- a/popups/line_history.html
+++ b/popups/line_history.html
@@ -7,7 +7,7 @@
 
 <h3>Actions</h3>
 <div>
-  <div><code><span class="shortcut-key">o&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>open commit</code></div>
+  <div><code><span class="shortcut-key">o&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>open commit; on <span class="shortcut-key">#issues</span>, open a browser</code></div>
   <div><code><span class="shortcut-key">O&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>open file revision at hunk</code></div>
   <div><code><span class="shortcut-key">g&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>show in graph</code></div>
   <div><code><span class="shortcut-key">,</span>/<span class="shortcut-key">.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>go to next/previous hunk (also: <span class="shortcut-key">j</span>/<span class="shortcut-key">k</span> in vintageous mode)</code></div>

--- a/popups/log_graph_view.html
+++ b/popups/log_graph_view.html
@@ -8,7 +8,7 @@
 <br />
 <div>
   <div><code><span class="shortcut-key">enter&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>open main menu with additional commands</code></div>
-  <div><code><span class="shortcut-key">o&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>open commit in a new view</code></div>
+  <div><code><span class="shortcut-key">o&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>open commit in a new view; on <span class="shortcut-key">#issues</span>, open a browser</code></div>
   <div><code><span class="shortcut-key">m&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>toggle commit details panel on the bottom</code></div>
   <div><code><span class="shortcut-key">{super_key}+C&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>copy commit's hash, subject or a combination to the clipboard</code></div>
 <br />

--- a/popups/show_commit_view.html
+++ b/popups/show_commit_view.html
@@ -7,7 +7,7 @@
 
 <h3>Navigation</h3>
 <div>
-  <div><code><span class="shortcut-key">o&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>open file revision at hunk</code></div>
+  <div><code><span class="shortcut-key">o&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>open file revision at hunk; on <span class="shortcut-key">#issues</span>, open a browser</code></div>
   <div><code><span class="shortcut-key">O&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>open working dir file</code></div>
   <div><code><span class="shortcut-key">g&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>show in graph</code></div>
   <div><code><span class="shortcut-key">,</span>/<span class="shortcut-key">.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>go to next/previous hunk (also: <span class="shortcut-key">j</span>/<span class="shortcut-key">k</span> in vintageous mode)</code></div>


### PR DESCRIPTION
Whenever we land on an issue, in a commit message or graph view, let
`[o]` open the issue (or PR) in the browser on GitHub.  

Show a simple popup to do the same on hover. 

![image](https://user-images.githubusercontent.com/8558/120186551-f07fb300-c213-11eb-9c41-81fc1fd1542f.png)
