### PR TITLE
Add "Update branch from upstream" action to the Repo History

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -193,6 +193,10 @@
         "command": "gs_fetch"
     },
     {
+        "caption": "git: fast-forward branch from upstream",
+        "command": "gs_ff_update_branch"
+    },
+    {
         "caption": "git: pull",
         "command": "gs_pull"
     },

--- a/core/commands/fetch.py
+++ b/core/commands/fetch.py
@@ -29,13 +29,13 @@ class gs_fetch(GsWindowCommand):
     }
 
     @on_worker
-    def run(self, remote):
+    def run(self, remote, refspec=None):
         fetch_all = remote == "<ALL>"
         if fetch_all:
             self.window.status_message("Start fetching all remotes...")
         else:
             self.window.status_message("Start fetching {}...".format(remote))
 
-        self.fetch(None if fetch_all else remote)
+        self.fetch(None if fetch_all else remote, refspec)
         self.window.status_message("Fetch complete.")
         util.view.refresh_gitsavvy_interfaces(self.window)

--- a/core/commands/fetch.py
+++ b/core/commands/fetch.py
@@ -1,4 +1,4 @@
-from ..runtime import enqueue_on_worker
+from ..runtime import on_worker
 from ...common import util
 from ..ui_mixins.quick_panel import show_remote_panel
 from GitSavvy.core.base_commands import GsWindowCommand
@@ -28,12 +28,8 @@ class gs_fetch(GsWindowCommand):
         "remote": ask_for_remote
     }
 
+    @on_worker
     def run(self, remote):
-        # type: (str) -> None
-        enqueue_on_worker(self.do_fetch, remote)
-
-    def do_fetch(self, remote):
-        # type: (str) -> None
         fetch_all = remote == "<ALL>"
         if fetch_all:
             self.window.status_message("Start fetching all remotes...")

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -2415,14 +2415,12 @@ class gs_log_graph_action(WindowCommand, GitCommand):
         remote = self.get_remote_for_branch(current_branch)
         self.window.run_command("gs_fetch", {"remote": remote} if remote else None)
 
-    def update_from_tracking(self, remote, branch_name_on_remote, branch_name):
+    def update_from_tracking(self, remote, remote_name, local_name):
         # type: (str, str, str) -> None
-        def program():
-            self.window.status_message("Start fetching from {}...".format(remote))
-            self.git("fetch", remote, "{}:{}".format(branch_name_on_remote, branch_name))
-            self.window.status_message("Fetch complete.")
-            util.view.refresh_gitsavvy_interfaces(self.window)
-        enqueue_on_worker(program)
+        self.window.run_command("gs_fetch", {
+            "remote": remote,
+            "refspec": "{}:{}".format(remote_name, local_name)
+        })
 
     def noop(self):
         return

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -73,6 +73,7 @@ if MYPY:
         TypeVar, Union
     )
     from GitSavvy.core.runtime import HopperR
+    from ..git_mixins.branches import Branch
     T = TypeVar('T')
 
 
@@ -2123,7 +2124,8 @@ class gs_log_graph_action(WindowCommand, GitCommand):
         if not view:
             return
 
-        remotes = set(self.get_remotes().keys())
+        branches = {b.name_with_remote: b for b in self.get_branches()}
+        remotes = set(b.remote for b in branches.values() if b.remote)
         infos = list(filter_(
             describe_graph_line(line, remotes)
             for line in unique(
@@ -2136,7 +2138,7 @@ class gs_log_graph_action(WindowCommand, GitCommand):
             return
 
         actions = (
-            self.actions_for_single_line(view, infos[0], remotes)
+            self.actions_for_single_line(view, infos[0], remotes, branches)
             if len(infos) == 1
             else self.actions_for_multiple_lines(view, infos, remotes)
         )
@@ -2254,8 +2256,8 @@ class gs_log_graph_action(WindowCommand, GitCommand):
             'follow': base_commit
         })
 
-    def actions_for_single_line(self, view, info, remotes):
-        # type: (sublime.View, LineInfo, Iterable[str]) -> List[Tuple[str, Callable[[], None]]]
+    def actions_for_single_line(self, view, info, remotes, branches):
+        # type: (sublime.View, LineInfo, Iterable[str], Dict[str, Branch]) -> List[Tuple[str, Callable[[], None]]]
         commit_hash = info["commit"]
         file_path = self.file_path
         actions = []  # type: List[Tuple[str, Callable[[], None]]]
@@ -2286,6 +2288,20 @@ class gs_log_graph_action(WindowCommand, GitCommand):
                     partial(self.checkout, good_commit_name)
                 ),
             ]
