### PR TITLE
Test if the reported filename is accessible

### DIFF
--- a/core/git_command.py
+++ b/core/git_command.py
@@ -436,6 +436,8 @@ class _GitCommand(SettingsMixin):
         def __search_paths():
             # type: () -> Iterator[str]
             file_name = self._current_filename()
+            if file_name and not os.path.isfile(file_name):
+                file_name = None
             if file_name:
                 yield os.path.dirname(file_name)
 


### PR DESCRIPTION
As an edge case, for example when viewing a file in a zip container,
Sublime Text might return a "correct" looking file path although the
later `resolve_path` will throw as the file does not exist.

That case was generally handled by a later call to `os.isdir`.  It is
only within this subroutine we might use the invalid filename.

Bug introduced by a5561c59 (Fallback to first folder only if necessary).