### PR TITLE
Iterate on merge conflicts

### DIFF
--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -338,7 +338,7 @@ class gs_diff_toggle_cached_mode(TextCommand):
     Toggle `in_cached_mode` or flip `base` with `target`.
     """
 
-    # NOTE: MUST NOT be async, otherwise `view.show` will not update the view 100%!
+    # NOTE: Blocking because `set_and_show_cursor` must run within a `TextCommand`
     def run(self, edit):
         settings = self.view.settings()
 
@@ -887,7 +887,7 @@ class gs_diff_undo(TextCommand, GitCommand):
     Undo the last action taken in the diff view, if possible.
     """
 
-    # NOTE: MUST NOT be async, otherwise `view.show` will not update the view 100%!
+    # NOTE: Blocking because `set_and_show_cursor` must run within a `TextCommand`
     def run(self, edit):
         history = self.view.settings().get("git_savvy.diff_view.history")
         if not history:

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -370,7 +370,7 @@ class gs_diff_toggle_cached_mode(TextCommand):
         just_hunked = self.view.settings().get("git_savvy.diff_view.just_hunked")
         # Check for `last_cursors` as well bc it is only falsy on the *first*
         # switch. T.i. if the user hunked and then switches to see what will be
-        # actually comitted, the view starts at the top. Later, the view will
+        # actually committed, the view starts at the top. Later, the view will
         # show the last added hunk.
         if just_hunked and last_cursors:
             self.view.settings().set("git_savvy.diff_view.just_hunked", "")

--- a/core/commands/merge.py
+++ b/core/commands/merge.py
@@ -6,7 +6,14 @@ from ...common import util
 from ..ui_mixins.quick_panel import show_branch_panel
 
 
-class GsMergeCommand(WindowCommand, GitCommand):
+__all__ = (
+    "gs_merge",
+    "gs_abort_merge",
+    "gs_restart_merge_for_file",
+)
+
+
+class gs_merge(WindowCommand, GitCommand):
 
     """
     Display a list of branches available to merge against the active branch.
@@ -33,7 +40,7 @@ class GsMergeCommand(WindowCommand, GitCommand):
             util.view.refresh_gitsavvy(self.window.active_view(), refresh_sidebar=True)
 
 
-class GsAbortMergeCommand(WindowCommand, GitCommand):
+class gs_abort_merge(WindowCommand, GitCommand):
 
     """
     Reset all files to pre-merge conditions, and abort the merge.
@@ -47,7 +54,7 @@ class GsAbortMergeCommand(WindowCommand, GitCommand):
         util.view.refresh_gitsavvy(self.window.active_view(), refresh_sidebar=True)
 
 
-class GsRestartMergeForFileCommand(WindowCommand, GitCommand):
+class gs_restart_merge_for_file(WindowCommand, GitCommand):
 
     """
     Reset a single file to pre-merge condition, but do not abort the merge.

--- a/core/commands/merge.py
+++ b/core/commands/merge.py
@@ -61,22 +61,17 @@ class gs_restart_merge_for_file(WindowCommand, GitCommand):
     """
 
     def run(self):
-        sublime.set_timeout_async(self.run_async, 0)
+        paths = self.conflicting_files_()
 
-    def run_async(self):
-        self._conflicts = [
-            f.path for f in self.get_working_dir_status().merge_conflicts
-        ]
+        def on_done(index):
+            if index == -1:
+                return
+            fpath = paths[index]
+            self.git("checkout", "-m", "--", fpath)
+
+            util.view.refresh_gitsavvy(self.window.active_view())
 
         self.window.show_quick_panel(
-            self._conflicts,
-            self.on_selection
+            paths,
+            on_done
         )
-
-    def on_selection(self, index):
-        if index == -1:
-            return
-        fpath = self._conflicts[index]
-        self.git("checkout", "--conflict=merge", "--", fpath)
-
-        util.view.refresh_gitsavvy(self.window.active_view())

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -1,7 +1,6 @@
 from functools import partial, wraps
 from itertools import chain
 import os
-import re
 import threading
 
 import sublime
@@ -20,7 +19,7 @@ flatten = chain.from_iterable
 
 MYPY = False
 if MYPY:
-    from typing import Iterable, Iterator, List, Optional, Set, Tuple
+    from typing import Iterable, Iterator, List, Optional, Tuple
 
 
 # Expected
@@ -604,24 +603,6 @@ class gs_status_stage_file(TextCommand, GitCommand):
             self.stage_file(*file_paths, force=False)
             window.status_message("Staged files successfully.")
             interface.refresh_repo_status_and_render()
-
-    def check_for_conflict_markers(self, file_paths):
-        # type: (List[str]) -> Set[str]
-        to_check = set(file_paths) & set(self.conflicting_files_())
-        if not to_check:
-            return set()
-
-        return {
-            re.search(r"^(?P<fpath>[^:]+)", line).group("fpath")  # type: ignore[union-attr]
-            for line in self.git(
-                "diff",
-                "--check",
-                "--", *to_check,
-                show_panel_on_error=False,
-                throw_on_error=False
-            ).splitlines()
-            if "leftover conflict marker" in line
-        }
 
 
 class GsStatusUnstageFileCommand(TextCommand, GitCommand):

--- a/core/parse_diff.py
+++ b/core/parse_diff.py
@@ -49,6 +49,13 @@ class SplittedDiff(SplittedDiffBase):
         # type: (sublime.View) -> SplittedDiff
         return cls.from_string(view.substr(sublime.Region(0, view.size())))
 
+    def is_combined_diff(self):
+        # type: () -> bool
+        for head in self.headers:
+            if head.first_line().startswith("diff --cc "):
+                return True
+        return False
+
     def head_and_hunk_for_pt(self, pt):
         # type: (int) -> Optional[Tuple[FileHeader, Hunk]]
         hunk = self.hunk_for_pt(pt)
@@ -62,6 +69,14 @@ class SplittedDiff(SplittedDiffBase):
         for hunk in self.hunks:
             if hunk.a <= pt < hunk.b:
                 return hunk
+        else:
+            return None
+
+    def head_for_pt(self, pt):
+        # type: (int) -> Optional[FileHeader]
+        for header in reversed(self.headers):
+            if header.a <= pt:
+                return header
         else:
             return None
 

--- a/core/parse_diff.py
+++ b/core/parse_diff.py
@@ -93,7 +93,7 @@ class SplittedDiff(SplittedDiffBase):
             lambda x: isinstance(x, Hunk),
             tail(dropwhile(
                 lambda x: x != head,
-                sorted(self.headers + self.hunks, key=lambda x: x.a)
+                sorted(self.headers + self.hunks, key=lambda x: x.a)  # type: ignore[arg-type]
             ))
         )
 

--- a/core/parse_diff.py
+++ b/core/parse_diff.py
@@ -15,7 +15,7 @@ if MYPY:
 
 if MYPY:
     SplittedDiffBase = NamedTuple(
-        'SplittedDiff', [
+        'SplittedDiffBase', [
             ('commits', Tuple['CommitHeader', ...]),
             ('headers', Tuple['FileHeader', ...]),
             ('hunks', Tuple['Hunk', ...])


### PR DESCRIPTION
Fixes #1353
Fixes #1579 

- allow restarting conflict resolution even after staging (`git checkout -m -- <path>`)
- warn when staging files with conflict markers 
- allow staging in the diff view (but all conflicts must be resolved)