### PR TITLE
Implement support for "auto" color schemes

### DIFF
--- a/common/theme_generator.py
+++ b/common/theme_generator.py
@@ -70,9 +70,6 @@ class ThemeGenerator():
                     break
             self.color_scheme_string = sublime.load_resource(paths[0])
 
-    def get_theme_name(self, name):
-        return "GitSavvy.{}.{}".format(name, self.hidden_theme_extension)
-
     def get_theme_path(self, name):
         """
         Save the transformed theme to disk and return the path to that theme,
@@ -81,7 +78,8 @@ class ThemeGenerator():
         if not os.path.exists(os.path.join(sublime.packages_path(), "User", "GitSavvy")):
             os.makedirs(os.path.join(sublime.packages_path(), "User", "GitSavvy"))
 
-        return os.path.join("User", "GitSavvy", self.get_theme_name(name))
+        theme_name = "GitSavvy.{}.{}".format(name, self.hidden_theme_extension)
+        return os.path.join("User", "GitSavvy", theme_name)
 
     def add_scoped_style(self, name, scope, **kwargs):
         """

--- a/common/theme_generator.py
+++ b/common/theme_generator.py
@@ -63,7 +63,7 @@ class ThemeGenerator():
                 raise IOError("{} cannot be found".format(original_color_scheme))
             for path in paths:
                 if path.startswith("Packages/User/"):
-                    # load user specfic theme first
+                    # load user specific theme first
                     self.color_scheme_string = sublime.load_resource(path)
                     break
             self.color_scheme_string = sublime.load_resource(paths[0])
@@ -170,7 +170,7 @@ class JSONThemeGenerator(ThemeGenerator):
 
 
 def try_apply_theme(view, theme_path, tries=0):
-    """ Safly apply new theme as color_scheme. """
+    """ Safely apply new theme as color_scheme. """
     try:
         sublime.load_resource(theme_path)
     except Exception:

--- a/common/theme_generator.py
+++ b/common/theme_generator.py
@@ -96,7 +96,8 @@ class ThemeGenerator():
     def _add_scoped_style(self, name, scope, **kwargs):
         raise NotImplementedError
 
-    def _write_new_theme(self, name):
+    def _write_new_theme(self, path):
+        # type: (str) -> None
         """
         Write the new theme on disk.
         """
@@ -109,9 +110,9 @@ class ThemeGenerator():
         if not self._dirty:
             return
 
-        self._write_new_theme(name)
-
         path_in_packages = self.get_theme_path(name)
+        full_path = os.path.join(sublime.packages_path(), path_in_packages)
+        self._write_new_theme(full_path)
 
         # Sublime expects `/`-delimited paths, even in Windows.
         theme_path = os.path.join("Packages", path_in_packages).replace("\\", "/")
@@ -138,10 +139,9 @@ class XMLThemeGenerator(ThemeGenerator):
         new_style = STYLE_TEMPLATE.format(name=name, scope=scope, properties=properties)
         self.styles.append(ElementTree.XML(new_style))
 
-    def _write_new_theme(self, name):
-        full_path = os.path.join(sublime.packages_path(), self.get_theme_path(name))
-
-        with util.file.safe_open(full_path, "wb", buffering=0) as out_f:
+    def _write_new_theme(self, path):
+        # type: (str) -> None
+        with util.file.safe_open(path, "wb", buffering=0) as out_f:
             out_f.write(STYLES_HEADER.encode("utf-8"))
             out_f.write(ElementTree.tostring(self.plist, encoding="utf-8"))
 
@@ -164,10 +164,9 @@ class JSONThemeGenerator(ThemeGenerator):
             new_rule[k] = v
         self.dict["rules"].insert(0, new_rule)
 
-    def _write_new_theme(self, name):
-        full_path = os.path.join(sublime.packages_path(), self.get_theme_path(name))
-
-        with util.file.safe_open(full_path, "wb", buffering=0) as out_f:
+    def _write_new_theme(self, path):
+        # type: (str) -> None
+        with util.file.safe_open(path, "wb", buffering=0) as out_f:
             out_f.write(sublime.encode_value(self.dict, pretty=True).encode("utf-8"))
 
 

--- a/common/theme_generator.py
+++ b/common/theme_generator.py
@@ -98,11 +98,11 @@ class ThemeGenerator():
     def _add_scoped_style(self, name, scope, **kwargs):
         raise NotImplementedError
 
