### PR TITLE
Remove redundant `verify`

### DIFF
--- a/tests/test_status_dashboard.py
+++ b/tests/test_status_dashboard.py
@@ -151,7 +151,6 @@ class TestStatusDashboard(DeferrableTestCase):
             view.find('fix-1048', 0, sublime.LITERAL)
             and view.find('modified_file', 0, sublime.LITERAL)
         )
-        verify(GitCommand, atleast=1).git('status', ...)
 
         region = sublime.Region(0, view.size())
         view.sel().clear()


### PR DESCRIPTION
At this point the view shows the data from the mocked "status" call, so there is literally no point in verifying the actual git call.