### PR TITLE
Fix too wide left column on blame views

### DIFF
--- a/core/commands/blame.py
+++ b/core/commands/blame.py
@@ -325,6 +325,8 @@ class gs_blame_refresh(BlameMixin):
         if len(summary) > 40:
             summary = summary[:36] + " ..."
         author_info = commit["author"] + " " + commit["author-mail"]
+        if len(author_info) > 40:
+            author_info = author_info[:37] + "..."
         time_stamp = util.dates.fuzzy(commit["author-time"]) if commit["author-time"] else ""
 
         return (summary, commit["short_hash"], author_info, time_stamp)

--- a/syntax/blame.sublime-syntax
+++ b/syntax/blame.sublime-syntax
@@ -14,16 +14,14 @@ contexts:
         2: comment.block.git-savvy.splitter.vertical
         3: comment.block.git-savvy.splitter.horizontal.source
 
-    - match: (\|)\s+(\d*).*
-      captures:
-        1: comment.block.git-savvy.splitter.vertical
-        2: constant.numeric.line-number.blame.git-savvy
-
-    - match: ^[0-9a-f]{12}
+    - match: ^([0-9a-f]{12})\s+
       comment: SHA
-      scope: meta.blame-line.git-savvy constant.numeric.commit-hash.git-savvy
+      scope: meta.blame-line.git-savvy
+      captures:
+        1: constant.numeric.commit-hash.git-savvy
+      push: right-column
 
-    - match: ^(.*) (<)([a-zA-Z0-9\-.]*@[a-zA-Z0-9\-.]*)(>)
+    - match: ^([^|]+) (<)(\S*?)(>|\.{3})\s+
       comment: name + email
       scope: meta.blame-line.git-savvy
       captures:
@@ -31,10 +29,16 @@ contexts:
         2: punctuation.definition.other.begin.git-savvy
         3: string.other.mail.git-savvy
         4: punctuation.definition.other.end.git-savvy
+      push: right-column
 
-    - match: \s+$
-      comment: marking empty spaces before end of line before it's marked by commit-info rule
-      scope: meta.empty
-
-    - match: '[^|]+'
+    - match: ^.+?(?=\s\|\s)
       scope: comment.block.git-savvy.commit-info
+      push: right-column
+
+  right-column:
+    - match: (\|)\s+(\d*).*$
+      captures:
+        1: comment.block.git-savvy.splitter.vertical
+        2: constant.numeric.line-number.blame.git-savvy
+    - match: $
+      pop: true

--- a/syntax/test/syntax_test_blame.txt
+++ b/syntax/test/syntax_test_blame.txt
@@ -20,12 +20,12 @@ gwenzek <guillaume.wenzek@gmail.com>         |    3 # http://www.sublimetext.com
 Jan 29, 2015                                 |
 #                                            ^ comment.block.git-savvy.splitter.vertical
 # <- comment.block.git-savvy.commit-info
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.git-savvy.commit-info
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.git-savvy.commit-info
 
 Rename `base_command#BaseCommand` to ...     |    4 from ..git_command import GitCommand
 #                                            ^ comment.block.git-savvy.splitter.vertical
 # <- comment.block.git-savvy.commit-info
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.git-savvy.commit-info
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.git-savvy.commit-info
 #                                                 ^ constant.numeric.line-number
 #                                                        ^ git-savvy.blame
 


### PR DESCRIPTION
Fixes #1653

We already truncated the commit message subject but need to follow here for the author value as well.

Adjust the blame syntax to only match the email very loose.  As we may
truncate the field, basically just watch out for the ending: (`>|...`).