### PR TITLE
Draw log graph more async, more streaming 

### DIFF
--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -737,22 +737,10 @@ class gs_log_graph_refresh(TextCommand, GitCommand):
             got_proc(proc)
         received_some_stdout = False
         with proc:
-            while True:
-                # Block size 2**14 taken from Sublime's `exec.py`. This
-                # may be a hint on how much chars Sublime can draw efficiently.
-                # But here we don't draw every line (except initially) but
-                # a diff. So we oscillate between getting a first meaningful
-                # content fast and not blocking too much here.
-                # TODO: `len(lines)` could be a good indicator of how fast
-                # the system currently is because it seems to vary a lot when
-                # comparing rather short or long (in count of commits) repos.
-                lines = proc.stdout.readlines(2**14)
-                if not lines:
-                    break
-                elif not received_some_stdout:
+            for line in iter(proc.stdout.readline, b''):
+                yield decode(line)
+                if not received_some_stdout:
                     received_some_stdout = True
-                for line in lines:
-                    yield decode(line)
 
             stderr = ''.join(map(decode, proc.stderr.readlines()))
 

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -300,11 +300,15 @@ else:
 
 def diff(a, b):
     # type: (Sequence[str], Iterable[str]) -> Iterator[Union[Ins, Del, FlushT]]
+    block_time_passed = block_time_passed_factory(100)
     a_index = 0
     b_index = -1  # init in case b is empty
     len_a = len(a)
     a_set = set(a)
     for b_index, line in enumerate(b):
+        if block_time_passed():
+            yield Flush
+
         is_commit_line = re.match(FIND_COMMIT_HASH, line)
         if is_commit_line and line not in a_set:
             len_a += 1


### PR DESCRIPTION
For slow graph outputs, for example when searching and filtering,
reading "2**14" locks for too long.  Just read line by line, just
like we do in `git_command.read_linewise`.