### PR TITLE
Add more fixup helpers

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1782,6 +1782,14 @@
         ]
     },
     {
+        "keys": ["f"],
+        "command": "gs_line_history_initiate_fixup_commit",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.line_history_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
         "keys": ["."],
         "command": "gs_diff_navigate",
         "args": { "forward": true },

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -65,6 +65,14 @@
         ]
     },
     {
+        "keys": ["f"],
+        "command": "gs_initiate_fixup_commit",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.inline_diff_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
         "keys": ["."],
         "command": "gs_inline_diff_navigate_hunk",
         "args": { "forward": true },
@@ -717,6 +725,14 @@
         "keys": ["m"],
         "command": "gs_commit",
         "args": {"amend": true},
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.diff_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["f"],
+        "command": "gs_initiate_fixup_commit",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.diff_view", "operator": "equal", "operand": true }

--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -76,6 +76,11 @@ def compute_identifier_for_view(view):
     ) if settings.get('git_savvy.commit_view') else None
 
 
+def view_has_simple_cursor(view):
+    # type: (sublime.View) -> bool
+    return len(view.sel()) == 1 and view.sel()[0].empty()
+
+
 class gs_commit(WindowCommand, GitCommand):
 
     """
@@ -96,6 +101,12 @@ class gs_commit(WindowCommand, GitCommand):
                 settings.set("git_savvy.commit_view.include_unstaged", include_unstaged)
                 settings.set("git_savvy.commit_view.amend", amend)
                 focus_view(view)
+                initial_text_ = initial_text.rstrip()
+                if initial_text_:
+                    replace_view_content(view, initial_text_ + "\n", sublime.Region(0))
+                    if view_has_simple_cursor(view):
+                        view.sel().clear()
+                        view.sel().add(len(initial_text_))
                 break
         else:
             view = self.window.new_file()

--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -101,12 +101,6 @@ class gs_commit(WindowCommand, GitCommand):
                 settings.set("git_savvy.commit_view.include_unstaged", include_unstaged)
                 settings.set("git_savvy.commit_view.amend", amend)
                 focus_view(view)
-                initial_text_ = initial_text.rstrip()
-                if initial_text_:
-                    replace_view_content(view, initial_text_ + "\n", sublime.Region(0))
-                    if view_has_simple_cursor(view):
-                        view.sel().clear()
-                        view.sel().add(len(initial_text_))
                 break
         else:
             view = self.window.new_file()
@@ -127,10 +121,17 @@ class gs_commit(WindowCommand, GitCommand):
             title = COMMIT_TITLE.format(os.path.basename(repo_path))
             view.set_name(title)
             view.set_scratch(True)  # ignore dirty on actual commit
-            self.initialize_view(view, amend, initial_text)
+            self.initialize_view(view, amend)
 
-    def initialize_view(self, view, amend, initial_text):
-        # type: (sublime.View, bool, str) -> None
+        initial_text_ = initial_text.rstrip()
+        if initial_text_:
+            replace_view_content(view, initial_text_ + "\n", sublime.Region(0))
+            if view_has_simple_cursor(view):
+                view.sel().clear()
+                view.sel().add(len(initial_text_))
+
+    def initialize_view(self, view, amend):
+        # type: (sublime.View, bool) -> None
         merge_msg_path = os.path.join(self.git_dir, "MERGE_MSG")
 
         help_text = (
@@ -139,9 +140,7 @@ class gs_commit(WindowCommand, GitCommand):
             else COMMIT_HELP_TEXT
         )
 
-        if initial_text:
-            initial_text += help_text
-        elif amend:
+        if amend:
             last_commit_message = self.git("log", "-1", "--pretty=%B").strip()
             initial_text = last_commit_message + help_text
         elif os.path.exists(merge_msg_path):

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -534,7 +534,10 @@ class gs_diff_stage_or_reset_hunk(TextCommand, GitCommand):
             if whole_file:
                 hunks = filter_(map(diff.hunk_for_pt, cursor_pts))
                 headers = unique(map(diff.head_for_hunk, hunks))
-                patches = flatten(chain([head], diff.hunks_for_head(head)) for head in headers)
+                patches = flatten(
+                    chain([head], diff.hunks_for_head(head))
+                    for head in headers
+                )  # type: Iterable[TextRange]
             else:
                 patches = unique(flatten(filter_(diff.head_and_hunk_for_pt(pt) for pt in cursor_pts)))
             patch = ''.join(part.text for part in patches)

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -18,6 +18,7 @@ from ..fns import filter_, flatten, unique
 from ..parse_diff import SplittedDiff
 from ..git_command import GitCommand
 from ..runtime import enqueue_on_ui, enqueue_on_worker
+from ..ui_mixins.quick_panel import LogHelperMixin
 from ..utils import flash, focus_view, line_indentation
 from ..view import replace_view_content, place_view, row_offset, Position
 from ...common import util
@@ -30,6 +31,7 @@ __all__ = (
     "gs_diff_toggle_cached_mode",
     "gs_diff_zoom",
     "gs_diff_stage_or_reset_hunk",
+    "gs_initiate_fixup_commit",
     "gs_diff_open_file_at_hunk",
     "gs_diff_navigate",
     "gs_diff_undo",
@@ -45,6 +47,7 @@ if MYPY:
     )
     from ..parse_diff import FileHeader, Hunk, HunkLine, TextRange
     from ..types import LineNo, ColNo
+    from ..git_mixins.history import LogEntry
 
     T = TypeVar('T')
     Point = int
@@ -630,6 +633,22 @@ def form_patch(lines):
     blen = sum(1 for line, a_b in lines if not line.is_from_line())
     content = "".join(line.text for line, a_b in lines)
     return stage_hunk.Hunk(a_start, alen, b_start, blen, content)
+
+
+class gs_initiate_fixup_commit(TextCommand, LogHelperMixin):
+    def run(self, edit):
+        view = self.view
+        window = view.window()
+        assert window
+
+        def action(entry):
+            # type: (LogEntry) -> None
+            commit_message = entry.summary
+            window.run_command("gs_commit", {  # type: ignore[union-attr]
+                "initial_text": "fixup! {}".format(commit_message)
+            })
+
+        self.show_log_panel(action)
 
 
 MYPY = False

--- a/popups/diff_view.html
+++ b/popups/diff_view.html
@@ -13,8 +13,7 @@
   <div><code><span class="shortcut-key">{super_key}-z&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>undo last action</code></div>
   <br />
 
-  <div><code><span class="shortcut-key">c&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>commit</code></div>
-  <div><code><span class="shortcut-key">C&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>commit, including unstaged</code></div>
+  <div><code><span class="shortcut-key">c</span>/<span class="shortcut-key">C</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;commit (<span class="shortcut-key">C</span> to include unstaged)</code></div>
   <div><code><span class="shortcut-key">m&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>amend previous commit</code></div>
 </div>
 

--- a/popups/diff_view.html
+++ b/popups/diff_view.html
@@ -15,6 +15,7 @@
 
   <div><code><span class="shortcut-key">c</span>/<span class="shortcut-key">C</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;commit (<span class="shortcut-key">C</span> to include unstaged)</code></div>
   <div><code><span class="shortcut-key">m&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>amend previous commit</code></div>
+  <div><code><span class="shortcut-key">f&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>make fixup commit</code></div>
 </div>
 
 <h3>Navigation</h3>

--- a/popups/inline_diff_view.html
+++ b/popups/inline_diff_view.html
@@ -17,6 +17,7 @@
 
   <div><code><span class="shortcut-key">c</span>/<span class="shortcut-key">C</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;commit (<span class="shortcut-key">C</span> to include unstaged)</code></div>
   <div><code><span class="shortcut-key">m&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>amend previous commit</code></div>
+  <div><code><span class="shortcut-key">f&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>make fixup commit</code></div>
 
 </div>
 

--- a/popups/inline_diff_view.html
+++ b/popups/inline_diff_view.html
@@ -15,8 +15,7 @@
   <div><code><span class="shortcut-key">{super_key}-z&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>undo last action</code></div>
   <br />
 
-  <div><code><span class="shortcut-key">c&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>commit</code></div>
-  <div><code><span class="shortcut-key">C&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>commit, including unstaged</code></div>
+  <div><code><span class="shortcut-key">c</span>/<span class="shortcut-key">C</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;commit (<span class="shortcut-key">C</span> to include unstaged)</code></div>
   <div><code><span class="shortcut-key">m&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>amend previous commit</code></div>
 
 </div>

--- a/popups/line_history.html
+++ b/popups/line_history.html
@@ -10,6 +10,7 @@
   <div><code><span class="shortcut-key">o&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>open commit; on <span class="shortcut-key">#issues</span>, open a browser</code></div>
   <div><code><span class="shortcut-key">O&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>open file revision at hunk</code></div>
   <div><code><span class="shortcut-key">g&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>show in graph</code></div>
+  <div><code><span class="shortcut-key">f&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>make fixup commit</code></div>
   <div><code><span class="shortcut-key">,</span>/<span class="shortcut-key">.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>go to next/previous hunk (also: <span class="shortcut-key">j</span>/<span class="shortcut-key">k</span> in vintageous mode)</code></div>
 </div>
 


### PR DESCRIPTION
Add fixup helpers -- bound to `[f]` -- to the `diff`, `inline-diff`, and the `Line History`.  

This is especially useful for the Line History as a user may fix a line, stage it and then search for the last commit that exact line has been modified recently.  Then looking at the Line History `[f]` will immediately open the pre-filled commit message view.

For the diff/inline-diff, opening a line history (or in that case: hunk history) would be very promising. 