### PR TITLE
Colorize intra-line differences from `gs_checkout_current_file_at_commit`

### DIFF
--- a/core/commands/checkout.py
+++ b/core/commands/checkout.py
@@ -4,6 +4,7 @@ from functools import partial
 import sublime
 from sublime_plugin import WindowCommand
 
+from . import intra_line_colorizer
 from .log import LogMixin
 from ..git_command import GitCommand, GitSavvyError
 from ..ui_mixins.quick_panel import show_branch_panel
@@ -219,3 +220,4 @@ class gs_show_file_diff(WindowCommand, GitCommand):
         view.set_read_only(True)
         replace_view_content(view, text)
         self.window.run_command("show_panel", {"panel": "output.show_file_diff"})
+        intra_line_colorizer.annotate_intra_line_differences(view)

--- a/core/commands/checkout.py
+++ b/core/commands/checkout.py
@@ -214,8 +214,8 @@ class gs_show_file_diff(WindowCommand, GitCommand):
             self._file_path
         )
 
-        output_view = self.window.create_output_panel("show_file_diff")
-        output_view.set_syntax_file("Packages/GitSavvy/syntax/diff.sublime-syntax")
-        output_view.set_read_only(True)
-        replace_view_content(output_view, text)
+        view = self.window.create_output_panel("show_file_diff")
+        view.set_syntax_file("Packages/GitSavvy/syntax/diff.sublime-syntax")
+        view.set_read_only(True)
+        replace_view_content(view, text)
         self.window.run_command("show_panel", {"panel": "output.show_file_diff"})


### PR DESCRIPTION
E.g. **now**

![image](https://user-images.githubusercontent.com/8558/161280731-34b4a727-380e-4da6-a56c-f36fa1b88e7d.png)

**before**

![image](https://user-images.githubusercontent.com/8558/161280895-04bd03ab-0fd6-41ce-9329-83b6b7f763bb.png)

