### PR TITLE
Iterate `merge.py`

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -333,8 +333,8 @@
         "command": "gs_merge"
     },
     {
-        "caption": "git: abort merge",
-        "command": "gs_abort_merge"
+        "caption": "git: merge --abort",
+        "command": "gs_merge_abort"
     },
     {
         "caption": "git: restart merge for file...",

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -223,7 +223,7 @@
     },
     {
         "keys": ["B"],
-        "command": "gs_abort_merge",
+        "command": "gs_merge_abort",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.status_view", "operator": "equal", "operand": true }

--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -249,7 +249,7 @@
         merges.  This will mean commit summaries will be included in the merge commit
         message.
     */
-    "merge_log": true,
+    "merge_log": false,
 
 
     /*

--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -245,14 +245,6 @@
     "show_git_flow_commands": false,
 
     /*
-        When set to `true`, GitSavvy will include the `--log` flag when performing
-        merges.  This will mean commit summaries will be included in the merge commit
-        message.
-    */
-    "merge_log": false,
-
-
-    /*
         The default base for the rebase dashboard.
     */
     "rebase_default_base_ref": "",

--- a/core/base_commands.py
+++ b/core/base_commands.py
@@ -152,10 +152,16 @@ if MYPY:
 # COMMON INPUT HANDLERS
 
 
-def ask_for_local_branch(self, args, done):
-    # type: (GsCommand, Args, Kont) -> None
-    show_branch_panel(
-        done,
-        local_branches_only=True,
-        ignore_current_branch=True,
-    )
+def ask_for_branch(**kw):
+    # type: (...) -> ArgProvider
+    def handler(self, args, done):
+        # type: (GsCommand, Args, Kont) -> None
+        show_branch_panel(done, **kw)
+
+    return handler
+
+
+ask_for_local_branch = ask_for_branch(
+    ignore_current_branch=True,
+    local_branches_only=True
+)

--- a/core/base_commands.py
+++ b/core/base_commands.py
@@ -154,11 +154,8 @@ if MYPY:
 
 def ask_for_local_branch(self, args, done):
     # type: (GsCommand, Args, Kont) -> None
-    def on_done(branch):
-        done(branch)
-
     show_branch_panel(
-        on_done,
+        done,
         local_branches_only=True,
         ignore_current_branch=True,
     )

--- a/core/commands/merge.py
+++ b/core/commands/merge.py
@@ -1,8 +1,6 @@
-from sublime_plugin import WindowCommand
-
-from ..git_command import GitCommand
 from ...common import util
 from ..ui_mixins.quick_panel import show_branch_panel
+from GitSavvy.core.base_commands import GsWindowCommand
 from GitSavvy.core.runtime import enqueue_on_worker
 
 
@@ -13,7 +11,7 @@ __all__ = (
 )
 
 
-class gs_merge(WindowCommand, GitCommand):
+class gs_merge(GsWindowCommand):
 
     """
     Display a list of branches available to merge against the active branch.
@@ -40,7 +38,7 @@ class gs_merge(WindowCommand, GitCommand):
             util.view.refresh_gitsavvy_interfaces(self.window, refresh_sidebar=True)
 
 
-class gs_abort_merge(WindowCommand, GitCommand):
+class gs_abort_merge(GsWindowCommand):
 
     """
     Reset all files to pre-merge conditions, and abort the merge.
@@ -54,7 +52,7 @@ class gs_abort_merge(WindowCommand, GitCommand):
         util.view.refresh_gitsavvy_interfaces(self.window, refresh_sidebar=True)
 
 
-class gs_restart_merge_for_file(WindowCommand, GitCommand):
+class gs_restart_merge_for_file(GsWindowCommand):
 
     """
     Reset a single file to pre-merge condition, but do not abort the merge.

--- a/core/commands/merge.py
+++ b/core/commands/merge.py
@@ -31,7 +31,6 @@ class gs_merge(GsWindowCommand):
         try:
             self.git(
                 "merge",
-                "--log" if self.savvy_settings.get("merge_log") else None,
                 branch
             )
         finally:

--- a/core/commands/merge.py
+++ b/core/commands/merge.py
@@ -1,6 +1,6 @@
 from ...common import util
 from GitSavvy.core.base_commands import ask_for_branch, GsWindowCommand
-from GitSavvy.core.utils import show_panel
+from GitSavvy.core.utils import show_noop_panel, show_panel
 from GitSavvy.core.runtime import on_worker
 
 
@@ -51,10 +51,8 @@ class gs_restart_merge_for_file(GsWindowCommand):
     def run(self):
         paths = self.conflicting_files_()
         if not paths:
-            show_panel(
-                self.window,
-                ["There are no files which have or had merge conflicts."],
-                lambda _: None
+            show_noop_panel(
+                self.window, "There are no files which have or had merge conflicts."
             )
 
         def on_done(index):

--- a/core/commands/merge.py
+++ b/core/commands/merge.py
@@ -50,6 +50,12 @@ class gs_restart_merge_for_file(GsWindowCommand):
 
     def run(self):
         paths = self.conflicting_files_()
+        if not paths:
+            show_panel(
+                self.window,
+                ["There are no files which have or had merge conflicts."],
+                lambda _: None
+            )
 
         def on_done(index):
             fpath = paths[index]

--- a/core/commands/merge.py
+++ b/core/commands/merge.py
@@ -2,7 +2,7 @@ from ...common import util
 from ..ui_mixins.quick_panel import show_branch_panel
 from GitSavvy.core.base_commands import GsWindowCommand
 from GitSavvy.core.utils import show_panel
-from GitSavvy.core.runtime import enqueue_on_worker
+from GitSavvy.core.runtime import enqueue_on_worker, on_worker
 
 
 __all__ = (
@@ -28,6 +28,7 @@ class gs_merge(GsWindowCommand):
             ignore_current_branch=True
         )
 
+    @on_worker
     def on_branch_selection(self, branch):
         try:
             self.git("merge", branch)
@@ -41,10 +42,8 @@ class gs_merge_abort(GsWindowCommand):
     Reset all files to pre-merge conditions, and abort the merge.
     """
 
+    @on_worker
     def run(self):
-        enqueue_on_worker(self.run_async)
-
-    def run_async(self):
         self.git("merge", "--abort")
         util.view.refresh_gitsavvy_interfaces(self.window, refresh_sidebar=True)
 

--- a/core/commands/merge.py
+++ b/core/commands/merge.py
@@ -1,9 +1,9 @@
-import sublime
 from sublime_plugin import WindowCommand
 
 from ..git_command import GitCommand
 from ...common import util
 from ..ui_mixins.quick_panel import show_branch_panel
+from GitSavvy.core.runtime import enqueue_on_worker
 
 
 __all__ = (
@@ -21,7 +21,7 @@ class gs_merge(WindowCommand, GitCommand):
     """
 
     def run(self):
-        sublime.set_timeout_async(lambda: self.run_async(), 1)
+        enqueue_on_worker(self.run_async)
 
     def run_async(self):
         show_branch_panel(
@@ -47,7 +47,7 @@ class gs_abort_merge(WindowCommand, GitCommand):
     """
 
     def run(self):
-        sublime.set_timeout_async(self.run_async, 0)
+        enqueue_on_worker(self.run_async)
 
     def run_async(self):
         self.git("reset", "--merge")

--- a/core/commands/merge.py
+++ b/core/commands/merge.py
@@ -7,7 +7,7 @@ from GitSavvy.core.runtime import enqueue_on_worker
 
 __all__ = (
     "gs_merge",
-    "gs_abort_merge",
+    "gs_merge_abort",
     "gs_restart_merge_for_file",
 )
 
@@ -35,7 +35,7 @@ class gs_merge(GsWindowCommand):
             util.view.refresh_gitsavvy_interfaces(self.window, refresh_sidebar=True)
 
 
-class gs_abort_merge(GsWindowCommand):
+class gs_merge_abort(GsWindowCommand):
 
     """
     Reset all files to pre-merge conditions, and abort the merge.

--- a/core/commands/merge.py
+++ b/core/commands/merge.py
@@ -37,7 +37,7 @@ class gs_merge(WindowCommand, GitCommand):
                 branch
             )
         finally:
-            util.view.refresh_gitsavvy(self.window.active_view(), refresh_sidebar=True)
+            util.view.refresh_gitsavvy_interfaces(self.window, refresh_sidebar=True)
 
 
 class gs_abort_merge(WindowCommand, GitCommand):
@@ -51,7 +51,7 @@ class gs_abort_merge(WindowCommand, GitCommand):
 
     def run_async(self):
         self.git("reset", "--merge")
-        util.view.refresh_gitsavvy(self.window.active_view(), refresh_sidebar=True)
+        util.view.refresh_gitsavvy_interfaces(self.window, refresh_sidebar=True)
 
 
 class gs_restart_merge_for_file(WindowCommand, GitCommand):
@@ -69,7 +69,7 @@ class gs_restart_merge_for_file(WindowCommand, GitCommand):
             fpath = paths[index]
             self.git("checkout", "-m", "--", fpath)
 
-            util.view.refresh_gitsavvy(self.window.active_view())
+            util.view.refresh_gitsavvy_interfaces(self.window)
 
         self.window.show_quick_panel(
             paths,

--- a/core/commands/merge.py
+++ b/core/commands/merge.py
@@ -29,10 +29,7 @@ class gs_merge(GsWindowCommand):
 
     def on_branch_selection(self, branch):
         try:
-            self.git(
-                "merge",
-                branch
-            )
+            self.git("merge", branch)
         finally:
             util.view.refresh_gitsavvy_interfaces(self.window, refresh_sidebar=True)
 
@@ -68,7 +65,4 @@ class gs_restart_merge_for_file(GsWindowCommand):
 
             util.view.refresh_gitsavvy_interfaces(self.window)
 
-        self.window.show_quick_panel(
-            paths,
-            on_done
-        )
+        self.window.show_quick_panel(paths, on_done)

--- a/core/commands/merge.py
+++ b/core/commands/merge.py
@@ -1,6 +1,7 @@
 from ...common import util
 from ..ui_mixins.quick_panel import show_branch_panel
 from GitSavvy.core.base_commands import GsWindowCommand
+from GitSavvy.core.utils import show_panel
 from GitSavvy.core.runtime import enqueue_on_worker
 
 
@@ -58,11 +59,9 @@ class gs_restart_merge_for_file(GsWindowCommand):
         paths = self.conflicting_files_()
 
         def on_done(index):
-            if index == -1:
-                return
             fpath = paths[index]
             self.git("checkout", "-m", "--", fpath)
 
             util.view.refresh_gitsavvy_interfaces(self.window)
 
-        self.window.show_quick_panel(paths, on_done)
+        show_panel(self.window, paths, on_done)

--- a/core/commands/merge.py
+++ b/core/commands/merge.py
@@ -1,8 +1,7 @@
 from ...common import util
-from ..ui_mixins.quick_panel import show_branch_panel
-from GitSavvy.core.base_commands import GsWindowCommand
+from GitSavvy.core.base_commands import ask_for_branch, GsWindowCommand
 from GitSavvy.core.utils import show_panel
-from GitSavvy.core.runtime import enqueue_on_worker, on_worker
+from GitSavvy.core.runtime import on_worker
 
 
 __all__ = (
@@ -19,17 +18,12 @@ class gs_merge(GsWindowCommand):
     When selected, perform merge with specified branch.
     """
 
-    def run(self):
-        enqueue_on_worker(self.run_async)
-
-    def run_async(self):
-        show_branch_panel(
-            self.on_branch_selection,
-            ignore_current_branch=True
-        )
+    defaults = {
+        "branch": ask_for_branch(ignore_current_branch=True),
+    }
 
     @on_worker
-    def on_branch_selection(self, branch):
+    def run(self, branch):
         try:
             self.git("merge", branch)
         finally:

--- a/core/commands/merge.py
+++ b/core/commands/merge.py
@@ -48,7 +48,7 @@ class gs_abort_merge(GsWindowCommand):
         enqueue_on_worker(self.run_async)
 
     def run_async(self):
-        self.git("reset", "--merge")
+        self.git("merge", "--abort")
         util.view.refresh_gitsavvy_interfaces(self.window, refresh_sidebar=True)
 
 

--- a/core/runtime.py
+++ b/core/runtime.py
@@ -73,6 +73,13 @@ def run_on_new_thread(fn, *args, **kwargs):
     threading.Thread(target=fn, args=args, kwargs=kwargs).start()
 
 
+def on_worker(fn):
+    @wraps(fn)
+    def wrapped(*a, **kw):
+        enqueue_on_worker(fn, *a, **kw)
+    return wrapped
+
+
 def on_new_thread(fn):
     @wraps(fn)
     def wrapped(*a, **kw):

--- a/core/utils.py
+++ b/core/utils.py
@@ -240,6 +240,11 @@ def show_actions_panel(window, actions, select=-1):
     )
 
 
+def show_noop_panel(window, message):
+    # type: (sublime.Window, str) -> None
+    show_actions_panel(window, [noop(message)])
+
+
 def noop(description):
     # type: (str) -> ActionType
     return Action(description, lambda: None)


### PR DESCRIPTION
- Use canonical `git merge --abort` instead of `reset --merge`
- Rename to "merge --abort" (was: "abort merge").  We replicate the namespacy structure of the git command.
The user types "merge" and then the Command palette will ouput what commands we have for merge. We do the same for the rebase commands: "rebase --continue", "rebase --abort", ...
- Remove `merge_log` setting.  This specialized setting is not necessary because it is the same as setting:

```
	"global_flags": {
		"merge": ["--log"]
	}
```

T.i. we have a generalized solution for custom flags already. 

