### PR TITLE
Allow deletion of the active branch

### DIFF
--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -2283,7 +2283,6 @@ class gs_log_graph_action(WindowCommand, GitCommand):
         actions += [
             ("Delete branch '{}'".format(branch_name), partial(self.delete_branch, branch_name))
             for branch_name in info.get("local_branches", [])
-            if info.get("HEAD") != branch_name
         ]
 
         if "HEAD" not in info:


### PR DESCRIPTION
As deleting the active branch is forbidden by git, offer to detach
first.

Typical usecase is that the user is on a feature branch which has been
merged upstream.  After `fetch`, the users sees the merge and can just
delete the feature branch without checking out a different branch
before.