### PR TITLE
Allow creation of worktrees from local and remote branches

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1541,6 +1541,14 @@
             { "key": "setting.git_savvy.branch_view", "operator": "equal", "operand": true }
         ]
     },
+    {
+        "keys": ["w"],
+        "command": "gs_branches_create_worktree",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.branch_view", "operator": "equal", "operand": true }
+        ]
+    },
 
 
     ////////////////

--- a/core/commands/__init__.py
+++ b/core/commands/__init__.py
@@ -39,3 +39,4 @@ from .stage_hunk import *
 from .stash import *
 from .status_bar import *
 from .tag import *
+from .worktree import *

--- a/core/commands/worktree.py
+++ b/core/commands/worktree.py
@@ -1,0 +1,103 @@
+import sublime
+from sublime_plugin import WindowCommand
+
+from .checkout import gs_checkout_remote_branch
+from ..git_command import GitCommand, GitSavvyError
+from ..ui_mixins.quick_panel import show_branch_panel
+from ..ui_mixins.input_panel import show_single_line_input_panel
+from ...common import util
+from GitSavvy.core import store
+
+
+__all__ = (
+    "gs_worktree_create",
+    "gs_worktree_create_for_remote",
+)
+
+
+class gs_worktree_create(WindowCommand, GitCommand):
+
+    """
+    Display a panel of all local branches.
+    Then prompt the user for a path.
+    """
+
+    def run(self, branch=None):
+        sublime.set_timeout_async(lambda: self.run_async(branch))
+
+    def run_async(self, branch=None):
+        if branch:
+            self.on_branch_selection(branch)
+        else:
+            show_branch_panel(
+                self.on_branch_selection,
+                local_branches_only=True,
+                ignore_current_branch=True,
+                selected_branch=store.current_state(self.repo_path)["last_branches"][-2]
+            )
+
+    def on_branch_selection(self, branch):
+        self.target_branch = branch
+        show_single_line_input_panel(
+            initial_text="../{0}".format(branch),
+            caption="New worktree path",
+            on_done=self.on_path_provided,
+        )
+
+    def on_path_provided(self, path):
+        self.create_worktree(self.target_branch, path)
+
+    def create_worktree(self, branch, path):
+        # type: (str, str) -> None
+        try:
+            self.git_throwing_silently(
+                "worktree", "add",
+                path,
+                branch
+            )
+        except GitSavvyError as e:
+            e.show_error_panel()
+            raise
+
+        self.window.status_message(
+            "Created worktree `{}` for branch `{}`.".format(path, branch))
+        util.view.refresh_gitsavvy_interfaces(self.window, refresh_sidebar=True)
+
+
+class gs_worktree_create_for_remote(WindowCommand, GitCommand):
+
+    """
+    Display a panel of all local branches.
+    Then prompt the user for a path.
+    """
+
+    def run(self, remote_branch=None):
+        sublime.set_timeout_async(lambda: self.run_async(remote_branch))
+
+    def run_async(self, remote_branch):
+        gs_checkout_remote_branch(remote_branch=remote_branch)
+        self.on_branch_selection(remote_branch)
+
+    def on_branch_selection(self, branch):
+        self.target_branch = branch
+
+        show_single_line_input_panel(
+            initial_text="../{0}".format(branch),
+            caption="New worktree path",
+            on_done=self.on_path_provided,
+        )
+
+    def on_path_provided(self, path):
+        branch = self.target_branch
+        try:
+            self.git_throwing_silently(
+                "worktree", "add",
+                path,
+            )
+        except GitSavvyError as e:
+            e.show_error_panel()
+            raise
+
+        self.window.status_message(
+            "Created worktree `{}` for branch `{}`.".format(path, branch))
+        util.view.refresh_gitsavvy_interfaces(self.window, refresh_sidebar=True)

--- a/core/git_mixins/branches.py
+++ b/core/git_mixins/branches.py
@@ -167,7 +167,8 @@ class BranchesMixin(mixin_base):
 
     def _parse_branch_line(self, line):
         # type: (str) -> Branch
-        head, ref, upstream, upstream_remote, upstream_status, worktree_path, commit_hash, commit_msg = line.split("\x00")
+        head, ref, upstream, upstream_remote, upstream_status, worktree_path, \
+            commit_hash, commit_msg = line.split("\x00")
 
         active = head == "*"
         is_remote = ref.startswith("refs/remotes/")

