### PR TITLE
Add command to unset tracking of a remote branch

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -185,6 +185,10 @@
         "command": "gs_rename_branch"
     },
     {
+        "caption": "git: unset tracking branch",
+        "command": "gs_unset_tracking_information"
+    },
+    {
         "caption": "git: fetch",
         "command": "gs_fetch"
     },

--- a/core/commands/branch.py
+++ b/core/commands/branch.py
@@ -12,6 +12,7 @@ from GitSavvy.core.utils import noop, show_actions_panel
 
 __all__ = (
     "gs_rename_branch",
+    "gs_unset_tracking_information",
     "gs_delete_branch",
 )
 
@@ -60,6 +61,17 @@ class gs_rename_branch(GsWindowCommand, GitCommand):
             return
         self.git("branch", "-m", branch, new_name)
         self.window.status_message("Renamed {} -> {}".format(branch, new_name))
+        util.view.refresh_gitsavvy_interfaces(self.window)
+
+
+class gs_unset_tracking_information(GsWindowCommand, GitCommand):
+    defaults = {
+        "branch": push.take_current_branch_name,  # type: ignore[dict-item]
+    }
+
+    def run(self, branch):
+        self.git("branch", branch, "--unset-upstream")
+        self.window.status_message("Remove the upstream information for {}".format(branch))
         util.view.refresh_gitsavvy_interfaces(self.window)
 
 


### PR DESCRIPTION
Fixes #1035

Add command `git: unset tracking branch` to the command palette