### PR TITLE
Symptom: the innocuous looking

### DIFF
--- a/core/base_commands.py
+++ b/core/base_commands.py
@@ -133,19 +133,19 @@ def _get_run_command(cmd):
 
 
 class GsTextCommand(
+    GitCommand,
     # order matters(!), `WithProvideWindow` also ensures unique instances per call
     WithProvideWindow,
     WithInputHandlers,
     sublime_plugin.TextCommand,
-    GitCommand,
 ):
     defaults = {}  # type: Dict[str, Callable[[GsTextCommand, Args, Kont], None]]
 
 
 class GsWindowCommand(
+    GitCommand,
     WithInputHandlers,
     sublime_plugin.WindowCommand,
-    GitCommand,
 ):
     defaults = {}  # type: Dict[str, Callable[[GsWindowCommand, Args, Kont], None]]
 


### PR DESCRIPTION
Symptom: the innocuous looking

```
class gs_reset(ResetMixin, LogMixin):
    pass
```

did not work because it did not call `LogMixin.run()`.  Flipping there did not call `ResetMixin.do_action()` but the one from `LogMixin`.

The bases were defined as follows:

```
class ResetMixin(GsWindowCommand):
class LogMixin(GitCommand):
```

I can't calculate the MRO here so this is more intuition and hopefully luck

Introduced-by: 84c8c719 (Use `GsWindowCommand` in `reset.py`)