### PR TITLE
Correctly use integrated remote

### DIFF
--- a/core/git_mixins/remotes.py
+++ b/core/git_mixins/remotes.py
@@ -6,7 +6,6 @@ from GitSavvy.core.fns import filter_
 
 MYPY = False
 if MYPY:
-    from typing import Dict
     from GitSavvy.core.git_command import (
         BranchesMixin,
         _GitCommand,
@@ -27,7 +26,7 @@ else:
 class RemotesMixin(mixin_base):
 
     def get_remotes(self):
-        # type: () -> Dict[name, url]
+        # type: () -> OrderedDict[name, url]
         """
         Get a list of remotes, provided as tuples of remote name and remote
         url/resource.

--- a/github/commands/commit.py
+++ b/github/commands/commit.py
@@ -83,7 +83,7 @@ class GsGithubShowIssuesCommand(TextCommand, git_mixins.GithubRemotesMixin, GitC
         self.view.run_command("insert", {"characters": str(issue["number"])})
 
 
-class GsGithubShowContributorsCommand(TextCommand, GitCommand):
+class GsGithubShowContributorsCommand(TextCommand, git_mixins.GithubRemotesMixin, GitCommand):
 
     """
     Query github for a list of people that have contributed to the GitHub project
@@ -96,9 +96,7 @@ class GsGithubShowContributorsCommand(TextCommand, GitCommand):
         sublime.set_timeout_async(lambda: self.run_async())
 
     def run_async(self):
-        default_remote_name, default_remote = self.get_remotes().popitem(last=False)
-        remote = github.parse_remote(default_remote)
-
+        remote = github.parse_remote(self.get_integrated_remote_url())
         contributors = github.get_contributors(remote)
 
         pp = show_paginated_panel(

--- a/github/commands/commit.py
+++ b/github/commands/commit.py
@@ -5,16 +5,22 @@ GitHub extensions to the new-commit view.
 import re
 
 import sublime
-from sublime_plugin import TextCommand
 
-from ...core.git_command import GitCommand
 from ...core.ui_mixins.quick_panel import show_paginated_panel
 from .. import github
 from .. import git_mixins
 from ...common import util
+from GitSavvy.core.base_commands import GsTextCommand
+from GitSavvy.core.runtime import enqueue_on_worker, on_worker
 
 
-class GsGithubShowIssuesCommand(TextCommand, git_mixins.GithubRemotesMixin, GitCommand):
+__all__ = (
+    "gs_github_show_issues",
+    "gs_github_show_contributors",
+)
+
+
+class gs_github_show_issues(git_mixins.GithubRemotesMixin, GsTextCommand):
 
     """
     Display a panel of GitHub issues to either:
@@ -31,12 +37,18 @@ class GsGithubShowIssuesCommand(TextCommand, git_mixins.GithubRemotesMixin, GitC
         if not default_repo:
             first_cursor = self.view.sel()[0].begin()
             text_before_cursor = self.view.substr(sublime.Region(0, first_cursor))
-            nondefault_repo = re.search(
-                r"([a-zA-Z\-_0-9\.]+)/([a-zA-Z\-_0-9\.]+)#$", text_before_cursor).groups()
+            match = re.search(
+                r"([a-zA-Z\-_0-9\.]+)/([a-zA-Z\-_0-9\.]+)#$", text_before_cursor)
+            if not match:
+                raise RuntimeError(
+                    "could not extract remote repository path. "
+                    "regex inconsistent with key binding context constraint. "
+                )
+            nondefault_repo = match.groups()
         else:
             nondefault_repo = None
 
-        sublime.set_timeout_async(lambda: self.run_async(nondefault_repo))
+        enqueue_on_worker(self.run_async, nondefault_repo)
 
     def run_async(self, nondefault_repo):
         remote = github.parse_remote(self.get_integrated_remote_url())
@@ -60,7 +72,7 @@ class GsGithubShowIssuesCommand(TextCommand, git_mixins.GithubRemotesMixin, GitC
             status_message="Getting issues..."
         )
         if pp.is_empty():
-            self.view.window().status_message("No issues found.")
+            self.window.status_message("No issues found.")
 
     def format_item(self, issue):
         return (
@@ -83,7 +95,7 @@ class GsGithubShowIssuesCommand(TextCommand, git_mixins.GithubRemotesMixin, GitC
         self.view.run_command("insert", {"characters": str(issue["number"])})
 
 
-class GsGithubShowContributorsCommand(TextCommand, git_mixins.GithubRemotesMixin, GitCommand):
+class gs_github_show_contributors(git_mixins.GithubRemotesMixin, GsTextCommand):
 
     """
     Query github for a list of people that have contributed to the GitHub project
@@ -92,10 +104,8 @@ class GsGithubShowContributorsCommand(TextCommand, git_mixins.GithubRemotesMixin
     position.
     """
 
+    @on_worker
     def run(self, edit):
-        sublime.set_timeout_async(lambda: self.run_async())
-
-    def run_async(self):
         remote = github.parse_remote(self.get_integrated_remote_url())
         contributors = github.get_contributors(remote)
 
@@ -107,7 +117,7 @@ class GsGithubShowContributorsCommand(TextCommand, git_mixins.GithubRemotesMixin
             status_message="Getting contributors..."
         )
         if pp.is_empty():
-            self.view.window().status_message("No contributors found.")
+            self.window.status_message("No contributors found.")
 
     def format_item(self, contributor):
         return (contributor["login"], contributor)


### PR DESCRIPTION
The code surprisingly used just the *first* defined remote for `GsGithubShowContributorsCommand` (=listing contributors; a helper command in the commit message view when typing `@<tab>`).

Fix that, and then as always, modernize and type check the associated file.