### PR TITLE
Recognize empty files in the diffstat

### DIFF
--- a/syntax/show_commit_diffstat.sublime-syntax
+++ b/syntax/show_commit_diffstat.sublime-syntax
@@ -6,7 +6,7 @@ hidden: true
 scope: git-savvy.commit-diffstat
 contexts:
   main:
-    - match: ^ (\S.+) \| +(\d+) (\+*)(-*)$\n?
+    - match: ^ (\S.+) \| +(\d+ |0)(\+*)(-*)$\n?
       comment: author and date info
       scope: meta.commit-info.diffstat.line
       captures:

--- a/syntax/show_commit_diffstat.sublime-syntax
+++ b/syntax/show_commit_diffstat.sublime-syntax
@@ -6,7 +6,7 @@ hidden: true
 scope: git-savvy.commit-diffstat
 contexts:
   main:
-    - match: ^ (\S.+) \| +(\d+ |0)(\+*)(-*)$\n?
+    - match: ^ (\S.+?) +\| +(\d+ |0)(\+*)(-*)$\n?
       comment: author and date info
       scope: meta.commit-info.diffstat.line
       captures:

--- a/syntax/test/syntax_test_show_commit_with_stat.txt
+++ b/syntax/test/syntax_test_show_commit_with_stat.txt
@@ -21,6 +21,9 @@ CommitDate: Mon Jun 12 19:58:27 2017 +0200
 #                            ^ markup.deleted.git-savvy.delete-block.content
 #                              ^ markup.deleted.git-savvy.delete-block.content
 # <- meta.commit-info.diffstat.line
+ common/ui.py           |  0
+#                          ^ constant.numeric.lines-count.git-savvy
+# <- meta.commit-info.diffstat.line
  popups/bl|me_view.html | 8 ++++
 #                           ^ markup.inserted.git-savvy.add-block.content
 #                              ^ markup.inserted.git-savvy.add-block.content

--- a/syntax/test/syntax_test_show_commit_with_stat.txt
+++ b/syntax/test/syntax_test_show_commit_with_stat.txt
@@ -17,6 +17,8 @@ CommitDate: Mon Jun 12 19:58:27 2017 +0200
 #                             ^ markup.deleted.git-savvy.delete-block.content
 # <- meta.commit-info.diffstat.line
  common/ui.py           |  3 ---
+#^^^^^^^^^^^^      meta.filename.diff
+#            ^^^^^^^^^^^^      -meta.filename.diff
 #                          ^ constant.numeric.lines-count.git-savvy
 #                            ^ markup.deleted.git-savvy.delete-block.content
 #                              ^ markup.deleted.git-savvy.delete-block.content


### PR DESCRIPTION
For example

```
 docs/testing.md                 | 32 +++++++++++++++++++++++++++
 tests/test_git/__init__.py      |  0
 tests/test_git/common.py        | 49 +++++++++++++++++++++++++++++++++++++++++
```

Here: the `0` was not highlighted.

Also do count trailing spaces *between* the filename and the `|` separator as part of the filename.

E.g. before

![image](https://user-images.githubusercontent.com/8558/182973518-ff25f416-b4d0-47c2-a9fe-44ac889f0cc1.png)

After:

![image](https://user-images.githubusercontent.com/8558/182973559-18c2868d-1b53-43b7-b0e4-93bbeb554158.png)
