### PR TITLE
More robust extraction of issue references

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -2255,7 +2255,7 @@
         "keys": ["o"],
         "command": "gs_github_open_issue_at_cursor",
         "context": [
-            { "key": "selector", "operand": "constant.other.issue-ref.git-savvy, string.other.issue.git-savvy" }
+            { "key": "selector", "operand": "meta.git-savvy.issue-reference" }
         ]
     }
 ]

--- a/github/commands/open_issue.py
+++ b/github/commands/open_issue.py
@@ -14,7 +14,7 @@ __all__ = (
 )
 
 
-ISSUE_SCOPES = "constant.other.issue-ref.git-savvy, string.other.issue.git-savvy"
+ISSUE_SCOPES = "meta.git-savvy.issue-reference"
 
 
 class gs_github_open_issue_at_cursor(TextCommand, git_mixins.GithubRemotesMixin, GitCommand):
@@ -30,7 +30,12 @@ class gs_github_open_issue_at_cursor(TextCommand, git_mixins.GithubRemotesMixin,
         def on_navigate(href: str):
             open_in_browser(href)
 
-        issue_nr = view.substr(view.extract_scope(point))[1:]
+        complete_str = view.substr(view.extract_scope(point))
+        if complete_str[0] != "#":
+            flash(view, "Only implemented for simple references.  (E.g. '#23')")
+            return
+
+        issue_nr = complete_str[1:]
         url = self.url_for_issue(issue_nr)
 
         if open_popup:

--- a/syntax/graph.sublime-syntax
+++ b/syntax/graph.sublime-syntax
@@ -86,9 +86,11 @@ contexts:
       comment: by name
       scope: keyword.by-name.git-savvy.
 
-    - match: '(?:[Ff]ix(?:e[ds])?|[Rr]esolve[ds]?|[Cc]lose[ds]?)?\s*(?:#\d+|\[.*?\])'
+    - match: '(?:[Ff]ix(?:e[ds])?|[Rr]esolve[ds]?|[Cc]lose[ds]?)?\s*(?:(#\d+)|\[.*?\])'
       comment: issue numbers
       scope: string.other.issue.git-savvy
+      captures:
+        1: meta.git-savvy.issue-reference
 
     - match: Merge branch (')(.*?)(')(?:\s+(?:of|into)\s+(\S*))?
       comment: merges
@@ -119,7 +121,7 @@ contexts:
       scope: meta.git-savvy.grph.merge
       captures:
         0: meta.git-savvy.grph.merge.pull-request
-        1: string.other.issue.git-savvy
+        1: string.other.issue.git-savvy meta.git-savvy.issue-reference
         2: string.other.merge.remote.git-savvy
 
     - match: ':'

--- a/syntax/make_commit.sublime-syntax
+++ b/syntax/make_commit.sublime-syntax
@@ -21,7 +21,7 @@ contexts:
 
     - match: '(\w+/\w+)?#[0-9]+'
       comment: issue
-      scope: constant.other.issue-ref.git-savvy.make-commit
+      scope: constant.other.issue-ref.git-savvy.make-commit meta.git-savvy.issue-reference
 
     - match: (?:\s|\w\@)(\h{7,})\b
       comment: sha reference

--- a/syntax/test/syntax_test_graph.txt
+++ b/syntax/test/syntax_test_graph.txt
@@ -58,8 +58,21 @@
 *   b7f8e07 Merge pull request #359 from dnicolson/blame-commit-lengths
 #           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.git-savvy.grph.merge
 #           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.git-savvy.grph.merge.pull-request
-#                               ^ string.other.issue
+#                              ^^^^ string.other.issue
+#                              ^^^^ meta.git-savvy.issue-reference
+#                             ^      - string.other.issue
+#                             ^      - meta.git-savvy.issue-reference
+#                                  ^ - string.other.issue
+#                                  ^ - meta.git-savvy.issue-reference
 #                                         ^ string.other.merge.remote
+
+*   b7f8e07 Fix #359 from dnicolson/blame-commit-lengths
+#           ^^^^^^^^ string.other.issue
+#               ^^^^ meta.git-savvy.issue-reference
+*   b7f8e07 Look #359 'ma
+#                ^^^^ string.other.issue
+#                ^^^^ meta.git-savvy.issue-reference
+
 |\
 # <- punctuation.other.git-savvy.graph.graph-line
 #^ punctuation.other.git-savvy.graph.graph-line

--- a/syntax/test/syntax_test_make_commit.txt
+++ b/syntax/test/syntax_test_make_commit.txt
@@ -9,9 +9,13 @@ This is for @aziz and close #76 aziz/git#123 aziz/good
 #          ^      - constant.other.github-username.git-savvy.make-commit
 #                ^ - constant.other.github-username.git-savvy.make-commit
 #                           ^^^ constant.other.issue-ref.git-savvy.make-commit
+#                           ^^^ meta.git-savvy.issue-reference
 #                          ^ - constant.other.issue-ref.git-savvy.make-commit
+#                          ^ - meta.git-savvy.issue-reference
 #                              ^ - constant.other.issue-ref.git-savvy.make-commit
+#                              ^ - meta.git-savvy.issue-reference
 #                               ^^^^^^^^^^^^ constant.other.issue-ref.git-savvy.make-commit
+#                               ^^^^^^^^^^^^ meta.git-savvy.issue-reference
 User @bett-miller has a proper username.
 #     ^^^^^^^^^^^ constant.other.github-username.git-savvy.make-commit
 @betty can be referenced on the first column!  Yeah!

--- a/syntax/test/syntax_test_show_commit_with_stat.txt
+++ b/syntax/test/syntax_test_show_commit_with_stat.txt
@@ -9,6 +9,7 @@ CommitDate: Mon Jun 12 19:58:27 2017 +0200
 
     This is a message.  Fixes #12
 #                             ^^^ constant.other.issue-ref.git-savvy.make-commit
+#                             ^^^ meta.git-savvy.issue-reference
     @betty made this.  :thanks:
 #   ^^^^^^ constant.other.github-username.git-savvy.make-commit
 


### PR DESCRIPTION
In the "graph" we captured e.g. `Fixes #3` (as a whole) as issue reference.  Also `aziz/git#4` is recognized as an issue reference.

Add a meta scope `meta.git-savvy.issue-reference` to mark issue references.  Then check in the code if we actually support the ref because at the moment we only support refs to the same repo.