### PR TITLE
Iterate on `checkout.py`

### DIFF
--- a/core/commands/checkout.py
+++ b/core/commands/checkout.py
@@ -1,4 +1,3 @@
-from collections import deque
 from functools import partial
 
 import sublime
@@ -11,6 +10,7 @@ from ..ui_mixins.quick_panel import show_branch_panel
 from ..ui_mixins.input_panel import show_single_line_input_panel
 from ..view import replace_view_content
 from ...common import util
+from GitSavvy.core import store
 from GitSavvy.core.utils import noop, show_actions_panel
 
 
@@ -21,11 +21,6 @@ __all__ = (
     "gs_checkout_current_file_at_commit",
     "gs_show_file_diff",
 )
-
-
-MYPY = False
-if MYPY:
-    from typing import Deque, Optional
 
 
 NEW_BRANCH_PROMPT = "Branch name:"
@@ -39,15 +34,10 @@ class gs_checkout_branch(WindowCommand, GitCommand):
     user selected.
     """
 
-    _last_branches = deque([None], 2)  # type: Deque[Optional[str]]
-
     def run(self, branch=None):
         sublime.set_timeout_async(lambda: self.run_async(branch), 0)
 
     def run_async(self, branch):
-        if len(self._last_branches) == 1:
-            self._last_branches.append(self.get_current_branch_name())
-
         if branch:
             self.on_branch_selection(branch)
         else:
@@ -55,7 +45,7 @@ class gs_checkout_branch(WindowCommand, GitCommand):
                 self.on_branch_selection,
                 local_branches_only=True,
                 ignore_current_branch=True,
-                selected_branch=self._last_branches[0]
+                selected_branch=store.current_state(self.repo_path)["last_branches"][-2]
             )
 
     def on_branch_selection(self, branch, merge=False):
@@ -88,7 +78,6 @@ class gs_checkout_branch(WindowCommand, GitCommand):
                     window=e.window,
                 )
 
-        self._last_branches.append(branch)
         self.window.status_message("Checked out `{}`.".format(branch))
         util.view.refresh_gitsavvy_interfaces(self.window, refresh_sidebar=True)
 

--- a/core/commands/checkout.py
+++ b/core/commands/checkout.py
@@ -35,9 +35,6 @@ class gs_checkout_branch(WindowCommand, GitCommand):
     """
 
     def run(self, branch=None):
-        sublime.set_timeout_async(lambda: self.run_async(branch), 0)
-
-    def run_async(self, branch):
         if branch:
             self.on_branch_selection(branch)
         else:

--- a/core/git_mixins/status.py
+++ b/core/git_mixins/status.py
@@ -178,7 +178,7 @@ class StatusMixin(mixin_base):
         If no remote or tracking branch is defined, do not include remote-data.
         If HEAD is detached, provide that status instead.
 
-        If a delimeter is provided, join tuple components with it, and return
+        If a delimiter is provided, join tuple components with it, and return
         that value.
         """
         lines = self._get_status()

--- a/core/git_mixins/status.py
+++ b/core/git_mixins/status.py
@@ -119,7 +119,14 @@ class StatusMixin(mixin_base):
             short_status=self._format_branch_status_short(branch_status),
             long_status=self._format_branch_status(branch_status)
         )
-        store.update_state(self.repo_path, {"status": rv})
+        current_branch = branch_status.branch
+        last_branches = store.current_state(self.repo_path)["last_branches"]
+        if current_branch and current_branch != last_branches[-1]:
+            last_branches.append(current_branch)
+        store.update_state(self.repo_path, {
+            "status": rv,
+            "last_branches": last_branches
+        })
         return rv
 
     def _parse_status_for_file_statuses(self, lines):

--- a/core/git_mixins/status.py
+++ b/core/git_mixins/status.py
@@ -61,7 +61,7 @@ else:
 class WorkingDirState(_WorkingDirState):
     def _asdict(self):  # broken in old Python versions
         rv = dict(zip(self._fields, self))
-        rv["clean"] = self.clean
+        rv["clean"] = self.clean  # type: ignore[assignment]
         return rv
 
     @property

--- a/core/store.py
+++ b/core/store.py
@@ -1,4 +1,4 @@
-from collections import defaultdict
+from collections import defaultdict, deque
 from functools import partial
 import threading
 import uuid
@@ -8,7 +8,7 @@ from .utils import eat_but_log_errors, Cache
 
 MYPY = False
 if MYPY:
-    from typing import AbstractSet, Any, Callable, DefaultDict, Dict, Optional, Tuple, TypedDict
+    from typing import AbstractSet, Any, Callable, DefaultDict, Deque, Dict, Optional, Tuple, TypedDict
     from GitSavvy.core.git_mixins.status import WorkingDirState
 
     RepoPath = str
@@ -16,6 +16,7 @@ if MYPY:
         'RepoStore',
         {
             "status": WorkingDirState,
+            "last_branches": Deque[Optional[str]],
             "last_remote_used": Optional[str],
             "last_remote_used_for_push": Optional[str],
             "last_remote_used_with_option_all": Optional[str],
@@ -26,7 +27,13 @@ if MYPY:
     SubscriberKey = str
     Keys = AbstractSet[str]
 
-state = defaultdict(lambda: {})  # type: DefaultDict[RepoPath, RepoStore]
+
+def initial_state():
+    # type: () -> RepoStore
+    return {"last_branches": deque([None] * 2, 2)}
+
+
+state = defaultdict(initial_state)  # type: DefaultDict[RepoPath, RepoStore]
 cache = Cache(maxsize=512)  # type: Dict[Tuple, Any]
 subscribers = {}  # type: Dict[SubscriberKey, Tuple[RepoPath, Keys, Callable]]
 


### PR DESCRIPTION
 - Do not manage `last_branches` as a by product of `gs_checkout_branch`
but rather as a side-effect of `get_status`.  

- *Always* checkout on the ui thread.  This is debatable and can be changed later,
for now we want consistency here ("always").  Although we typically avoid blocking 
Sublime Text, checking out means changing the files we probably currently looking
at.   It is probably not desirable to allow editing at the same time; of course a ProgressBar 
would be nice