### PR TITLE
Improve `gs_clone` and `gs_init`

### DIFF
--- a/core/commands/init.py
+++ b/core/commands/init.py
@@ -5,6 +5,7 @@ import sublime
 from sublime_plugin import WindowCommand
 
 from GitSavvy.core.fns import filter_, maybe
+from GitSavvy.core.runtime import enqueue_on_worker
 from ..git_command import GitCommand
 from ...common import util
 from ..ui_mixins.input_panel import show_single_line_input_panel
@@ -163,7 +164,7 @@ class gs_clone(WindowCommand, GitCommand):
             sublime.ok_cancel_dialog(RECLONE_CANT_BE_DONE)
             return
 
-        sublime.set_timeout_async(self.do_clone, 0)
+        enqueue_on_worker(self.do_clone)
 
     def do_clone(self):
         self.window.status_message("Start cloning {}".format(self.git_url))

--- a/core/commands/init.py
+++ b/core/commands/init.py
@@ -69,9 +69,6 @@ class gs_init(WindowCommand, GitCommand):
     """
 
     def run(self):
-        sublime.set_timeout_async(self.run_async, 0)
-
-    def run_async(self):
         git_root = self.find_working_dir()
 
         if git_root and os.path.exists(os.path.join(git_root, ".git")):
@@ -198,9 +195,6 @@ class gs_setup_user(WindowCommand, GitCommand):
     """
 
     def run(self):
-        sublime.set_timeout_async(self.run_async, 0)
-
-    def run_async(self):
         if sublime.ok_cancel_dialog(NO_CONFIG_MESSAGE):
             self.get_name()
 

--- a/core/commands/init.py
+++ b/core/commands/init.py
@@ -59,13 +59,14 @@ class gs_offer_init(WindowCommand, GitCommand):
 class gs_init(WindowCommand, GitCommand):
 
     """
-    If the active Sublime window has folders added to the project (or if Sublime was
-    opened from the terminal with something like `subl .`), initialize a new Git repo
-    at that location.  If that directory cannot be determined, use the open file's
-    directory.  If there is no open file, prompt the user for the directory to use.
+    If the active Sublime window has folders added to the project (or if
+    Sublime was opened from the terminal with something like `subl .`),
+    initialize a new Git repo at that location.  If that directory cannot be
+    determined, use the open file's directory.  If there is no open file,
+    prompt the user for the directory to use.
 
-    If the selected directory has previously been initialized with Git, prompt the user
-    to confirm a re-initialize before proceeding.
+    If the selected directory has previously been initialized with Git, prompt
+    the user to confirm a re-initialize before proceeding.
     """
 
     def run(self):

--- a/core/commands/init.py
+++ b/core/commands/init.py
@@ -147,8 +147,10 @@ class gs_clone(WindowCommand, GitCommand):
         return ""
 
     def on_enter_directory(self, path):
-        self.suggested_git_root = os.path.expanduser(path)  # handle ~/%HOME%
-        if self.suggested_git_root and os.path.exists(os.path.join(self.suggested_git_root, ".git")):
+        if not path:
+            return
+        self.target_dir = os.path.expanduser(path)
+        if os.path.exists(os.path.join(self.target_dir, ".git")):
             sublime.ok_cancel_dialog(RECLONE_CANT_BE_DONE)
             return
 
@@ -160,10 +162,11 @@ class gs_clone(WindowCommand, GitCommand):
             "clone",
             "--recursive" if self.recursive else None,
             self.git_url,
-            self.suggested_git_root,
-            working_dir='.')
+            self.target_dir,
+            working_dir='.'
+        )
         self.window.status_message("Cloned repo successfully.")
-        open_folder_in_new_window(self.suggested_git_root)
+        open_folder_in_new_window(self.target_dir)
         util.view.refresh_gitsavvy(self.window.active_view())
 
 

