### PR TITLE
Fix off-by-one error when jumping from historical to working dir file

### DIFF
--- a/core/commands/show_file_at_commit.py
+++ b/core/commands/show_file_at_commit.py
@@ -293,7 +293,7 @@ class gs_show_file_at_commit_open_file_on_working_dir(TextCommand, GitCommand):
         row, col = self.view.rowcol(self.view.sel()[0].begin())
         row = self.find_matching_lineno(commit_hash, None, row + 1, full_path)
         window.open_file(
-            "{file}:{row}:{col}".format(file=full_path, row=row, col=col),
+            "{file}:{row}:{col}".format(file=full_path, row=row, col=col + 1),
             sublime.ENCODED_POSITION
         )
 

--- a/core/commands/show_file_at_commit.py
+++ b/core/commands/show_file_at_commit.py
@@ -291,9 +291,9 @@ class gs_show_file_at_commit_open_file_on_working_dir(TextCommand, GitCommand):
 
         full_path = os.path.join(self.repo_path, file_path)
         row, col = self.view.rowcol(self.view.sel()[0].begin())
-        row = self.find_matching_lineno(commit_hash, None, row + 1, full_path)
+        line = self.find_matching_lineno(commit_hash, None, row + 1, full_path)
         window.open_file(
-            "{file}:{row}:{col}".format(file=full_path, row=row, col=col + 1),
+            "{file}:{line}:{col}".format(file=full_path, line=line, col=col + 1),
             sublime.ENCODED_POSITION
         )
 


### PR DESCRIPTION
Note (again) that `rowcol` returns 0-based information but `open_file`
expects 1-based line/col values.