### PR TITLE
support "color_scheme": "auto"

### DIFF
--- a/common/theme_generator.py
+++ b/common/theme_generator.py
@@ -46,7 +46,7 @@ class ThemeGenerator():
     @staticmethod
     def for_view(view):
         # type: (sublime.View) -> ThemeGenerator
-        color_scheme = view.settings().get('color_scheme')
+        color_scheme = sublime.ui_info()["color_scheme"]["resolved_value"]
         if color_scheme.endswith(".tmTheme"):
             return XMLThemeGenerator(color_scheme)
         else:


### PR DESCRIPTION
Simple fix to #1502 

The main caveat is that if you switch the global color scheme light -> dark, the Gitsavvy view will stil use the old scheme that was generated from the light scheme, even though all other views are now using the dark one.
I'm not sure there is a better fix, since there is no event to detect this kind of changes. 

For me the "_right solution_" would be to replace the Git savvy scopes https://github.com/gwenzek/GitSavvy/blob/3b71e40b3f708e4163a2b0b636fca325f1b5a33b/core/commands/log_graph.py#L90-L94

by the "magic" colored scope (`region.redish`, etc): https://www.sublimetext.com/docs/api_reference.html#sublime.View.add_regions
This way you don't need to override the view scheme, and you let SublimeText deal with the light/dark scheme.
You can see what it would look like at: https://github.com/timbrel/GitSavvy/commit/10f08252a95e32e8ffa3e72ea5aa7e67750a996c.
This would require a bit more work to make the colors configurable, let me know if you're interested.
