### PR TITLE
Use distinct title for "Show Commit" views

### DIFF
--- a/core/commands/show_commit.py
+++ b/core/commands/show_commit.py
@@ -24,7 +24,7 @@ if MYPY:
     from typing import Optional, Tuple
     from ..types import LineNo, ColNo
 
-SHOW_COMMIT_TITLE = "COMMIT: {}"
+SHOW_COMMIT_TITLE = "SHOW-COMMIT: {}"
 
 
 def compute_identifier_for_view(view):


### PR DESCRIPTION
As "COMMIT: " is taken by the make commit view, use "SHOW-COMMIT" to
distinguish them better.