### PR TITLE
Improve focus management of the commit info panel

### DIFF
--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -1476,7 +1476,7 @@ class GsLogGraphCursorListener(EventListener, GitCommand):
             if panel:
                 window.run_command("show_panel", {"panel": panel})
             else:
-                window.run_command('hide_panel')
+                window.run_command("hide_panel")
 
         # Auto-show panel if the user switches back
         elif (

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -1495,7 +1495,7 @@ class GsLogGraphCursorListener(EventListener, GitCommand):
     # `on_selection_modified` triggers twice per mouse click
     # multiplied with the number of views into the same buffer,
     # hence it is *important* to throttle these events.
-    # We do this seperately per side-effect. See the fn
+    # We do this separately per side-effect. See the fn
     # implementations.
     def on_selection_modified(self, view):
         # type: (sublime.View) -> None
@@ -1539,7 +1539,7 @@ class GsLogGraphCursorListener(EventListener, GitCommand):
             # Special case some panels. For these panels, showing them does not count
             # as intent to close the show_commit panel. It will thus reappear
             # automatically as soon as you focus the graph again. E.g. closing the
-            # incremantal find panel via `<enter>` will bring the commit panel up
+            # incremental find panel via `<enter>` will bring the commit panel up
             # again.
             if args.get('panel') == "incremental_find":
                 return

--- a/core/commands/show_commit.py
+++ b/core/commands/show_commit.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 import os
 from webbrowser import open as open_in_browser
 
@@ -216,15 +217,43 @@ class gs_show_commit_show_hunk_on_working_dir(diff.gs_diff_open_file_at_hunk):
 
         full_path = os.path.join(self.repo_path, filename)
         line = self.find_matching_lineno(commit_hash, None, line, full_path)
-        view = window.open_file(
-            "{file}:{line}:{col}".format(file=full_path, line=line, col=col),
-            sublime.ENCODED_POSITION
-        )
-        # https://github.com/sublimehq/sublime_text/issues/4418
-        # Sublime Text 4 focuses the view automatically *if* it
-        # was already open, otherwise it makes the view only
-        # visible. Force the focus for a consistent behavior.
-        focus_view(view)
+
+        with force_remember_commit_info_panel_focus_state(window):
+            view = window.open_file(
+                "{file}:{line}:{col}".format(file=full_path, line=line, col=col),
+                sublime.ENCODED_POSITION
+            )
+            # https://github.com/sublimehq/sublime_text/issues/4418
+            # Sublime Text 4 focuses the view automatically *if* it
+            # was already open, otherwise it makes the view only
+            # visible. Force the focus for a consistent behavior.
+            focus_view(view)
+
+
+@contextmanager
+def force_remember_commit_info_panel_focus_state(window):
+    # Although we automatically detect when the panel loses its focus in `log_graph.py`,
+    # it fails when `window.open_file` brought the file to front *without* focusing
+    # it.  In that case, t.i. when it just *opens* the file, `focus_view()` will first
+    # activate the graph view and *then* the file we just opened.  This looks like
+    # a bug, probably related to https://github.com/sublimehq/sublime_text/issues/4418
+
+    # When `gs_show_commit_show_hunk_on_working_dir` runs and the graph view is the
+    # `active_view`, the panel has the focus as the command is only bound to the panel
+    # view.
+    av = window.active_view()
+    had_focus = (
+        av.settings().get("git_savvy.log_graph_view", False)
+        if av
+        else False
+    )
+
+    yield
+
+    if had_focus:
+        panel_view = window.find_output_panel('show_commit_info')
+        if panel_view:
+            panel_view.settings().set("git_savvy.show_commit_view.had_focus", True)
 
 
 class gs_show_commit_open_graph_context(TextCommand, GitCommand):

--- a/core/commands/show_commit.py
+++ b/core/commands/show_commit.py
@@ -216,10 +216,15 @@ class gs_show_commit_show_hunk_on_working_dir(diff.gs_diff_open_file_at_hunk):
 
         full_path = os.path.join(self.repo_path, filename)
         line = self.find_matching_lineno(commit_hash, None, line, full_path)
-        window.open_file(
+        view = window.open_file(
             "{file}:{line}:{col}".format(file=full_path, line=line, col=col),
             sublime.ENCODED_POSITION
         )
+        # https://github.com/sublimehq/sublime_text/issues/4418
+        # Sublime Text 4 focuses the view automatically *if* it
+        # was already open, otherwise it makes the view only
+        # visible. Force the focus for a consistent behavior.
+        focus_view(view)
 
 
 class gs_show_commit_open_graph_context(TextCommand, GitCommand):


### PR DESCRIPTION
- When moving out of the panel, e.g. via `[o]` or `[O]`, automatically close the panel.
- Remember that the panel had the focus, and give it the focus back when you switch back to the graph view.