### PR TITLE
Do not sort remote branches by name

### DIFF
--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -190,15 +190,12 @@ class BranchInterface(ui.Interface, GitCommand):
     def render_remotes_on(self):
         output_tmpl = "\n"
         render_fns = []
-
-        sorted_branches = sorted(
-            [b for b in self._branches if b.is_remote],
-            key=lambda branch: branch.canonical_name)
+        remote_branches = [b for b in self._branches if b.is_remote]
 
         for remote_name in self.remotes:
             key = "branch_list_" + remote_name
             output_tmpl += "{" + key + "}\n"
-            branches = [b for b in sorted_branches if b.canonical_name.startswith(remote_name + "/")]
+            branches = [b for b in remote_branches if b.canonical_name.startswith(remote_name + "/")]
 
             @ui.section(key)
             def render(remote_name=remote_name, branches=branches):


### PR DESCRIPTION
Fixes #1643

With the setting `sort_by_recent_in_branch_dashboard` users can opt-into sorting the branches.  This sorting is (surprisingly) done on the git side (so we don't see it here) and thus resorting is not allowed.