### PR TITLE
Make file references in some views clickable

### DIFF
--- a/core/commands/line_history.py
+++ b/core/commands/line_history.py
@@ -3,6 +3,7 @@ import os
 import sublime
 from sublime_plugin import TextCommand, WindowCommand
 
+from . import diff
 from ..fns import filter_
 from ..git_command import GitCommand
 from ..parse_diff import SplittedDiff
@@ -82,6 +83,10 @@ class gs_open_line_history(WindowCommand, GitCommand):
         settings = view.settings()
         settings.set("git_savvy.repo_path", repo_path)
         settings.set("git_savvy.file_path", file_path)
+
+        settings.set("result_file_regex", diff.FILE_RE)
+        settings.set("result_line_regex", diff.LINE_RE)
+        settings.set("result_base_dir", repo_path)
 
         rel_file_path = os.path.relpath(file_path, repo_path)
         title = ''.join(

--- a/core/commands/show_commit.py
+++ b/core/commands/show_commit.py
@@ -60,6 +60,11 @@ class gs_show_commit(WindowCommand, GitCommand):
             settings.set("git_savvy.repo_path", repo_path)
             settings.set("git_savvy.show_commit_view.ignore_whitespace", False)
             settings.set("git_savvy.show_commit_view.show_diffstat", self.savvy_settings.get("show_diffstat", True))
+
+            settings.set("result_file_regex", diff.FILE_RE)
+            settings.set("result_line_regex", diff.LINE_RE)
+            settings.set("result_base_dir", repo_path)
+
             view.set_syntax_file("Packages/GitSavvy/syntax/show_commit.sublime-syntax")
             view.set_name(SHOW_COMMIT_TITLE.format(self.get_short_hash(commit_hash)))
             view.set_scratch(True)

--- a/core/commands/show_commit_info.py
+++ b/core/commands/show_commit_info.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 import sublime
 from sublime_plugin import WindowCommand
 
+from . import diff
 from . import intra_line_colorizer
 from ..git_command import GitCommand
 from ..runtime import enqueue_on_worker, enqueue_on_ui, throttled
@@ -69,7 +70,12 @@ class gs_show_commit_info(WindowCommand, GitCommand):
 
     def run_impl(self, commit_hash, file_path=None):
         output_view = ensure_panel(self.window)
-        output_view.settings().set("git_savvy.repo_path", self.repo_path)
+        settings = output_view.settings()
+        settings.set("git_savvy.repo_path", self.repo_path)
+
+        settings.set("result_file_regex", diff.FILE_RE)
+        settings.set("result_line_regex", diff.LINE_RE)
+        settings.set("result_base_dir", self.repo_path)
 
         if commit_hash:
             show_patch = self.savvy_settings.get("show_full_commit_info")


### PR DESCRIPTION
For the views `show_commit`, `show_commit_info` (the panel), and the `Line History`, actually the views showing patches, make the filenames double-clickable.  A double-click will "jump-to" or open the corresponding file.