### PR TITLE
For new graph views follow "HEAD" if nothing else is specified

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -76,12 +76,12 @@
     {
         "caption": "git: graph",
         "command": "gs_graph",
-        "args": { "all": true, "follow": "HEAD" }
+        "args": { "all": true }
     },
     {
         "caption": "git: Repo History",
         "command": "gs_graph",
-        "args": { "all": true, "follow": "HEAD" }
+        "args": { "all": true }
     },
     {
         "caption": "git: graph current file",

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -192,6 +192,8 @@ class gs_graph(WindowCommand, GitCommand):
             view.run_command("gs_handle_arrow_keys")
             run_on_new_thread(augment_color_scheme, view)
 
+            if follow is None:
+                follow = "HEAD"
             settings = view.settings()
             settings.set("git_savvy.repo_path", repo_path)
             settings.set("git_savvy.log_graph_view.paths", paths)


### PR DESCRIPTION
With this `[g]` follows "HEAD" on the status dashboard.  For the global commands we remove the explicit `follow` directive though.

With that set we jump to "HEAD" for *new* views, but we do not move (or "hijack") the cursor if we merely jump to a different tab.