+
+        for branch_name in info.get("local_branches", []):
+            if branch_name == info.get("HEAD"):
+                continue
+
+            b = branches[branch_name]
+            if b.tracking and b.tracking_status != "gone":
+                remote_name, branch_name_on_remote = b.tracking.split("/", 1)
+                actions += [
+                    (
+                        "Update '{}' from '{}'".format(branch_name, b.tracking),
+                        partial(self.update_from_tracking, remote_name, branch_name_on_remote, b.name)
+                    ),
+                ]
 
         if file_path:
             actions += [
@@ -2398,6 +2414,15 @@ class gs_log_graph_action(WindowCommand, GitCommand):
     def fetch(self, current_branch):
         remote = self.get_remote_for_branch(current_branch)
         self.window.run_command("gs_fetch", {"remote": remote} if remote else None)
+
+    def update_from_tracking(self, remote, branch_name_on_remote, branch_name):
+        # type: (str, str, str) -> None
+        def program():
+            self.window.status_message("Start fetching from {}...".format(remote))
+            self.git("fetch", remote, "{}:{}".format(branch_name_on_remote, branch_name))
+            self.window.status_message("Fetch complete.")
+            util.view.refresh_gitsavvy_interfaces(self.window)
+        enqueue_on_worker(program)
 
     def noop(self):
         return

--- a/core/git_mixins/branches.py
+++ b/core/git_mixins/branches.py
@@ -6,21 +6,32 @@ from GitSavvy.core.git_command import mixin_base
 
 MYPY = False
 if MYPY:
-    from typing import Dict, Iterable, Optional, Sequence
-
+    from typing import Dict, Iterable, NamedTuple, Optional, Sequence
+    Branch = NamedTuple("Branch", [
+        ("name", str),
+        ("remote", Optional[str]),
+        ("name_with_remote", str),
+        ("commit_hash", str),
+        ("commit_msg", str),
+        ("tracking", str),
+        ("tracking_status", str),
+        ("active", bool),
+        ("description", str)
+    ])
+else:
+    Branch = namedtuple("Branch", (
+        "name",
+        "remote",
+        "name_with_remote",
+        "commit_hash",
+        "commit_msg",
+        "tracking",
+        "tracking_status",
+        "active",
+        "description"
+    ))
 
 BRANCH_DESCRIPTION_RE = re.compile(r"^branch\.(.*?)\.description (.*)$")
-Branch = namedtuple("Branch", (
-    "name",
-    "remote",
-    "name_with_remote",
-    "commit_hash",
-    "commit_msg",
-    "tracking",
-    "tracking_status",
-    "active",
-    "description"
-))
 
 
 class BranchesMixin(mixin_base):

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -422,15 +422,26 @@ class GsBranchesFetchAndMergeCommand(TextCommand, GitCommand):
         branches = self.interface.get_selected_branches(ignore_current_branch=True)
 
         for branch in branches:
-            if branch[0] is None:
+            remote, branch_name = branch
+            if remote is None:
                 # update local branches which have tracking remote
-                local_branch = self.get_local_branch_by_name(branch[1])
+                local_branch = self.get_local_branch_by_name(branch_name)
+                if not local_branch:
+                    raise RuntimeError(
+                        "repo and view inconsistent.  "
+                        "can't fetch more info about branch {}"
+                        .format(branch_name)
+                    )
                 if local_branch.tracking:
                     remote, remote_branch = local_branch.tracking.split("/", 1)
-                    self.fetch(remote=remote, branch=branch[1], remote_branch=remote_branch)
+                    self.fetch(
+                        remote=remote,
+                        remote_branch=remote_branch,
+                        local_branch=branch_name,
+                    )
             else:
                 # fetch remote branches
-                self.fetch(remote=branch[0], branch=branch[1])
+                self.fetch(remote, branch_name)
 
         branches_strings = self.interface.create_branches_strs(branches)
         try:

--- a/tests/test_git_mixins.py
+++ b/tests/test_git_mixins.py
@@ -1,0 +1,48 @@
+from unittesting import DeferrableTestCase
+from GitSavvy.tests.mockito import unstub, when
+from GitSavvy.tests.parameterized import parameterized as p, param
+
+from GitSavvy.core.git_command import GitCommand
+
+
+class TestGitMixinsUsage(DeferrableTestCase):
+    def tearDown(self):
+        unstub()
+
+
+class TestFetchInterface(TestGitMixinsUsage):
+    def test_fetch_all(self):
+        repo = GitCommand()
+        when(repo).git("fetch", "--prune", "--all", None)
+        repo.fetch()
+
+    def test_fetch_remote(self):
+        repo = GitCommand()
+        when(repo).git("fetch", "--prune", "origin", None)
+        repo.fetch("origin")
+
+    def test_fetch_branch(self):
+        repo = GitCommand()
+        when(repo).git("fetch", "--prune", "origin", "master")
+        repo.fetch("origin", "master")
+
+    def test_fetch_remote_local_mapping(self):
+        repo = GitCommand()
+        when(repo).git("fetch", "--prune", "origin", "moster:muster")
+        repo.fetch("origin", remote_branch="moster", local_branch="muster")
+        repo.fetch(remote="origin", remote_branch="moster", local_branch="muster")
+
+    @p.expand([
+        (param(refspec="monster:manster"),),
+        (param(None, "master"),),
+        (param(remote_branch="master"),),
+        (param(local_branch="master"),),
+
+        (param("origin", "mi:mu", remote_branch="master"),),
+        (param("origin", "mi:mu", local_branch="master"),),
+
+    ])
+    def test_invalid_calls(self, parameters):
+        repo = GitCommand()
+        when(repo).git("fetch", "--prune", ...)
+        self.assertRaises(TypeError, lambda: repo.fetch(*parameters.args, **parameters.kwargs))


### PR DESCRIPTION
Fixes #1466

Very typical use-case is to just update the master/main branch from upstream **without** checking it out.  (You stay on the feature branch!)

Really the same as `git fetch origin master:master`.