### PR TITLE
Display worktree path in branch list

### DIFF
--- a/core/git_mixins/branches.py
+++ b/core/git_mixins/branches.py
@@ -24,6 +24,7 @@ if MYPY:
         ("canonical_name", str),    # e.g. "origin/master"
         ("commit_hash", str),
         ("commit_msg", str),
+        ("worktree_path", str),
         ("active", bool),
         ("is_remote", bool),
         ("committerdate", int),
@@ -37,6 +38,7 @@ else:
         "canonical_name",
         "commit_hash",
         "commit_msg",
+        "worktree_path",
         "active",
         "is_remote",
         "committerdate",
@@ -106,6 +108,7 @@ class BranchesMixin(mixin_base):
                 "%(upstream:remotename)%00"
                 "%(upstream:track,nobracket)%00"
                 "%(committerdate:unix)%00"
+                "%(worktreepath)%00"
                 "%(objectname)%00"
                 "%(contents:subject)"
             ),
@@ -143,7 +146,7 @@ class BranchesMixin(mixin_base):
     def _parse_branch_line(self, line):
         # type: (str) -> Branch
         (head, ref, upstream, upstream_remote, upstream_status,
-         committerdate, commit_hash, commit_msg) = line.split("\x00")
+         committerdate, worktree_path, commit_hash, commit_msg) = line.split("\x00")
 
         active = head == "*"
         is_remote = ref.startswith("refs/remotes/")
@@ -173,6 +176,7 @@ class BranchesMixin(mixin_base):
             canonical_name,
             commit_hash,
             commit_msg,
+            worktree_path,
             active,
             is_remote,
             int(committerdate),

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -199,8 +199,9 @@ class BranchInterface(ui.ReactiveInterface, GitCommand):
     def _render_branch_list(self, remote_name, branches, descriptions):
         # type: (Optional[str], List[Branch], Dict[str, str]) -> str
         remote_name_length = len(remote_name + "/") if remote_name else 0
+        current_worktree = next((b.worktree_path for b in branches if b.active), None)
         return "\n".join(
-            "  {indicator} {hash:.7} {name}{tracking}{description}".format(
+            "  {indicator} {hash:.7} {name}{tracking}{description}{worktreepath}".format(
                 indicator="▸" if branch.active else " ",
                 hash=branch.commit_hash,
                 name=branch.canonical_name[remote_name_length:],
@@ -208,7 +209,12 @@ class BranchInterface(ui.ReactiveInterface, GitCommand):
                 tracking=(" ({branch}{status})".format(
                     branch=branch.upstream.canonical_name,
                     status=", " + branch.upstream.status if branch.upstream.status else ""
-                ) if branch.upstream else "")
+                ) if branch.upstream else ""),
+                worktreepath=(
+                    " ({})".format(branch.worktree_path)
+                    if branch.worktree_path and branch.worktree_path != current_worktree
+                    else ""
+                )
             ) for branch in branches
         )
 


### PR DESCRIPTION
Works towards providing worktree support.

This PR just displays the worktree in the branch list.

- [ ] fix unit tests

---

No worktrees other than current branch.
![image](https://user-images.githubusercontent.com/61225/194736882-b72b3306-b79f-4390-bfd2-68fd7f0de7d4.png)

after running `git worktree add ../clusterfiles-template template` : 
![image](https://user-images.githubusercontent.com/61225/194736915-5d671a05-3fa4-49ab-b688-f838b51b8750.png)

after running : `subl ../clusterfiles-template`
![image](https://user-images.githubusercontent.com/61225/194736934-59a39d81-02b5-47d3-a6dc-884ba0b82a32.png)

I noticed the main branch window shows : 

![image](https://user-images.githubusercontent.com/61225/194737103-1eebe5e8-59b1-435c-9147-da7ece113df3.png)

So perhaps we should be consistent and show the worktree like: 

![image](https://user-images.githubusercontent.com/61225/194737115-6528bf68-72d1-4a65-8f54-8c5558ae44f6.png)


---

I can follow up with creating and manipulating worktrees in some follow up PRs 

