### PR TITLE
Automatically close a Line History view after committing

### DIFF
--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -411,7 +411,7 @@ class gs_commit_view_do_commit(TextCommand, GitCommand):
             commit_message = extract_commit_message(self.view)
 
         settings.set("git_savvy.commit_view.is_commiting", True)
-        window.status_message("Commiting...")
+        window.status_message("Committing...")
         try:
             self.git(
                 "commit",

--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -426,6 +426,13 @@ class gs_commit_view_do_commit(TextCommand, GitCommand):
 
         window.status_message("Committed successfully.")
 
+        # We close Line History right on the left side if it initiated the fixup
+        for v in reversed(adjacent_views_on_the_left(self.view)):
+            initiated_message = v.settings().get("initiated_fixup_commit")
+            if initiated_message and initiated_message in extract_commit_subject(self.view):
+                v.close()
+            break
+
         # We want to refresh and maybe close open diff views.
         diff_views = mark_all_diff_views(window, self.repo_path)
         # Since we're closing the commit view, the next focused view will

--- a/core/commands/line_history.py
+++ b/core/commands/line_history.py
@@ -167,6 +167,7 @@ class gs_line_history_initiate_fixup_commit(TextCommand, LogHelperMixin):
         for r in view.find_by_selector("meta.commit_message meta.subject.git.commit"):
             if r.a > commit_header.a:
                 commit_message = view.substr(r).strip()
+                view.settings().set("initiated_fixup_commit", commit_message)
                 window.run_command("gs_commit", {
                     "initial_text": "fixup! {}".format(commit_message)
                 })


### PR DESCRIPTION
Since 2.34.0 we can initiate a fixup commit from the `Line History`.  We already close unneeded diff views after committing; and we follow here because that makes a nice workflow.