### PR TITLE
Fix extracting the project name from a remote url

### DIFF
--- a/core/commands/init.py
+++ b/core/commands/init.py
@@ -125,6 +125,16 @@ def parse_url_from_clipboard(clip_content):
     return ""
 
 
+def project_name_from_url(input_url):
+    # URLs can come in various formats, for example
+    # https://github.com/timbrel/GitSavvy.git
+    #     git@github.com:divmain/GitSavvy.git
+    _split_url = input_url.rsplit("/", 1)[-1]
+    if _split_url.endswith(".git"):
+        _split_url = _split_url[:-4]
+    return _split_url
+
+
 class gs_clone(WindowCommand, GitCommand):
 
     def run(self, recursive=False):
@@ -151,7 +161,7 @@ class gs_clone(WindowCommand, GitCommand):
     def find_suggested_git_root(self, url):
         # type: (str) -> str
         base_folder = self.guess_base_folder()
-        project_name = self.project_name_from_url(url)
+        project_name = project_name_from_url(url)
         return os.path.join(base_folder, project_name)
 
     def guess_base_folder(self):

--- a/core/git_mixins/remotes.py
+++ b/core/git_mixins/remotes.py
@@ -79,15 +79,6 @@ class RemotesMixin(mixin_base):
             branch if not remote_branch else "{}:{}".format(branch, remote_branch)
         )
 
-    def project_name_from_url(self, input_url):
-        # URLs can come in one of following formats format
-        # https://github.com/timbrel/GitSavvy.git
-        #     git@github.com:divmain/GitSavvy.git
-        # Kind of funky, but does the job
-        _split_url = re.split('/|:', input_url)
-        _split_url = re.split(r'\.', _split_url[-1])
-        return _split_url[0] if len(_split_url) >= 1 else ''
-
     def username_from_url(self, input_url):
         # URLs can come in one of following formats format
         # https://github.com/timbrel/GitSavvy.git

--- a/tests/test_gsclone.py
+++ b/tests/test_gsclone.py
@@ -1,7 +1,10 @@
 from unittesting import DeferrableTestCase
 from GitSavvy.tests.parameterized import parameterized as p
 
-from GitSavvy.core.commands.init import parse_url_from_clipboard
+from GitSavvy.core.commands.init import (
+    parse_url_from_clipboard,
+    project_name_from_url
+)
 
 
 class TestGsCloneHelper(DeferrableTestCase):
@@ -28,3 +31,18 @@ class TestGsCloneHelper(DeferrableTestCase):
     ])
     def test_parse_url_from_clipboard(self, IN, OUT):
         self.assertEqual(OUT, parse_url_from_clipboard(IN))
+
+    @p.expand([
+        ("git://github.com/timbrel/GitSavvy.git", "GitSavvy"),
+        ("git@github.com:divmain/GitSavvy.git", "GitSavvy"),
+        ("https://github.com/timbrel/GitSavvy.git", "GitSavvy"),
+        ("https://github.com/timbrel/GitSavvy", "GitSavvy"),
+        ("https://github.com/wbond/packagecontrol.io.git", "packagecontrol.io"),
+        ("https://github.com/wbond/packagecontrol.io", "packagecontrol.io"),
+
+        # pathological cases
+        ("", ""),
+        ("abc", "abc"),
+    ])
+    def test_project_name_from_git_url(self, GIT_URL, PROJECT_NAME):
+        self.assertEqual(PROJECT_NAME, project_name_from_url(GIT_URL))


### PR DESCRIPTION
The remote url can contain `.`s, and our algorithm did not expect
that.  It might not need to end with `.git` as well.  And it doesn't
have to be funky implemented.

Note that the old implementation indicated it would return the empty
string for pathological cases but this was never the case; the else
clause in the return statement was unreachable.