### PR TITLE
Fix: Ensure refs in "local_branches" are actual branches

### DIFF
--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -2076,7 +2076,7 @@ def describe_graph_line(line, known_branches):
             else:
                 branches.append(name)
                 branch = known_branches.get(name)
-                if not branch or not branch.is_remote:
+                if branch and not branch.is_remote:
                     local_branches.append(name)
         if branches:
             rv["branches"] = branches

--- a/tests/test_describe_graph_line.py
+++ b/tests/test_describe_graph_line.py
@@ -34,17 +34,16 @@ examples = [
         }
     ),
     (
-        # Unknown branches are put under `local_branches`.  At the time of writing the
-        # test this was an arbitrary decision.
-        "● a3062b2 (HEAD -> optimize-graph-render, feat/optimize-graph-render) Abort .. | Thu 21:07, herr kaste",
+        # Unknown refs are in `branches` (sic!) but *not* under `local_branches`.
+        "● a3062b2 (HEAD -> optimize-graph-render, refs/bisect/bad) Abort .. | Thu 21:07, herr kaste",
         {
             "optimize-graph-render": mock({"is_remote": False}),
         },
         {
             "commit": "a3062b2",
             "HEAD": "optimize-graph-render",
-            "branches": ["optimize-graph-render", "feat/optimize-graph-render"],
-            "local_branches": ["optimize-graph-render", "feat/optimize-graph-render"]
+            "branches": ["optimize-graph-render", "refs/bisect/bad"],
+            "local_branches": ["optimize-graph-render"]
         }
     ),
     (


### PR DESCRIPTION
A typical other ref name is for example `refs/bisect/bad` etc.  These should not count as local "branches".

Filter them here so they do not show up under "Delete <x>" or "Move <x> to ...".

In reality we even raised because other code assumed everything under `local_branches` would be also in `get_branches()`.  Fix that.