### PR TITLE
Flip base and target commit

### DIFF
--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -2179,8 +2179,8 @@ class gs_log_graph_action(WindowCommand, GitCommand):
                 else:
                     return info["commit"]
 
-            base_commit = display_name(infos[0])
-            target_commit = display_name(infos[1])
+            base_commit = display_name(infos[1])
+            target_commit = display_name(infos[0])
 
             actions += [
                 (


### PR DESCRIPTION
When we have two cursors and hence two "infos", these are sorted and naturally the *base* commit should be the older commit of the two.