### PR TITLE
Improve jumping to the inline diff

### DIFF
--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -399,8 +399,8 @@ class gs_inline_diff_refresh(TextCommand, GitCommand):
 
     def _run(self, runs_on_ui_thread, match_position, raw_diff):
         # type: (bool, Optional[Position], Optional[str]) -> None
-        file_path = self.file_path
         settings = self.view.settings()
+        file_path = settings.get("git_savvy.file_path")
         in_cached_mode = settings.get("git_savvy.inline_diff_view.in_cached_mode")
         base_commit = settings.get("git_savvy.inline_diff_view.base_commit")
         target_commit = settings.get("git_savvy.inline_diff_view.target_commit")
@@ -914,14 +914,15 @@ class gs_inline_diff_open_file(TextCommand, GitCommand):
             return
         row, col = coords
 
-        file_path = self.file_path
+        settings = self.view.settings()
+        file_path = settings.get("git_savvy.file_path")
         line_no, col_no = translate_pos_from_diff_view_to_file(self.view, row + 1, col + 1)
         if is_interactive_diff(self.view):
-            if self.view.settings().get("git_savvy.inline_diff_view.in_cached_mode"):
+            if settings.get("git_savvy.inline_diff_view.in_cached_mode"):
                 diff = self.git("diff", "-U0", "--", file_path)
                 line_no = self.adjust_line_according_to_diff(diff, line_no)
         else:
-            target_commit = self.view.settings().get("git_savvy.inline_diff_view.target_commit")
+            target_commit = settings.get("git_savvy.inline_diff_view.target_commit")
             line_no = self.find_matching_lineno(target_commit, None, line_no, file_path)
         self.open_file(window, file_path, line_no, col_no)
 

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -229,8 +229,9 @@ class gs_inline_diff(WindowCommand, GitCommand):
             return
 
         if jump_position.commit_hash:
-            flash(view, "Sorry, not implemented for historical commits yet.")
-            return
+            raise RuntimeError(
+                "Assertion failed! "
+                "Historical diffs shouldn't have `jump_position.commit_hash`.")
 
         file_path = os.path.normpath(os.path.join(repo_path, jump_position.filename))
         syntax_file = util.file.guess_syntax_for_file(self.window, file_path)

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -384,7 +384,7 @@ class gs_inline_diff_refresh(TextCommand, GitCommand):
     selected and the secondary action for the view is taken (pressing `L` or
     `H`), remove those changes from the file in the working tree.
 
-    If in `cached` mode, compare the file in the index againt the same file
+    If in `cached` mode, compare the file in the index against the same file
     in the HEAD.  If a link or hunk is selected and the primary action for
     the view is taken, remove that line from the index.  Secondary actions
     are not supported in `cached` mode.

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -228,6 +228,8 @@ class gs_inline_diff(WindowCommand, GitCommand):
 
         file_path = os.path.normpath(os.path.join(repo_path, jump_position.filename))
         syntax_file = util.file.guess_syntax_for_file(self.window, file_path)
+        base_commit = settings.get("git_savvy.diff_view.base_commit")
+        target_commit = settings.get("git_savvy.diff_view.target_commit")
 
         cur_pos = Position(
             jump_position.line - 1,
@@ -244,7 +246,9 @@ class gs_inline_diff(WindowCommand, GitCommand):
             "file_path": file_path,
             "syntax": syntax_file,
             "cached": bool(cached),
-            "match_position": cur_pos
+            "match_position": cur_pos,
+            "base_commit": base_commit,
+            "target_commit": target_commit
         })
 
     def open_from_show_file_at_commit_view(self, view):

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -459,6 +459,12 @@ class gs_inline_diff_refresh(TextCommand, GitCommand):
 
         title = INLINE_DIFF_CACHED_TITLE if in_cached_mode else INLINE_DIFF_TITLE
         title += os.path.basename(file_path)
+        if target_commit:
+            title += (
+                "  ({} <-{})".format(target_commit, base_commit)
+                if base_commit
+                else "  (initial version)"
+            )
         if runs_on_ui_thread:
             self.draw(self.view, title, match_position, inline_diff_contents, hunks)
         else:


### PR DESCRIPTION
Support jumping from historical diffs (`gs_diff`), commit views (`gs_show_commit[_info]`), and the line history **to** the inline diff with correct cursor position and the viewport scrolled.