### PR TITLE
Quote git command when logging

### DIFF
--- a/common/util/debug.py
+++ b/common/util/debug.py
@@ -1,5 +1,8 @@
 import json
+import shlex
 import threading
+
+from GitSavvy.core.fns import filter_
 
 
 MYPY = False
@@ -64,6 +67,11 @@ def print_cwd_change(cwd, left_space):
         print('\n', ' ' * left_space, '  [{}]'.format(cwd))
 
 
+def pretty_git_command(args):
+    # type: (Sequence[Optional[str]]) -> str
+    return ' '.join(['git'] + list(map(shlex.quote, filter_(args))))
+
+
 def log_git(
     command,  # type: Sequence[Optional[str]]
     cwd,      # type: str
@@ -83,7 +91,7 @@ def log_git(
         print_cwd_change(cwd, left_space=len(pre_info))
         print(' {pre_info} $ {cmd}'.format(
             pre_info=pre_info,
-            cmd=' '.join(['git'] + list(filter(None, command))),
+            cmd=pretty_git_command(command)
         ))
 
     message = make_log_message(

--- a/core/commands/branch.py
+++ b/core/commands/branch.py
@@ -96,14 +96,8 @@ class gs_delete_branch(GsWindowCommand, GitCommand):
                 if CANT_DELETE_CURRENT_BRANCH.search(e.stderr):
                     self.offer_detaching_head(branch)
                     return
-                raise GitSavvyError(
-                    e.message,
-                    cmd=e.cmd,
-                    stdout=e.stdout,
-                    stderr=e.stderr,
-                    show_panel=True,
-                    window=e.window,
-                )
+                e.show_error_panel()
+                raise
 
         match = EXTRACT_COMMIT.search(rv.strip())
         if match:

--- a/core/commands/checkout.py
+++ b/core/commands/checkout.py
@@ -66,14 +66,8 @@ class gs_checkout_branch(WindowCommand, GitCommand):
                 ])
                 return
             else:
-                raise GitSavvyError(
-                    e.message,
-                    cmd=e.cmd,
-                    stdout=e.stdout,
-                    stderr=e.stderr,
-                    show_panel=True,
-                    window=e.window,
-                )
+                e.show_error_panel()
+                raise
 
         self.window.status_message("Checked out `{}`.".format(branch))
         util.view.refresh_gitsavvy_interfaces(self.window, refresh_sidebar=True)

--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -207,14 +207,8 @@ class gs_prepare_commit_refresh_diff(TextCommand, GitCommand):
                     decode=False
                 )
             else:
-                raise GitSavvyError(
-                    e.message,
-                    cmd=e.cmd,
-                    stdout=e.stdout,
-                    stderr=e.stderr,
-                    show_panel=True,
-                    window=e.window,
-                )
+                e.show_error_panel()
+                raise
 
         try:
             diff_text = self.strict_decode(raw_diff_text)

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -811,7 +811,7 @@ class gs_log_graph_refresh(TextCommand, GitCommand):
             stdout = "<STDOUT SNIPPED>\n" if received_some_stdout else ""
             raise GitSavvyError(
                 "$ {}\n\n{}".format(
-                    " ".join(["git"] + list(filter(None, args))),
+                    util.debug.pretty_git_command(args),
                     ''.join([stdout, stderr])
                 ),
                 cmd=proc.args,

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -841,14 +841,8 @@ class gs_log_graph_refresh(TextCommand, GitCommand):
                     enqueue_on_worker(self.view.run_command, "gs_log_graph_refresh")
                     return iter('')
                 else:
-                    raise GitSavvyError(
-                        e.message,
-                        cmd=e.cmd,
-                        stdout=e.stdout,
-                        stderr=e.stderr,
-                        show_panel=True,
-                        window=e.window,
-                    )
+                    e.show_error_panel()
+                    raise
             else:
                 DATE_FORMAT_STATE = 'final'
 

--- a/core/commands/log_graph_rebase_actions.py
+++ b/core/commands/log_graph_rebase_actions.py
@@ -311,14 +311,8 @@ class gs_rebase_action(GsWindowCommand, GitCommand):
                 flash(view, "The branch '{}' has no previous tip.".format(branch_name))
                 return
             else:
-                raise GitSavvyError(
-                    e.message,
-                    cmd=e.cmd,
-                    stdout=e.stdout,
-                    stderr=e.stderr,
-                    show_panel=True,
-                    window=e.window,
-                )
+                e.show_error_panel()
+                raise
 
         else:
             settings.set("git_savvy.log_graph_view.follow", commit_hash)

--- a/core/exceptions.py
+++ b/core/exceptions.py
@@ -19,8 +19,11 @@ class GitSavvyError(Exception):
         self.window = window
         if msg:
             if show_panel:
-                util.log.display_panel(window or sublime.active_window(), msg)
+                self.show_error_panel()
             util.debug.log_error(msg)
+
+    def show_error_panel(self):
+        util.log.display_panel(self.window or sublime.active_window(), self.message)
 
 
 class FailedGithubRequest(GitSavvyError):

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -225,7 +225,7 @@ class _GitCommand(SettingsMixin):
         window = self.some_window()
         final_args = self._add_global_flags(git_cmd, list(args))
         command = [self.git_binary_path] + list(filter_(final_args))
-        command_str = " ".join(["git"] + command[1:])
+        command_str = util.debug.pretty_git_command(command[1:])
 
         if show_panel is None:
             show_panel = git_cmd in self.savvy_settings.get("show_panel_for")


### PR DESCRIPTION
To allow copy-pasting the git commands, quote the arguments.

Note that `shlex.quote` is already a noop if the command doesn't need
to be quoted which simplifies the work we have to do a lot.