### PR TITLE
Flash status message when trying to discard staged files

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -50,7 +50,6 @@
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.diff_view", "operator": "equal", "operand": true },
-            { "key": "setting.git_savvy.diff_view.in_cached_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.diff_view.disable_stage", "operator": "equal", "operand": false }
         ]
     },

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -50,7 +50,6 @@
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.diff_view", "operator": "equal", "operand": true },
-            { "key": "setting.git_savvy.diff_view.in_cached_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.diff_view.disable_stage", "operator": "equal", "operand": false }
         ]
     },

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -50,7 +50,6 @@
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.diff_view", "operator": "equal", "operand": true },
-            { "key": "setting.git_savvy.diff_view.in_cached_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.diff_view.disable_stage", "operator": "equal", "operand": false }
         ]
     },

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -26,8 +26,7 @@
         "args": { "reset": true },
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
-            { "key": "setting.git_savvy.inline_diff_view", "operator": "equal", "operand": true },
-            { "key": "setting.git_savvy.inline_diff_view.in_cached_mode", "operator": "equal", "operand": false }
+            { "key": "setting.git_savvy.inline_diff_view", "operator": "equal", "operand": true }
         ]
     },
     {
@@ -36,8 +35,7 @@
         "args": { "reset": true },
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
-            { "key": "setting.git_savvy.inline_diff_view", "operator": "equal", "operand": true },
-            { "key": "setting.git_savvy.inline_diff_view.in_cached_mode", "operator": "equal", "operand": false }
+            { "key": "setting.git_savvy.inline_diff_view", "operator": "equal", "operand": true }
         ]
     },
     {

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -630,7 +630,6 @@
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.diff_view", "operator": "equal", "operand": true },
-            { "key": "setting.git_savvy.diff_view.in_cached_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.diff_view.disable_stage", "operator": "equal", "operand": false }
         ]
     },
@@ -661,7 +660,6 @@
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.diff_view", "operator": "equal", "operand": true },
-            { "key": "setting.git_savvy.diff_view.in_cached_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.diff_view.disable_stage", "operator": "equal", "operand": false }
         ]
     },
@@ -694,7 +692,6 @@
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.diff_view", "operator": "equal", "operand": true },
-            { "key": "setting.git_savvy.diff_view.in_cached_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.diff_view.disable_stage", "operator": "equal", "operand": false }
         ]
     },

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -521,6 +521,11 @@ class gs_diff_stage_or_reset_hunk(TextCommand, GitCommand):
             sublime.error_message("Staging is not supported while ignoring [w]hitespace is on.")
             return None
 
+        in_cached_mode = self.view.settings().get("git_savvy.diff_view.in_cached_mode")
+        if in_cached_mode and reset:
+            flash(self.view, "Can't discard staged changes.  Unstage first.")
+            return None
+
         frozen_sel = [s for s in self.view.sel()]
         cursor_pts = [s.a for s in frozen_sel]
         diff = SplittedDiff.from_view(self.view)
@@ -536,7 +541,6 @@ class gs_diff_stage_or_reset_hunk(TextCommand, GitCommand):
             zero_diff = self.view.settings().get('git_savvy.diff_view.context_lines') == 0
         else:
             line_starts = selected_line_starts(self.view, frozen_sel)
-            in_cached_mode = self.view.settings().get("git_savvy.diff_view.in_cached_mode")
             patch = compute_patch_for_sel(diff, line_starts, reset or in_cached_mode)
             zero_diff = True
 

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -550,9 +550,7 @@ class gs_diff_stage_or_reset_hunk(TextCommand, GitCommand):
             self.view.sel().clear()
             self.view.sel().add(first_cursor)
         else:
-            window = self.view.window()
-            if window:
-                window.status_message('Not within a hunk')
+            flash(self.view, "Not within a hunk")
 
     def apply_patch(self, patch, pts, reset, zero_diff):
         # type: (str, List[int], bool, bool) -> None
@@ -852,9 +850,7 @@ class gs_diff_undo(TextCommand, GitCommand):
     def run(self, edit):
         history = self.view.settings().get("git_savvy.diff_view.history")
         if not history:
-            window = self.view.window()
-            if window:
-                window.status_message("Undo stack is empty")
+            flash(self.view, "Undo stack is empty")
             return
 
         args, stdin, cursors, in_cached_mode = history.pop()

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -624,6 +624,10 @@ class gs_inline_diff_stage_or_reset_base(TextCommand, GitCommand):
     def run_async(self, reset=False):
         # type: (bool) -> None
         in_cached_mode = self.view.settings().get("git_savvy.inline_diff_view.in_cached_mode")
+        if in_cached_mode and reset:
+            flash(self.view, "Can't discard staged changes.  Unstage first.")
+            return None
+
         ignore_ws = (
             "--ignore-whitespace"
             if self.savvy_settings.get("inline_diff_ignore_eol_whitespaces", True)

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -619,6 +619,8 @@ class GsStatusDiscardChangesToFileCommand(TextCommand, GitCommand):
         if untracked_files or unstaged_files:
             window.status_message("Successfully discarded changes.")
             interface.refresh_repo_status_and_render()
+        if get_selected_subjects(self.view, 'staged'):
+            window.status_message("Staged files cannot be discarded.  Unstage them first.")
 
     def discard_untracked(self):
         # type: () -> Optional[List[str]]


### PR DESCRIPTION
Ideally we would support discarding staged files or hunks but it gets complicated rather quickly:

a) a file can have staged and unstaged parts
b) a file can be actually untracked, only "i-t-a"

For now, flash status bar if discarding cannot be applied to inform the user.  This is better than doing nothing.