### PR TITLE
GitLab: correctly fetch opened merge requests

### DIFF
--- a/gitlab/commands/merge_request.py
+++ b/gitlab/commands/merge_request.py
@@ -34,7 +34,7 @@ class gs_gitlab_merge_request(WindowCommand, GitCommand, git_mixins.GitLabRemote
     def run_async(self):
         self.remote_url = self.get_integrated_remote_url()
         self.base_remote = gitlab.parse_remote(self.remote_url)
-        self.merge_requests = gitlab.get_merge_requests(self.base_remote)
+        self.merge_requests = gitlab.get_merge_requests(self.base_remote, {}, { 'state': "opened" })
 
         pp = show_paginated_panel(
             self.merge_requests,
@@ -115,7 +115,7 @@ class gs_gitlab_merge_request(WindowCommand, GitCommand, git_mixins.GitLabRemote
 
     def view_diff_for_mr(self):
         mr_changes = gitlab.get_merge_request_changes(
-            self.base_remote, mr_id=self.mr['iid'])
+            self.base_remote, { 'mr_id': self.mr['iid'] })
 
         diff_view = util.view.get_scratch_view(self, "mr_diff", read_only=True)
         diff_view.set_name("MR #{}".format(self.mr["iid"]))

--- a/gitlab/commands/merge_request.py
+++ b/gitlab/commands/merge_request.py
@@ -34,7 +34,7 @@ class gs_gitlab_merge_request(WindowCommand, GitCommand, git_mixins.GitLabRemote
     def run_async(self):
         self.remote_url = self.get_integrated_remote_url()
         self.base_remote = gitlab.parse_remote(self.remote_url)
-        self.merge_requests = gitlab.get_merge_requests(self.base_remote, {}, { 'state': "opened" })
+        self.merge_requests = gitlab.get_merge_requests(self.base_remote, {}, {'state': "opened"})
 
         pp = show_paginated_panel(
             self.merge_requests,
@@ -115,7 +115,7 @@ class gs_gitlab_merge_request(WindowCommand, GitCommand, git_mixins.GitLabRemote
 
     def view_diff_for_mr(self):
         mr_changes = gitlab.get_merge_request_changes(
-            self.base_remote, { 'mr_id': self.mr['iid'] })
+            self.base_remote, {'mr_id': self.mr['iid']})
 
         diff_view = util.view.get_scratch_view(self, "mr_diff", read_only=True)
         diff_view.set_name("MR #{}".format(self.mr["iid"]))

--- a/gitlab/gitlab.py
+++ b/gitlab/gitlab.py
@@ -127,7 +127,7 @@ def get_api_fqdn(gitlab_repo):
     return True, gitlab_repo.fqdn
 
 
-def gitlab_api_url(api_url_template, repository, url_params={}, **kwargs):
+def gitlab_api_url(api_url_template, repository, url_params={}, query_params={}):
     """
     Construct a GitLab URL to query using the given url template string,
     and a gitlab.GitLabRepo instance, and optionally query parameters
@@ -146,7 +146,7 @@ def gitlab_api_url(api_url_template, repository, url_params={}, **kwargs):
     return fqdn, "{base_path}{path}?{query_params}".format(
         base_path=base_path,
         path=request_path,
-        query_params=interwebs.urlencode(kwargs))
+        query_params=interwebs.urlencode(query_params))
 
 
 def validate_response(response, method="GET"):
@@ -169,13 +169,13 @@ def get_common_kwargs(gitlab_repo):
     return dict(port=443, https=True, headers=headers)
 
 
-def query_gitlab(api_url_template, gitlab_repo, **url_params):
+def query_gitlab(api_url_template, gitlab_repo, url_params={}, query_params={}):
     """
     Takes a URL template that takes `owner` and `repo` template variables
     and as a GitLab repo object.  Do a GET for the provided URL and return
     the response payload, if successful.  If unsuccessfuly raise an error.
     """
-    fqdn, path = gitlab_api_url(api_url_template, gitlab_repo, url_params)
+    fqdn, path = gitlab_api_url(api_url_template, gitlab_repo, url_params, query_params)
     kwargs = get_common_kwargs(gitlab_repo)
 
     util.debug.add_to_log({
@@ -192,13 +192,13 @@ def query_gitlab(api_url_template, gitlab_repo, **url_params):
 # get_repo_data = partial(query_gitlab, "/repos/{owner}/{repo}")
 
 
-def iteratively_query_gitlab(api_url_template, gitlab_repo, **url_params):
+def iteratively_query_gitlab(api_url_template, gitlab_repo, url_params={}, query_params={}):
     """
     Like `query_gitlab` but return a generator by repeatedly
     iterating until no link to next page.
     """
-    fqdn, path = gitlab_api_url(api_url_template, gitlab_repo, url_params,
-                                per_page=GITLAB_PER_PAGE_MAX)
+    query_params['per_page'] = GITLAB_PER_PAGE_MAX
+    fqdn, path = gitlab_api_url(api_url_template, gitlab_repo, url_params, query_params)
     kwargs = get_common_kwargs(gitlab_repo)
 
     response = None


### PR DESCRIPTION
`gitlab: review merge request` is using the `List merge requests` GitLab API endpoint: https://docs.gitlab.com/ee/api/merge_requests.html
The default behavior for the `state` query parameter is to `return all merge requests`.

In order to be consistent with the documentation (`Display open merge requests on the base repo`) + how the `github: review pull requests` work, I added a `state=opened` query parameter to the API call to display only opened MRs.

I also slightly refactored the helper methods to correctly differentiate the params from the path and the params from the query.