--- a/core/commands/init.py
+++ b/core/commands/init.py
@@ -69,16 +69,25 @@ class gs_init(WindowCommand, GitCommand):
     """
 
     def run(self):
-        git_root = self.find_working_dir()
-
+        git_root = (
+            maybe(lambda: self.window.folders()[0])
+            or maybe(lambda: os.path.dirname(self._current_filename()))  # type: ignore[type-var]
+        )
         if git_root and os.path.exists(os.path.join(git_root, ".git")):
             if sublime.ok_cancel_dialog(CONFIRM_REINITIALIZE):
                 self.on_done(git_root, re_init=True)
             return
 
-        show_single_line_input_panel(REPO_PATH_PROMPT, git_root, self.on_done, None, None)
+        show_single_line_input_panel(
+            REPO_PATH_PROMPT,
+            git_root,
+            self.on_done,
+            select_text=False
+        )
 
     def on_done(self, path, re_init=False):
+        if not path:
+            return
         self.git("init", working_dir=path)
         self.window.status_message("{word_start}nitialized repo successfully.".format(
             word_start="Re-i" if re_init else "I"))

--- a/core/commands/init.py
+++ b/core/commands/init.py
@@ -122,16 +122,6 @@ def parse_url_from_clipboard(clip_content):
 
 class gs_clone(WindowCommand, GitCommand):
 
-    """
-    If the active Sublime window has folders added to the project (or if Sublime was
-    opened from the terminal with something like `subl .`), initialize a new Git repo
-    at that location.  If that directory cannot be determined, use the open file's
-    directory.  If there is no open file, prompt the user for the directory to use.
-
-    If the selected directory has previously been initialized with Git, prompt the user
-    to confirm a re-initialize before proceeding.
-    """
-
     def run(self, recursive=False):
         self.recursive = recursive
         clip_content = sublime.get_clipboard(256).strip()

--- a/core/commands/init.py
+++ b/core/commands/init.py
@@ -158,7 +158,7 @@ class gs_clone(WindowCommand, GitCommand):
             return
         self.target_dir = os.path.expanduser(path)
         if os.path.exists(os.path.join(self.target_dir, ".git")):
-            sublime.ok_cancel_dialog(RECLONE_CANT_BE_DONE)
+            sublime.error_message(RECLONE_CANT_BE_DONE)
             return
 
         enqueue_on_worker(self.do_clone)

--- a/core/commands/init.py
+++ b/core/commands/init.py
@@ -8,6 +8,14 @@ from ...common import util
 from ..ui_mixins.input_panel import show_single_line_input_panel
 
 
+__all__ = (
+    "gs_offer_init",
+    "gs_init",
+    "gs_clone",
+    "gs_setup_user"
+)
+
+
 NO_REPO_MESSAGE = ("It looks like you haven't initialized Git in this directory.  "
                    "Would you like to?")
 REPO_PATH_PROMPT = "Enter root path of new git repo:"
@@ -25,7 +33,7 @@ GIT_URL = "Enter git url:"
 views_with_offer_made = set()
 
 
-class GsOfferInit(WindowCommand, GitCommand):
+class gs_offer_init(WindowCommand, GitCommand):
 
     """
     If a git command fails indicating no git repo was found, this
@@ -45,7 +53,7 @@ class GsOfferInit(WindowCommand, GitCommand):
             views_with_offer_made.add(active_view_id)
 
 
