### PR TITLE
Check `returncode` to decide if `git log` failed

### DIFF
--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -739,7 +739,7 @@ class gs_log_graph_refresh(TextCommand, GitCommand):
                 # content fast and not blocking too much here.
                 # TODO: `len(lines)` could be a good indicator of how fast
                 # the system currently is because it seems to vary a lot when
-                # comapring rather short or long (in count of commits) repos.
+                # comparing rather short or long (in count of commits) repos.
                 lines = proc.stdout.readlines(2**14)
                 if not lines:
                     break

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -723,8 +723,9 @@ class gs_log_graph_refresh(TextCommand, GitCommand):
     @log_git_command
     def git_stdout(self, *args, show_panel_on_error=True, throw_on_error=True, got_proc=None, **kwargs):
         # type: (...) -> Iterator[str]
-        # Note: Can't use `self.decode_stdout` because it blocks the
-        # main thread!
+        # Note: Can't use `self.lax_decode` because it internally uses
+        # `self.get_encoding_candidates()` which blocks the main thread as it
+        # needs to access the settings!
         decode = lax_decoder(self.get_encoding_candidates())
         proc = self.git(*args, just_the_proc=True, **kwargs)
         if got_proc:

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -750,7 +750,7 @@ class gs_log_graph_refresh(TextCommand, GitCommand):
 
             stderr = ''.join(map(decode, proc.stderr.readlines()))
 
-        if throw_on_error and stderr:
+        if throw_on_error and not proc.returncode == 0:
             stdout = "<STDOUT SNIPPED>\n" if received_some_stdout else ""
             raise GitSavvyError(
                 "$ {}\n\n{}".format(


### PR DESCRIPTION
Checking `returncode` and not if `stderr` is non-empty is consistent
with `git_command`'s behavior.

The previous behavior leads to a bug in conjunction with git v2.33 which
emits encoding warnings on stderr. Without this patch, we would throw
and fail although we actually lax decode git's output just fine. (This
behavior of git has been reverted in v2.34.)