### PR TITLE
Fix `previous_commit`

### DIFF
--- a/core/git_mixins/history.py
+++ b/core/git_mixins/history.py
@@ -387,16 +387,18 @@ class HistoryMixin(mixin_base):
 
     def _previous_commit(self, current_commit, file_path, follow):
         # type: (str, str, bool) -> Optional[str]
-        return self.git(
-            "log",
-            "--format=%H",
-            "--follow" if follow else None,
-            "--skip", "1",
-            "-n", "1",
-            current_commit,
-            "--",
-            file_path
-        ).strip() or None
+        try:
+            return self.git(
+                "log",
+                "--format=%H",
+                "--follow" if follow else None,
+                "-2",
+                current_commit,
+                "--",
+                file_path
+            ).strip().splitlines()[1]
+        except IndexError:
+            return None
 
     def next_commit(self, current_commit, file_path, follow=False):
         # type: (str, str, bool) -> Optional[str]

--- a/core/git_mixins/history.py
+++ b/core/git_mixins/history.py
@@ -374,7 +374,7 @@ class HistoryMixin(mixin_base):
         return rv
 
     def previous_commit(self, current_commit, file_path, follow=False):
-        # type: (str, str, bool) -> Optional[str]
+        # type: (Optional[str], str, bool) -> Optional[str]
         if not current_commit or current_commit == "HEAD":
             return self._previous_commit(current_commit, file_path, follow)
 
@@ -386,7 +386,7 @@ class HistoryMixin(mixin_base):
             return rv
 
     def _previous_commit(self, current_commit, file_path, follow):
-        # type: (str, str, bool) -> Optional[str]
+        # type: (Optional[str], str, bool) -> Optional[str]
         try:
             return self.git(
                 "log",
@@ -396,7 +396,7 @@ class HistoryMixin(mixin_base):
                 current_commit,
                 "--",
                 file_path
-            ).strip().splitlines()[1]
+            ).strip().splitlines()[1 if current_commit else 0]
         except IndexError:
             return None
 


### PR DESCRIPTION
If `follow` is on and the `current_commit` is the one where the rename
happens, skip 1 actually skips the rename and we will thus not get the
correct result.

Hence, always take 2 commits and skip the first here in python land.

This is in effect only in the blame view because `follow` is not used
anywhere else.