### PR TITLE
Follow the active branch and remove `nuke_cursors` instruction

### DIFF
--- a/common/ui.py
+++ b/common/ui.py
@@ -169,12 +169,10 @@ class Interface(metaclass=_PrepareInterface):
     def reset_cursor(self):
         pass
 
-    def render(self, nuke_cursors=False):
+    def render(self):
         self.pre_render()
         content, regions = self._render_template()
         self.draw(self.title(), content, regions)
-        if nuke_cursors:
-            self.reset_cursor()
 
     def draw(self, title, content, regions):
         # type: (str, str, SectionRegions) -> None
@@ -381,19 +379,19 @@ class gs_interface_refresh(TextCommand):
     """
 
     @on_worker
-    def run(self, edit, nuke_cursors=False):
-        # type: (object, bool) -> None
+    def run(self, edit):
+        # type: (object) -> None
         vid = self.view.id()
         interface = interfaces.get(vid, None)
         if interface:
-            interface.render(nuke_cursors=nuke_cursors)
+            interface.render()
             return
 
         interface_type = self.view.settings().get("git_savvy.interface")
         for cls in subclasses:
             if cls.interface_type == interface_type:
                 interface = interfaces[vid] = cls(view=self.view)
-                interface.render(nuke_cursors=nuke_cursors)
+                interface.render()
                 break
 
 

--- a/common/util/view.py
+++ b/common/util/view.py
@@ -90,7 +90,7 @@ def refresh_gitsavvy_interfaces(
     for group in range(window.num_groups()):
         view = window.active_view_in_group(group)
         if view.settings().get("git_savvy.interface") is not None:
-            view.run_command("gs_interface_refresh", {"nuke_cursors": interface_reset_cursor})
+            view.run_command("gs_interface_refresh")
 
         if view.settings().get("git_savvy.log_graph_view", False):
             view.run_command("gs_log_graph_refresh")
@@ -111,7 +111,7 @@ def refresh_gitsavvy(
         return
 
     if view.settings().get("git_savvy.interface") is not None:
-        view.run_command("gs_interface_refresh", {"nuke_cursors": interface_reset_cursor})
+        view.run_command("gs_interface_refresh")
 
     if view.settings().get("git_savvy.log_graph_view", False):
         view.run_command("gs_log_graph_refresh")

--- a/common/util/view.py
+++ b/common/util/view.py
@@ -68,9 +68,8 @@ def refresh_gitsavvy_interfaces(
     window,
     refresh_sidebar=False,
     refresh_status_bar=True,
-    interface_reset_cursor=False
 ):
-    # type: (Optional[sublime.Window], bool, bool, bool) -> None
+    # type: (Optional[sublime.Window], bool, bool) -> None
     """
     Looks for GitSavvy interface views in the current window and refresh them.
 
@@ -100,9 +99,8 @@ def refresh_gitsavvy(
     view,
     refresh_sidebar=False,
     refresh_status_bar=True,
-    interface_reset_cursor=False
 ):
-    # type: (Optional[sublime.View], bool, bool, bool) -> None
+    # type: (Optional[sublime.View], bool, bool) -> None
     """
     Called after GitSavvy action was taken that may have effected the
     state of the Git repo.

--- a/core/commands/checkout.py
+++ b/core/commands/checkout.py
@@ -100,9 +100,7 @@ class gs_checkout_new_branch(WindowCommand, GitCommand):
             branch_name,
             self.base_branch if self.base_branch else None)
         self.window.status_message("Created and checked out `{}` branch.".format(branch_name))
-        util.view.refresh_gitsavvy_interfaces(self.window,
-                                              refresh_sidebar=True,
-                                              interface_reset_cursor=True)
+        util.view.refresh_gitsavvy_interfaces(self.window, refresh_sidebar=True)
 
 
 class gs_checkout_remote_branch(WindowCommand, GitCommand):
@@ -143,9 +141,7 @@ class gs_checkout_remote_branch(WindowCommand, GitCommand):
         self.git("checkout", "-b", branch_name, "--track", self.remote_branch)
         self.window.status_message(
             "Checked out `{}` as local branch `{}`.".format(self.remote_branch, branch_name))
-        util.view.refresh_gitsavvy_interfaces(self.window,
-                                              refresh_sidebar=True,
-                                              interface_reset_cursor=True)
+        util.view.refresh_gitsavvy_interfaces(self.window, refresh_sidebar=True)
 
 
 class gs_checkout_current_file_at_commit(LogMixin, WindowCommand, GitCommand):
@@ -177,7 +173,7 @@ class gs_checkout_current_file_at_commit(LogMixin, WindowCommand, GitCommand):
                     self.get_short_hash(commit_hash)
                 )
             )
-            util.view.refresh_gitsavvy_interfaces(self.window, interface_reset_cursor=True)
+            util.view.refresh_gitsavvy_interfaces(self.window)
 
 
 class gs_show_file_diff(WindowCommand, GitCommand):

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -117,6 +117,22 @@ class BranchInterface(ui.Interface, GitCommand):
             self.show_remotes = self.savvy_settings.get("show_remotes_in_branch_dashboard")
         self.remotes = self.get_remotes() if self.show_remotes else {}
 
+    def render(self, nuke_cursors=False):
+        def cursor_is_on_active_branch():
+            sel = self.view.sel()
+            return (
+                len(sel) == 1
+                and self.view.match_selector(
+                    sel[0].begin(),
+                    "meta.git-savvy.branches.branch.active-branch"
+                )
+            )
+
+        cursor_was_on_active_branch = cursor_is_on_active_branch()
+        super().render(nuke_cursors=nuke_cursors)
+        if cursor_was_on_active_branch and not cursor_is_on_active_branch():
+            self.view.run_command("gs_branches_navigate_to_active_branch")
+
     def on_new_dashboard(self):
         self.view.run_command("gs_branches_navigate_to_active_branch")
 

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -117,7 +117,7 @@ class BranchInterface(ui.Interface, GitCommand):
             self.show_remotes = self.savvy_settings.get("show_remotes_in_branch_dashboard")
         self.remotes = self.get_remotes() if self.show_remotes else {}
 
-    def render(self, nuke_cursors=False):
+    def render(self):
         def cursor_is_on_active_branch():
             sel = self.view.sel()
             return (
@@ -129,7 +129,7 @@ class BranchInterface(ui.Interface, GitCommand):
             )
 
         cursor_was_on_active_branch = cursor_is_on_active_branch()
-        super().render(nuke_cursors=nuke_cursors)
+        super().render()
         if cursor_was_on_active_branch and not cursor_is_on_active_branch():
             self.view.run_command("gs_branches_navigate_to_active_branch")
 

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -275,12 +275,10 @@ class StatusInterface(ui.Interface, GitCommand):
         if callable(then):
             then()
 
-    def render(self, nuke_cursors=False):
+    def render(self):
         """Refresh view state and render."""
         self.refresh_view_state()
         self.just_render()
-        if nuke_cursors:
-            self.reset_cursor()
 
     @distinct_until_state_changed
     def just_render(self):


### PR DESCRIPTION
Fixes #776
Fixes #1252

General, `nuke_cursors` is only used by the branch dashboard, and here 
to follow the active branch.  But being an imperative this was for example
not implemented for renaming the current branch.  Or the user just switch
branches in Terminus?  

The subproblem to follow the active branch is much easier to solve than
the general problem to follow any branch so we do the simple thing here
first and obsolete `nuke_cursors`.