### PR TITLE
Highlight links in GitSavvy's output panel

### DIFF
--- a/syntax/output_panel.sublime-syntax
+++ b/syntax/output_panel.sublime-syntax
@@ -22,3 +22,7 @@ contexts:
     - match: -> ([^ ]*)
       captures:
         1: storage
+
+    - match: \s(https?:\S+)
+      captures:
+        1: markup.underline.link

--- a/syntax/test/syntax_test_output_panel.txt
+++ b/syntax/test/syntax_test_output_panel.txt
@@ -1,0 +1,21 @@
+# SYNTAX TEST "Packages/GitSavvy/syntax/output_panel.sublime-syntax"
+
+$ git push --set-upstream origin test:test
+# <- markup.heading entity.name.section
+
+remote:
+remote: Create a pull request for 'test' on GitHub by visiting:
+remote:      https://github.com/example/example/pull/new/test
+#            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link
+remote:
+To github.com:example/example.git
+ * [new branch]            test -> test
+#                                  ^^^^ storage
+
+Branch 'test' set up to track remote branch 'test' from 'origin'.
+Lirum larum 8f7c117e ipsim...
+#           ^^^^^^^^ constant.numeric.graph.commit-hash.git-savvy
+
+[Done in 4.92s]
+# <- string.other
+# ^^^^^^^^^^^^^ string.other


### PR DESCRIPTION
Fixes #1504

E.g. 

![image](https://user-images.githubusercontent.com/8558/144845859-fa74d848-e338-4945-9e80-1f7969d9b3a3.png)
