### PR TITLE
Fix: Always show "Diff against workdir" if on HEAD commit

### DIFF
--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -2399,7 +2399,7 @@ class gs_log_graph_action(WindowCommand, GitCommand):
                     partial(self.diff_commit, commit_hash)
                 ),
             ]
-        elif on_checked_out_branch:
+        elif "HEAD" in info:
             actions += [
                 ("Diff against workdir", self.diff),
             ]


### PR DESCRIPTION
I.e. it is not necessary to check if we're on the checked out branch, being on the "HEAD" commit is enough.

Otherwise we open the explicit diff "HEAD against the head commit" which is -- of course -- always empty.