### PR TITLE
Add global command to rename the current branch

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -181,6 +181,10 @@
         "command": "gs_checkout_current_file_at_commit"
     },
     {
+        "caption": "git: rename current branch",
+        "command": "gs_rename_branch"
+    },
+    {
         "caption": "git: fetch",
         "command": "gs_fetch"
     },

--- a/core/commands/push.py
+++ b/core/commands/push.py
@@ -148,8 +148,13 @@ class gs_push(PushBase):
             })
 
 
+if MYPY:
+    class _Base(GsWindowCommand, GitCommand):
+        pass
+
+
 def take_current_branch_name(cmd, args, done):
-    # type: (PushBase, Args, Kont) -> None
+    # type: (_Base, Args, Kont) -> None
     current_branch_name = cmd.get_current_branch_name()
     if current_branch_name:
         done(current_branch_name)

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -309,22 +309,16 @@ class GsBranchesRenameCommand(TextCommand, GitCommand):
         sublime.set_timeout_async(self.run_async, 0)
 
     def run_async(self):
+        window = self.view.window()
+        if not window:
+            return
+
         interface = ui.get_interface(self.view.id())
         remote_name, branch_name = interface.get_selected_branch()
         if not branch_name or remote_name:
             return
-        self.branch_name = branch_name
 
-        show_single_line_input_panel(
-            "Enter new branch name (for {}):".format(self.branch_name),
-            self.branch_name,
-            self.on_entered_name
-        )
-
-    def on_entered_name(self, new_name):
-        new_name = new_name.strip().replace(" ", "-")
-        self.git("branch", "-m", self.branch_name, new_name)
-        util.view.refresh_gitsavvy(self.view)
+        window.run_command("gs_rename_branch", {"branch": branch_name})
 
 
 class GsBranchesConfigureTrackingCommand(TextCommand, GitCommand):


### PR DESCRIPTION
Add command in the command palette `git: rename current branch` to rename the current branch.  This was only possible within our branch dashboard before.