### PR TITLE
Fix: Remove trailing spaces from local regular tags

### DIFF
--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -126,7 +126,7 @@ class TagsInterface(ui.Interface, GitCommand):
                                                 # the syntax expects the remote section begins
             filter_((
                 "\n".join(
-                    "    {} {:<10}".format(
+                    "    {} {}".format(
                         self.get_short_hash(tag.sha),
                         tag.tag,
                     )


### PR DESCRIPTION
There is no need for trailing spaces here and the last space gets interpreted as "comment" from our syntax.