### PR TITLE
Fix syntax highlighting github usernames

### DIFF
--- a/syntax/make_commit.sublime-syntax
+++ b/syntax/make_commit.sublime-syntax
@@ -14,7 +14,7 @@ contexts:
       set: commit-subject
 
   references:
-    - match: (?:\s)(\@\w+)
+    - match: (?:\s|^)(\@[\w-]+)
       comment: github username
       captures:
         1: constant.other.github-username.git-savvy.make-commit

--- a/syntax/test/syntax_test_make_commit.txt
+++ b/syntax/test/syntax_test_make_commit.txt
@@ -12,6 +12,11 @@ This is for @aziz and close #76 aziz/git#123 aziz/good
 #                          ^ - constant.other.issue-ref.git-savvy.make-commit
 #                              ^ - constant.other.issue-ref.git-savvy.make-commit
 #                               ^^^^^^^^^^^^ constant.other.issue-ref.git-savvy.make-commit
+User @bett-miller has a proper username.
+#     ^^^^^^^^^^^ constant.other.github-username.git-savvy.make-commit
+@betty can be referenced on the first column!  Yeah!
+# <-   constant.other.github-username.git-savvy.make-commit
+#^^^^^ constant.other.github-username.git-savvy.make-commit
 This is a ref to a commit 89d6780.
 #                         ^^^^^^^ constant.other.commit-sha.git-savvy.make-commit
 #                        ^ - constant.other.commit-sha.git-savvy.make-commit

--- a/syntax/test/syntax_test_show_commit_with_stat.txt
+++ b/syntax/test/syntax_test_show_commit_with_stat.txt
@@ -6,6 +6,12 @@ Commit:     Simon <simon.toivo@telhaug.no>
 CommitDate: Mon Jun 12 19:58:27 2017 +0200
 
     Blame popup option 2
+
+    This is a message.  Fixes #12
+#                             ^^^ constant.other.issue-ref.git-savvy.make-commit
+    @betty made this.  :thanks:
+#   ^^^^^^ constant.other.github-username.git-savvy.make-commit
+
 ---
 # <- git-savvy.commit meta.commit-header-and-stat-splitter
  Default.sublime-keymap | 22 +-


### PR DESCRIPTION
GitHub usernames can have `-` which we did not consider.  Also fix that
they can appear on the first column.