### PR TITLE
Fix `gs_setup_user`

### DIFF
--- a/core/commands/init.py
+++ b/core/commands/init.py
@@ -151,14 +151,14 @@ class GsSetupUserCommand(WindowCommand, GitCommand):
             self.get_name()
 
     def get_name(self):
-        show_single_line_input_panel(NAME_MESSAGE, "", self.on_done_name, None, None)
+        show_single_line_input_panel(NAME_MESSAGE, "", self.on_done_name)
 
     def on_done_name(self, name):
         self.git("config", "--global", "user.name", "{}".format(name))
         self.get_email()
 
     def get_email(self):
-        show_single_line_input_panel(EMAIL_MESSAGE, "", self.on_done_email, None, None)
+        show_single_line_input_panel(EMAIL_MESSAGE, "", self.on_done_email)
 
     def on_done_email(self, email):
         self.git("config", "--global", "user.email", "{}".format(email))

--- a/core/commands/init.py
+++ b/core/commands/init.py
@@ -154,11 +154,11 @@ class GsSetupUserCommand(WindowCommand, GitCommand):
         show_single_line_input_panel(NAME_MESSAGE, "", self.on_done_name, None, None)
 
     def on_done_name(self, name):
-        self.git("config", "--global", "user.name", "\"{}\"".format(name))
+        self.git("config", "--global", "user.name", "{}".format(name))
         self.get_email()
 
     def get_email(self):
         show_single_line_input_panel(EMAIL_MESSAGE, "", self.on_done_email, None, None)
 
     def on_done_email(self, email):
-        self.git("config", "--global", "user.email", "\"{}\"".format(email))
+        self.git("config", "--global", "user.email", "{}".format(email))

--- a/core/commands/init.py
+++ b/core/commands/init.py
@@ -147,7 +147,7 @@ class GsSetupUserCommand(WindowCommand, GitCommand):
         sublime.set_timeout_async(self.run_async, 0)
 
     def run_async(self):
-        if sublime.ok_cancel_dialog(NO_CONFIG_MESSAGE, "OK"):
+        if sublime.ok_cancel_dialog(NO_CONFIG_MESSAGE):
             self.get_name()
 
     def get_name(self):


### PR DESCRIPTION
Do not quote the name and email.

The original author maybe thought we need to quote here like on the
command line, but we pass args down so quoting would result in storing
a quoted name which is not what we want.

The old code did produce something like

![image](https://user-images.githubusercontent.com/8558/120824023-4e840180-c558-11eb-88ae-58239bfdf6f5.png)
