### PR TITLE
Makeup for fixup commit messages

### DIFF
--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -125,7 +125,9 @@ class gs_commit(WindowCommand, GitCommand):
 
         initial_text_ = initial_text.rstrip()
         if initial_text_:
-            replace_view_content(view, initial_text_ + "\n", sublime.Region(0))
+            if extract_commit_subject(view).strip():
+                initial_text_ += "\n\n"
+            replace_view_content(view, initial_text_, sublime.Region(0))
             if view_has_simple_cursor(view):
                 view.sel().clear()
                 view.sel().add(len(initial_text_))


### PR DESCRIPTION
We unconditionally added a newline (`"\n"`) after the commit subject which just looks not 100%.  Instead check if we actually have a message subject already and only then move that subject two(!) lines down so it becomes part of the message body.

We decided earlier that we *don't* replace old subject lines but only prepend.  Adding two newlines makes a perfect commit message ready to commit.