### PR TITLE
Fix: Do not bind fixup helpers if the message just begins with "fixup"

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -558,7 +558,7 @@
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.commit_view", "operator": "equal", "operand": true },
-            { "key": "preceding_text", "operator": "regex_match", "operand": "fix(|up(! ?)?).*" },
+            { "key": "preceding_text", "operator": "regex_match", "operand": "fixup! .+|fix(|up(! ?)?)$" },
             { "key": "following_text", "operator": "regex_match", "operand": "^$" },
             { "key": "selection_empty" },
             { "key": "num_selections", "operator": "equal", "operand": 1 },
@@ -572,7 +572,7 @@
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.commit_view", "operator": "equal", "operand": true },
-            { "key": "preceding_text", "operator": "regex_match", "operand": "sq(|uash(! ?)?).*" },
+            { "key": "preceding_text", "operator": "regex_match", "operand": "squash! .+|sq(|uash(! ?)?)$" },
             { "key": "following_text", "operator": "regex_match", "operand": "^$" },
             { "key": "selection_empty" },
             { "key": "num_selections", "operator": "equal", "operand": 1 },


### PR DESCRIPTION
For example: a user just writes "fix lirum" and now wants to complete
"lirum" using `tab` completion.

The trailing `.*` were introduced in b1f59acc (Fine tune fixup and
squash helper triggers).  The idea was to allow running the helper again
just on `tab` at EOL position in case a user selected the wrong commit.

Revert `.*` to `$` and add a special explicit branch, e.g. `fixup! .+`,
for that exact use case instead.