### PR TITLE
Iterate on the show commit syntax

### DIFF
--- a/syntax/show_commit.sublime-syntax
+++ b/syntax/show_commit.sublime-syntax
@@ -49,7 +49,7 @@ contexts:
 
   commit-subject:
     - meta_content_scope: meta.commit_message meta.subject.git.commit markup.heading.subject.git.commit
-    - match: $\n?
+    - match: $
       set: commit-message-body
     - include: make_commit.sublime-syntax#references
 

--- a/syntax/show_commit.sublime-syntax
+++ b/syntax/show_commit.sublime-syntax
@@ -48,7 +48,7 @@ contexts:
       set: commit-subject
 
   commit-subject:
-    - meta_content_scope: meta.commit_message meta.subject.git.commit markup.heading.subject.git.commit
+    - meta_content_scope: gitsavvy.gotosymbol meta.commit_message meta.subject.git.commit markup.heading.subject.git.commit
     - match: $
       set: commit-message-body
     - include: make_commit.sublime-syntax#references


### PR DESCRIPTION
- Do not include the trailing "\n" in the message subject
- Make the message subject a "Goto" reference (`ctrl+r`) (useful to navigate a longer `Line History`)