### PR TITLE
Fix: show all tags by default

### DIFF
--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -182,7 +182,7 @@
     /*
         Limit the number of tags listed in the tags dashboard.
     */
-    "max_items_in_tags_dashboard": -1,
+    "max_items_in_tags_dashboard": null,
 
     /*
         When set to `true`, GitSavvy will automatically display more info about the

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -86,8 +86,8 @@ class TagsInterface(ui.Interface, GitCommand):
     def pre_render(self):
         if self.show_remotes is None:
             self.show_remotes = self.savvy_settings.get("show_remotes_in_tags_dashboard")
-            self.max_items = self.savvy_settings.get("max_items_in_tags_dashboard", None)
 
+        self.max_items = self.savvy_settings.get("max_items_in_tags_dashboard", None)
         self.local_tags = self.get_tags(reverse=True)
         if self.remotes is None:
             self.remotes = {


### PR DESCRIPTION
Fixes #1540

In the tags dashboard we were showing all but the last tag by default.
This bug was introduced by be511d8 ("set the default for
max_items_in_tags_dashboard to -1", Nov 2017) via #803.

Note that the intention of #803 was to show all tags but slicing `[:-1]` 
is incorrect and we change it to `[:None]`.  Note that `None` in Python 
translates to `null` in JSON.