### PR TITLE
Add simplistic output panel syntax plus specific settings

### DIFF
--- a/common/util/log.py
+++ b/common/util/log.py
@@ -43,7 +43,9 @@ def get_panel(window):
 
 def create_panel(window):
     # type: (sublime.Window) -> sublime.View
-    return window.create_output_panel(PANEL_NAME)
+    panel_view = window.create_output_panel(PANEL_NAME)
+    panel_view.set_syntax_file("Packages/GitSavvy/syntax/output_panel.sublime-syntax")
+    return panel_view
 
 
 def show_panel(window):

--- a/syntax/output_panel.sublime-settings
+++ b/syntax/output_panel.sublime-settings
@@ -1,0 +1,14 @@
+{
+    "auto_indent": false,
+    "detect_indentation": false,
+    "draw_indent_guides": false,
+    "draw_white_space": "None",
+    "gutter": false,
+    "is_widget": true,
+    "line_numbers": false,
+    "rulers": false,
+    "scroll_past_end": false,
+    "spell_check": false,
+    "translate_tabs_to_spaces": false,
+    "word_wrap": false
+}

--- a/syntax/output_panel.sublime-syntax
+++ b/syntax/output_panel.sublime-syntax
@@ -1,0 +1,24 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/3/syntax.html
+name: GitSavvy Output Panel
+hidden: true
+scope: output.git-savvy
+variables:
+  sha: '[0-9a-f]{6,40}'
+contexts:
+  main:
+    - match: ^(\$)\s
+      captures:
+        1: markup.heading entity.name.section
+
+    - match: ^\[Done.*\]$
+      scope: string.other
+
+    - match: ({{sha}}\^?)
+      comment: SHA
+      scope: constant.numeric.graph.commit-hash.git-savvy
+
+    - match: -> ([^ ]*)
+      captures:
+        1: storage


### PR DESCRIPTION
Start with just a little touch.  We want the settings to apply because
Sublime Text 4 renders the panel with line-numbers and gutter etc., t.i. 
with different defaults.

![image](https://user-images.githubusercontent.com/8558/120186826-4eac9600-c214-11eb-830d-f0cb055fb53d.png)
