### PR TITLE
Run after first render callback immediately

### DIFF
--- a/common/ui.py
+++ b/common/ui.py
@@ -129,7 +129,7 @@ class Interface(metaclass=_PrepareInterface):
         interface = cls(view=view)
         interface.after_view_creation(view)  # before first render
         interface.render()
-        enqueue_on_worker(interface.on_new_dashboard)  # after first render
+        interface.on_new_dashboard()         # after first render
 
         focus_view(view)
         return interface


### PR DESCRIPTION
This did not work previously in that the callback run before meaningful content was rendered, so I had this artificial "async" delay here (`enqueue_on_worker`).  But it does now and feels so much faster, well ... because it is instant now.

Note for testing: we use `on_new_dashboard` to move the cursor to a meaningful position for new views.
And it was the `nuke_cursors` thing that needed the delay. So this PR relies on the previous #1632 