-    def write_new_theme(self, name):
+    def _write_new_theme(self, name):
         """
         Write the new theme on disk.
         """
-        pass
+        raise NotImplementedError
 
     def apply_new_theme(self, name, target_view):
         """
@@ -111,7 +111,7 @@ class ThemeGenerator():
         if not self._dirty:
             return
 
-        self.write_new_theme(name)
+        self._write_new_theme(name)
 
         path_in_packages = self.get_theme_path(name)
 
@@ -140,7 +140,7 @@ class XMLThemeGenerator(ThemeGenerator):
         new_style = STYLE_TEMPLATE.format(name=name, scope=scope, properties=properties)
         self.styles.append(ElementTree.XML(new_style))
 
-    def write_new_theme(self, name):
+    def _write_new_theme(self, name):
         full_path = os.path.join(sublime.packages_path(), self.get_theme_path(name))
 
         with util.file.safe_open(full_path, "wb", buffering=0) as out_f:
@@ -166,7 +166,7 @@ class JSONThemeGenerator(ThemeGenerator):
             new_rule[k] = v
         self.dict["rules"].insert(0, new_rule)
 
-    def write_new_theme(self, name):
+    def _write_new_theme(self, name):
         full_path = os.path.join(sublime.packages_path(), self.get_theme_path(name))
 
         with util.file.safe_open(full_path, "wb", buffering=0) as out_f:

--- a/common/theme_generator.py
+++ b/common/theme_generator.py
@@ -78,7 +78,7 @@ class ThemeGenerator():
         if not os.path.exists(os.path.join(sublime.packages_path(), "User", "GitSavvy")):
             os.makedirs(os.path.join(sublime.packages_path(), "User", "GitSavvy"))
 
-        theme_name = "GitSavvy.{}.{}".format(name, self.hidden_theme_extension)
+        theme_name = "GitSavvy.{}.{}.{}".format(name, self.setting_name, self.hidden_theme_extension)
         return os.path.join("User", "GitSavvy", theme_name)
 
     def add_scoped_style(self, name, scope, **kwargs):

--- a/common/theme_generator.py
+++ b/common/theme_generator.py
@@ -70,17 +70,6 @@ class ThemeGenerator():
                     break
             self.color_scheme_string = sublime.load_resource(paths[0])
 
-    def get_theme_path(self, name):
-        """
-        Save the transformed theme to disk and return the path to that theme,
-        relative to the Sublime packages directory.
-        """
-        if not os.path.exists(os.path.join(sublime.packages_path(), "User", "GitSavvy")):
-            os.makedirs(os.path.join(sublime.packages_path(), "User", "GitSavvy"))
-
-        theme_name = "GitSavvy.{}.{}.{}".format(name, self.setting_name, self.hidden_theme_extension)
-        return os.path.join("User", "GitSavvy", theme_name)
-
     def add_scoped_style(self, name, scope, **kwargs):
         """
         Add scope-specific styles to the theme.  A unique name should be provided
@@ -110,13 +99,24 @@ class ThemeGenerator():
         if not self._dirty:
             return
 
-        path_in_packages = self.get_theme_path(name)
+        path_in_packages = self._get_theme_path(name)
         full_path = os.path.join(sublime.packages_path(), path_in_packages)
         self._write_new_theme(full_path)
 
         # Sublime expects `/`-delimited paths, even in Windows.
         theme_path = os.path.join("Packages", path_in_packages).replace("\\", "/")
         try_apply_theme(target_view, self.setting_name, theme_path)
+
+    def _get_theme_path(self, name):
+        """
+        Save the transformed theme to disk and return the path to that theme,
+        relative to the Sublime packages directory.
+        """
+        if not os.path.exists(os.path.join(sublime.packages_path(), "User", "GitSavvy")):
+            os.makedirs(os.path.join(sublime.packages_path(), "User", "GitSavvy"))
+
+        theme_name = "GitSavvy.{}.{}.{}".format(name, self.setting_name, self.hidden_theme_extension)
+        return os.path.join("User", "GitSavvy", theme_name)
 
 
 class XMLThemeGenerator(ThemeGenerator):


### PR DESCRIPTION


Fixes #1502
Closes #1645

An "auto" color scheme is really just two schemes and then switching
between them.

Implement therefore a composite `ThemeGenerator` which acts on one or
many concrete theme generators.
