### PR TITLE
Fix `validate_branch_name`

### DIFF
--- a/core/git_mixins/branches.py
+++ b/core/git_mixins/branches.py
@@ -178,5 +178,4 @@ class BranchesMixin(mixin_base):
         return [branch.strip() for branch in branches]
 
     def validate_branch_name(self, branch):
-        ref = "refs/heads/{}".format(branch)
-        return self.git("check-ref-format", "--branch", ref, throw_on_error=False).strip()
+        return self.git("check-ref-format", "--branch", branch, throw_on_error=False).strip()


### PR DESCRIPTION
When using `--branch` you must not construct `refs/head/<name>` as git
will do this for you.  In fact the *branch* 'refs/head/-+' is valid.

![image](https://user-images.githubusercontent.com/8558/182971685-985e3936-a66c-4ab4-808c-89e19547cdef.png)
