### PR TITLE
Place diff views next to the current view

### DIFF
--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -19,7 +19,7 @@ from ..parse_diff import SplittedDiff
 from ..git_command import GitCommand
 from ..runtime import enqueue_on_ui, enqueue_on_worker
 from ..utils import flash, focus_view, line_indentation
-from ..view import replace_view_content, row_offset, Position
+from ..view import replace_view_content, place_view, row_offset, Position
 from ...common import util
 
 
@@ -155,6 +155,8 @@ class gs_diff(WindowCommand, GitCommand):
                 if in_cached_mode is not None:
                     settings.set("git_savvy.diff_view.in_cached_mode", in_cached_mode)
                 focus_view(view)
+                if active_view:
+                    place_view(self.window, view, after=active_view)
                 break
 
         else:

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -12,7 +12,7 @@ from ..git_command import GitCommand
 from ..parse_diff import SplittedDiff, UnsupportedCombinedDiff
 from ..runtime import enqueue_on_ui, enqueue_on_worker
 from ..utils import flash, focus_view
-from ..view import capture_cur_position, replace_view_content, row_offset, Position
+from ..view import capture_cur_position, place_view, replace_view_content, row_offset, Position
 from ...common import util
 
 
@@ -286,6 +286,7 @@ class gs_inline_diff_open(WindowCommand, GitCommand):
         target_commit=None
     ):
         # type: (str, str, str, bool, Position, str, str) -> None
+        active_view = self.window.active_view()
         this_id = (repo_path, file_path, base_commit, target_commit)
         for view in self.window.views():
             if compute_identifier_for_view(view) == this_id:
@@ -294,6 +295,8 @@ class gs_inline_diff_open(WindowCommand, GitCommand):
                 settings.set("git_savvy.inline_diff_view.in_cached_mode", cached)
                 with disabled_on_activated():
                     focus_view(diff_view)
+                if active_view:
+                    place_view(self.window, view, after=active_view)
                 break
 
         else:

--- a/core/view.py
+++ b/core/view.py
@@ -115,6 +115,15 @@ def row_offset(view, cursor):
     return (cy - vy) / view.line_height()
 
 
+def place_view(window, view, after):
+    # type: (sublime.Window, sublime.View, sublime.View) -> None
+    view_group, current_index = window.get_view_index(view)
+    group, index = window.get_view_index(after)
+    if view_group == group:
+        wanted_index = index + 1 if index < current_index else index
+        window.set_view_index(view, group, wanted_index)
+
+
 # `replace_view_content` is a wrapper for `_replace_region` to get some
 # typing support from mypy.
 def replace_view_content(view, text, region=None, wrappers=[]):


### PR DESCRIPTION
Diff views are usually created or switched-to from the status dashboard
or any possible source file.  They can be reused in which case we just
switch to them.

If we create a new diff view it always is created on the right of the
current view, so that upon closing the diff view the user lands again on
the original view.

We want the same when switching (or "re-using") existing views so we
move the diff view in the correct position so that closing it works as
expected.