### PR TITLE
Convert spaces to dashes for new branch names

### DIFF
--- a/core/commands/checkout.py
+++ b/core/commands/checkout.py
@@ -108,6 +108,7 @@ class gs_checkout_new_branch(WindowCommand, GitCommand):
             NEW_BRANCH_PROMPT, new_branch or base_branch or "", self.on_done)
 
     def on_done(self, branch_name):
+        branch_name = branch_name.strip().replace(" ", "-")
         if not self.validate_branch_name(branch_name):
             sublime.error_message(NEW_BRANCH_INVALID.format(branch_name))
             sublime.set_timeout_async(

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -322,6 +322,7 @@ class GsBranchesRenameCommand(TextCommand, GitCommand):
         )
 
     def on_entered_name(self, new_name):
+        new_name = new_name.strip().replace(" ", "-")
         self.git("branch", "-m", self.branch_name, new_name)
         util.view.refresh_gitsavvy(self.view)
 


### PR DESCRIPTION
Fixes #1465

That's a totally minor life-hack so we can enter `fix 43` etc instead of `fix-43` for new branch names. 