--- a/core/git_mixins/branches.py
+++ b/core/git_mixins/branches.py
@@ -23,6 +23,7 @@ if MYPY:
         ("canonical_name", str),    # e.g. "origin/master"
         ("commit_hash", str),
         ("commit_msg", str),
+        ("worktree_path", str),
         ("active", bool),
         ("is_remote", bool),
         ("description", str),
@@ -36,6 +37,7 @@ else:
         "canonical_name",
         "commit_hash",
         "commit_msg",
+        "worktree_path",
         "active",
         "is_remote",
         "description",
@@ -64,6 +66,18 @@ class BranchesMixin(mixin_base):
             return branch.name
         return None
 
+
+    def get_current_worktree(self):
+        # type: () -> Optional[str]
+        """
+        Return the worktree path for the current branch.
+        """
+        branch = self.get_current_branch()
+        if branch:
+            return branch.worktree_path
+
+        return None
+
     def get_upstream_for_active_branch(self):
         # type: () -> Optional[Upstream]
         branch = self.get_current_branch()
@@ -84,6 +98,7 @@ class BranchesMixin(mixin_base):
         for branch in self.get_local_branches():
             if branch.name == branch_name:
                 return branch
+
         return None
 
     def get_local_branches(self):
@@ -109,6 +124,7 @@ class BranchesMixin(mixin_base):
                 "%(upstream)%00"
                 "%(upstream:remotename)%00"
                 "%(upstream:track,nobracket)%00"
+                "%(worktreepath)%00"
                 "%(objectname)%00"
                 "%(contents:subject)"
             ),
@@ -151,7 +167,7 @@ class BranchesMixin(mixin_base):
 
     def _parse_branch_line(self, line):
         # type: (str) -> Branch
-        head, ref, upstream, upstream_remote, upstream_status, commit_hash, commit_msg = line.split("\x00")
+        head, ref, upstream, upstream_remote, upstream_status, worktree_path, commit_hash, commit_msg = line.split("\x00")
 
         active = head == "*"
         is_remote = ref.startswith("refs/remotes/")
@@ -181,6 +197,7 @@ class BranchesMixin(mixin_base):
             canonical_name,
             commit_hash,
             commit_msg,
+            worktree_path,
             active,
             is_remote,
             description="",

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -43,6 +43,7 @@ if MYPY:
     from GitSavvy.core.git_mixins.branches import Branch
 
 
+
 class gs_show_branch(WindowCommand, GitCommand):
 
     """
@@ -156,9 +157,11 @@ class BranchInterface(ui.Interface, GitCommand):
         if not branches:
             branches = [branch for branch in self._branches if not branch.is_remote]
 
+        current_worktree = self.get_current_worktree()
         remote_name_l = len(remote_name + "/") if remote_name else 0
+
         return "\n".join(
-            "  {indicator} {hash:.7} {name}{tracking}{description}".format(
+            "  {indicator} {hash:.7} {name}{tracking}{description}{worktreepath}".format(
                 indicator="▸" if branch.active else " ",
                 hash=branch.commit_hash,
                 name=branch.canonical_name[remote_name_l:],
@@ -166,7 +169,8 @@ class BranchInterface(ui.Interface, GitCommand):
                 tracking=(" ({branch}{status})".format(
                     branch=branch.upstream.canonical_name,
                     status=", " + branch.upstream.status if branch.upstream.status else ""
-                ) if branch.upstream else "")
+                ) if branch.upstream else ""),
+                worktreepath=" [ worktree: " + ("current" if current_worktree == branch.worktree_path else branch.worktree_path) + " ]" if branch.worktree_path and not remote_name else ""
             ) for branch in branches
         )
 

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -170,7 +170,7 @@ class BranchInterface(ui.Interface, GitCommand):
                     branch=branch.upstream.canonical_name,
                     status=", " + branch.upstream.status if branch.upstream.status else ""
                 ) if branch.upstream else ""),
-                worktreepath=" [ worktree: " + ("current" if current_worktree == branch.worktree_path else branch.worktree_path) + " ]" if branch.worktree_path and not remote_name else ""
+                worktreepath=" root: " + branch.worktree_path if branch.worktree_path and not remote_name and current_worktree != branch.worktree_path else ""
             ) for branch in branches
         )
 


### PR DESCRIPTION
very rough draft.

depends on #1637 

- [ ] Fix tests
- [ ] Fix linting

On branches view:

- press w to create a worktree from the branch
    -  prompted to destination path (default is inferred from branchname)