### PR TITLE
Fix computing the new viewport position y value

### DIFF
--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -12,7 +12,7 @@ from ..git_command import GitCommand
 from ..parse_diff import SplittedDiff, UnsupportedCombinedDiff
 from ..runtime import enqueue_on_ui, enqueue_on_worker
 from ..utils import flash, focus_view
-from ..view import capture_cur_position, place_view, replace_view_content, row_offset, Position
+from ..view import capture_cur_position, place_view, replace_view_content, y_offset, Position
 from ...common import util
 
 
@@ -74,7 +74,8 @@ def place_cursor_and_show(view, row, col, row_offset):
     pt = view.text_point(row, col)
     view.sel().add(sublime.Region(pt, pt))
 
-    vy = (row - row_offset) * view.line_height()
+    _, cy = view.text_to_layout(pt)
+    vy = cy - row_offset
     vx, _ = view.viewport_position()
     view.set_viewport_position((vx, vy), animate=False)
 
@@ -231,7 +232,7 @@ class gs_inline_diff(WindowCommand, GitCommand):
         cur_pos = Position(
             jump_position.line - 1,
             jump_position.col - 1,
-            row_offset(view, cursor)
+            y_offset(view, cursor)
         )
         if cached:
             row, col, offset = cur_pos

--- a/core/commands/show_file_at_commit.py
+++ b/core/commands/show_file_at_commit.py
@@ -152,7 +152,8 @@ def move_cursor_to_line_col(view, position):
     if row_offset is None:
         view.show(pt)
     else:
-        vy = (row - row_offset) * view.line_height()
+        _, cy = view.text_to_layout(pt)
+        vy = cy - row_offset
         vx, _ = view.viewport_position()
         view.set_viewport_position((vx, vy), animate=False)
 

--- a/core/view.py
+++ b/core/view.py
@@ -115,13 +115,6 @@ def y_offset(view, cursor):
     return cy - vy
 
 
-def row_offset(view, cursor):
-    # type: (sublime.View, int) -> float
-    _, cy = view.text_to_layout(cursor)
-    _, vy = view.viewport_position()
-    return (cy - vy) / view.line_height()
-
-
 def place_view(window, view, after):
     # type: (sublime.Window, sublime.View, sublime.View) -> None
     view_group, current_index = window.get_view_index(view)

--- a/core/view.py
+++ b/core/view.py
@@ -105,7 +105,14 @@ def capture_cur_position(view):
         return None
 
     row, col = view.rowcol(sel.begin())
-    return Position(row, col, row_offset(view, sel.begin()))
+    return Position(row, col, y_offset(view, sel.begin()))
+
+
+def y_offset(view, cursor):
+    # type: (sublime.View, int) -> float
+    _, cy = view.text_to_layout(cursor)
+    _, vy = view.viewport_position()
+    return cy - vy
 
 
 def row_offset(view, cursor):


### PR DESCRIPTION
The old algorithm was not correct if Sublime Text word wrap was set.

Instead of computing the relative `row`, e.g. the cursor is on the 20th
visible row from the top of the viewport, stay in the pixel land and
compute the cursor is "231px" from the top border.  Then after
modifying the view, read the new cursor position (`cy`) in pixel via
`text_to_layout` and set the viewport so that we're still "231px" from
the top (`cy - row_offset`).

😊

Probably fixes #1349 