-class GsInit(WindowCommand, GitCommand):
+class gs_init(WindowCommand, GitCommand):
 
     """
     If the active Sublime window has folders added to the project (or if Sublime was
@@ -77,7 +85,7 @@ class GsInit(WindowCommand, GitCommand):
         util.view.refresh_gitsavvy(self.window.active_view())
 
 
-class GsClone(WindowCommand, GitCommand):
+class gs_clone(WindowCommand, GitCommand):
 
     """
     If the active Sublime window has folders added to the project (or if Sublime was
@@ -137,7 +145,7 @@ class GsClone(WindowCommand, GitCommand):
         sublime.active_window().set_project_data(project_data)
 
 
-class GsSetupUserCommand(WindowCommand, GitCommand):
+class gs_setup_user(WindowCommand, GitCommand):
 
     """
     Set user's name and email address in global Git config.

--- a/core/commands/init.py
+++ b/core/commands/init.py
@@ -64,7 +64,7 @@ class gs_init(WindowCommand, GitCommand):
     at that location.  If that directory cannot be determined, use the open file's
     directory.  If there is no open file, prompt the user for the directory to use.
 
-    If the selected directory has previosly been initialized with Git, prompt the user
+    If the selected directory has previously been initialized with Git, prompt the user
     to confirm a re-initialize before proceeding.
     """
 

--- a/core/commands/init.py
+++ b/core/commands/init.py
@@ -31,6 +31,11 @@ NO_CONFIG_MESSAGE = ("It looks like you haven't configured Git yet.  Would you "
 RECLONE_CANT_BE_DONE = ("It looks like Git is already initialized here.  "
                         "You can not re-clone")
 GIT_URL = "Enter git url:"
+DEFAULT_PROJECT_ROOT = (
+    os.path.expanduser(R'~\Desktop')
+    if os.name == "nt"
+    else os.path.expanduser('~')
+)
 
 
 views_with_offer_made = set()
@@ -153,7 +158,7 @@ class gs_clone(WindowCommand, GitCommand):
         # type: () -> str
         return (
             maybe(lambda: os.path.dirname(self.window.folders()[0]))
-            or os.path.expanduser('~')
+            or DEFAULT_PROJECT_ROOT
         )
 
     def on_enter_directory(self, path):

--- a/core/commands/init.py
+++ b/core/commands/init.py
@@ -90,8 +90,11 @@ class gs_init(WindowCommand, GitCommand):
         if not path:
             return
         self.git("init", working_dir=path)
-        self.window.status_message("{word_start}nitialized repo successfully.".format(
-            word_start="Re-i" if re_init else "I"))
+        self.window.status_message(
+            "{word_start}nitialized repo successfully.".format(
+                word_start="Re-i" if re_init else "I"
+            )
+        )
         util.view.refresh_gitsavvy(self.window.active_view())
 
 

--- a/core/commands/init.py
+++ b/core/commands/init.py
@@ -163,15 +163,19 @@ class gs_clone(WindowCommand, GitCommand):
             self.suggested_git_root,
             working_dir='.')
         self.window.status_message("Cloned repo successfully.")
-        self.open_folder()
+        open_folder_in_new_window(self.suggested_git_root)
         util.view.refresh_gitsavvy(self.window.active_view())
 
-    def open_folder(self):
-        # taken from
-        # https://github.com/rosshemsley/iOpener/blob/a35117a201290b63b53ba6372dbf8bbfc68f28b9/i_opener.py#L203-L205
-        sublime.run_command("new_window")
-        project_data = dict(folders=[dict(follow_symlinks=True, path=self.suggested_git_root)])
-        sublime.active_window().set_project_data(project_data)
+
+def open_folder_in_new_window(folder):
+    # type: (str) -> None
+    # taken from
+    # https://github.com/rosshemsley/iOpener/blob/a35117a201290b63b53ba6372dbf8bbfc68f28b9/i_opener.py#L203-L205
+    sublime.run_command("new_window")
+    new_window = sublime.active_window()
+    new_window.set_project_data({
+        "folders": [dict(follow_symlinks=True, path=folder)]
+    })
 
 
 class gs_setup_user(WindowCommand, GitCommand):

--- a/core/commands/init.py
+++ b/core/commands/init.py
@@ -132,8 +132,8 @@ class gs_clone(WindowCommand, GitCommand):
 
     def on_enter_url(self, url):
         self.git_url = url
-        self.suggested_git_root = self.find_suggested_git_root()
-        show_single_line_input_panel(REPO_PATH_PROMPT, self.suggested_git_root, self.on_enter_directory, None, None)
+        suggested_git_root = self.find_suggested_git_root()
+        show_single_line_input_panel(REPO_PATH_PROMPT, suggested_git_root, self.on_enter_directory, None, None)
 
     def find_suggested_git_root(self):
         folder = self.find_working_dir()

--- a/core/fns.py
+++ b/core/fns.py
@@ -12,6 +12,14 @@ filter_ = partial(filter, None)  # type: Callable[[Iterable[Optional[T]]], Itera
 flatten = chain.from_iterable
 
 
+def maybe(fn):
+    # type: (Callable[[], T]) -> Optional[T]
+    try:
+        return fn()
+    except Exception:
+        return None
+
+
 def accumulate(iterable, initial=None):
     # type: (Iterable[int], int) -> Iterable[int]
     if initial is None:

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -451,16 +451,8 @@ class _GitCommand(SettingsMixin):
 
         return filter(os.path.isdir, __search_paths())
 
-    def find_working_dir(self):
-        # type: () -> Optional[str]
-        return next(self._search_paths(), None)
-
     def find_repo_path(self):
         # type: () -> Optional[str]
-        """
-        Similar to find_working_dir, except that it does not stop on the first
-        directory found, rather on the first git repository found.
-        """
         view = self._current_view()
         repo_path = view.settings().get("git_savvy.repo_path") if view else None
         if repo_path and os.path.exists(repo_path):

--- a/core/settings.py
+++ b/core/settings.py
@@ -3,6 +3,8 @@ from functools import lru_cache
 import sublime
 import sublime_plugin
 
+from GitSavvy.core.fns import maybe
+
 
 __all__ = (
     "ProjectFileChanges",
@@ -10,8 +12,7 @@ __all__ = (
 
 MYPY = False
 if MYPY:
-    from typing import Callable, Dict, Optional, TypeVar
-    T = TypeVar("T")
+    from typing import Dict
 
 
 class GitSavvySettings:
@@ -101,11 +102,3 @@ class SettingsMixin:
             or maybe(lambda: self.view.window())  # type: ignore[attr-defined]
             or sublime.active_window()
         )
-
-
-def maybe(fn):
-    # type: (Callable[[], T]) -> Optional[T]
-    try:
-        return fn()
-    except Exception:
-        return None

--- a/tests/test_gsclone.py
+++ b/tests/test_gsclone.py
@@ -1,0 +1,30 @@
+from unittesting import DeferrableTestCase
+from GitSavvy.tests.parameterized import parameterized as p
+
+from GitSavvy.core.commands.init import parse_url_from_clipboard
+
+
+class TestGsCloneHelper(DeferrableTestCase):
+    @p.expand([
+        ("git://github.com/timbrel/GitSavvy.git", "git://github.com/timbrel/GitSavvy.git"),
+        ("git@github.com:divmain/GitSavvy.git", "git@github.com:divmain/GitSavvy.git"),
+        ("https://github.com/timbrel/GitSavvy.git", "https://github.com/timbrel/GitSavvy.git"),
+
+        ("https://github.com/timbrel/GitSavvy", "https://github.com/timbrel/GitSavvy.git"),
+        (
+            "https://github.com/timbrel/GitSavvy/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc",
+            "https://github.com/timbrel/GitSavvy.git"
+        ),
+        (
+            "https://github.com/timbrel/GitSavvy/blob/master/core/git_command.py",
+            "https://github.com/timbrel/GitSavvy.git"
+        ),
+
+        ("", ""),
+        ("https://github.com", ""),
+        ("https://github.com/", ""),
+        ("https://github.com/timbrel", ""),
+        ("https://github.com/timbrel/", ""),
+    ])
+    def test_parse_url_from_clipboard(self, IN, OUT):
+        self.assertEqual(OUT, parse_url_from_clipboard(IN))


### PR DESCRIPTION
Fixes #1469 
Fixes #1470 

- Read a possible url from the clipboard to use in the clone wizard
- Suggest a sibling parent of the current open folder as the target to clone to
- Use the output panel as a progress indicator.  
- Open a new window which will host the to be cloned project immediately.  This leads to a much nicer UX.  But reuse an empty window.
- If there is no open folder, suggest `~` or, on Windows, `~\Desktop`.

For `gs_init`, suggest to initialize the repository in the currently open folder.


We want to support two workflows:

- Cloning as a sibling project
  Invoke `gs_clone` from any, already used window
- Cloning possibly temporary projects to a default location
  Invoke `gs_clone` after (`ctrl+shift+n`) creating a new, empty window.

TBC:  It seems plausible to let the user define the default project root.  