### PR TITLE
Iterate on the blame view

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -296,8 +296,7 @@
     },
     {
         "caption": "git: blame current file",
-        "command": "gs_blame_current_file",
-        "args": { "commit_hash": "HEAD" }
+        "command": "gs_blame"
     },
     {
         "caption": "GitSavvy: reload modules (debug)",

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -296,7 +296,8 @@
     },
     {
         "caption": "git: blame current file",
-        "command": "gs_blame_current_file"
+        "command": "gs_blame_current_file",
+        "args": { "commit_hash": "HEAD" }
     },
     {
         "caption": "GitSavvy: reload modules (debug)",

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1053,7 +1053,14 @@
             { "key": "setting.git_savvy.blame_view", "operator": "equal", "operand": true }
         ]
     },
-
+    {
+        "keys": ["g"],
+        "command": "gs_blame_open_graph_context",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.blame_view", "operator": "equal", "operand": true }
+        ]
+    },
     {
         "keys": ["."],
         "command": "gs_blame_navigate_chunk",

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1073,6 +1073,15 @@
         ]
     },
     {
+        "keys": ["h"],
+        "command": "gs_blame_navigate_head",
+        "args": { "forward": true },
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.blame_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
         "keys": ["j"],
         "command": "gs_blame_navigate_chunk",
         "args": { "forward": true },

--- a/core/commands/blame.py
+++ b/core/commands/blame.py
@@ -298,8 +298,7 @@ class gs_blame_refresh(BlameMixin):
 
         return blamed_lines, commits
 
-    @staticmethod
-    def partition(blamed_lines):
+    def partition(self, blamed_lines):
         prev_line = None
         current_hunk = []
         for line in blamed_lines:
@@ -328,8 +327,7 @@ class gs_blame_refresh(BlameMixin):
             commit_hash += "  (CURRENT COMMIT)"
         return (summary, commit_hash, author_info, time_stamp)
 
-    @staticmethod
-    def couple_partitions_and_commits(partitions, commit_infos, left_pad):
+    def couple_partitions_and_commits(self, partitions, commit_infos, left_pad):
         left_fallback = " " * left_pad
         right_fallback = ""
 

--- a/core/commands/blame.py
+++ b/core/commands/blame.py
@@ -208,9 +208,7 @@ class gs_blame_refresh(BlameMixin):
                 self.view.show_at_center(self.view.line(self.view.sel()[0].begin()).begin())
             else:
                 cursor_layout = self.view.text_to_layout(self.view.sel()[0].begin())
-                sublime.set_timeout_async(
-                    lambda: self.view.set_viewport_position(
-                        (0, cursor_layout[1] - yoffset), animate=False), 100)
+                self.view.set_viewport_position((0, cursor_layout[1] - yoffset), animate=False)
 
     def get_content(self, ignore_whitespace=False, detect_options=None, commit_hash=None):
         if commit_hash:

--- a/core/commands/blame.py
+++ b/core/commands/blame.py
@@ -20,6 +20,7 @@ __all__ = (
     "gs_blame_action",
     "gs_blame_toggle_setting",
     "gs_blame_navigate_chunk",
+    "gs_blame_navigate_head",
 )
 
 
@@ -488,9 +489,25 @@ class gs_blame_navigate_chunk(GsNavigate):
     offset = 0
 
     def get_available_regions(self):
+        return self.view.find_by_selector("constant.numeric.commit-hash.git-savvy")
+
+
+class gs_blame_navigate_head(GsNavigate):
+
+    """
+    Move cursor to the most recent changes
+    """
+
+    offset = 0
+
+    def get_available_regions(self):
+        selector = (
+            "meta.current-commit.blame.git-savvy"
+            if self.view.settings().get("git_savvy.commit_hash") else
+            "meta.not-committed.blame.git-savvy"
+        )
         return [
             branch_region
-            for region in self.view.find_by_selector(
-                "constant.numeric.commit-hash.git-savvy"
-            )
+            for region in self.view.find_by_selector(selector)
+            # Grab the line region to pin the cursor at the first column
             for branch_region in self.view.lines(region)]

--- a/core/commands/blame.py
+++ b/core/commands/blame.py
@@ -279,8 +279,8 @@ class gs_blame_refresh(BlameMixin):
             while not next_line.startswith("\t"):
                 # Iterate through header keys and values.
                 try:
-                    k, v = re.match(r"([^ ]+) (.+)", next_line).groups()  # type: ignore[union-attr]
-                except AttributeError:
+                    k, v = next_line.split(" ", 1)
+                except ValueError:
                     # Sometimes git-blame includes keys without values;
                     # since we don't care about these, simply discard.
                     print("Skipping blame line: " + repr(next_line))

--- a/core/commands/blame.py
+++ b/core/commands/blame.py
@@ -211,15 +211,12 @@ class gs_blame_refresh(BlameMixin):
                 self.view.set_viewport_position((0, cursor_layout[1] - yoffset), animate=False)
 
     def get_content(self, ignore_whitespace=False, detect_options=None, commit_hash=None):
-        if commit_hash:
-            # git blame does not follow file name changes like git log, therefore we
-            # need to look at the log first too see if the file has changed names since
-            # selected commit. I would not be surprised if this brakes in some special cases
-            # like rebased or multimerged commits
-            follow = self.savvy_settings.get("blame_follow_rename")
-            filename_at_commit = self.filename_at_commit(self.file_path, commit_hash, follow=follow)
+        file_path = self.file_path
+        assert file_path
+        if commit_hash and self.savvy_settings.get("blame_follow_rename"):
+            filename_at_commit = self.filename_at_commit(file_path, commit_hash)
         else:
-            filename_at_commit = self.file_path
+            filename_at_commit = file_path
 
         blame_porcelain = self.git(
             "blame", "-p", '-w' if ignore_whitespace else None, detect_options,

--- a/core/commands/blame.py
+++ b/core/commands/blame.py
@@ -130,7 +130,7 @@ class gs_blame_current_file(LogMixin, GsTextCommand):
 
         self._file_path = self.file_path
         kwargs["file_path"] = self._file_path
-        sublime.set_timeout_async(lambda: self.run_async(**kwargs), 0)
+        super().run(**kwargs)
 
     def do_action(self, commit_hash, **kwargs):
         self._commit_hash = commit_hash

--- a/core/commands/blame.py
+++ b/core/commands/blame.py
@@ -231,7 +231,7 @@ class gs_blame_refresh(BlameMixin):
             for commit_hash_, commit in commits.items()
         }
 
-        partitions = tuple(self.partition(blamed_lines))
+        partitions = tuple(self.group_consecutive_lines(blamed_lines))
 
         longest_commit_line = max(
             (line
@@ -299,7 +299,7 @@ class gs_blame_refresh(BlameMixin):
 
         return blamed_lines, commits
 
-    def partition(self, blamed_lines):
+    def group_consecutive_lines(self, blamed_lines):
         # type: (List[BlamedLine]) -> Iterator[List[BlamedLine]]
         for _, lines in groupby(blamed_lines, lambda line: line.commit_hash):
             yield list(lines)

--- a/core/commands/blame.py
+++ b/core/commands/blame.py
@@ -161,11 +161,12 @@ class gs_blame_refresh(BlameMixin):
     def run(self, edit):
 
         settings = self.view.settings()
+        file_path = settings.get("git_savvy.file_path")
         commit_hash = settings.get("git_savvy.commit_hash", None)  # type: Optional[str]
 
         self.view.set_name(
             BLAME_TITLE.format(
-                self.get_rel_path(self.file_path) if self.file_path else "unknown",
+                self.get_rel_path(file_path),
                 " at {}".format(commit_hash[0:7]) if commit_hash else ""
             )
         )
@@ -175,6 +176,7 @@ class gs_blame_refresh(BlameMixin):
             within_what = self.savvy_settings.get("blame_detect_move_or_copy_within")
 
         content = self.get_content(
+            file_path,
             ignore_whitespace=settings.get("git_savvy.ignore_whitespace", False),
             detect_options=self._detect_move_or_copy_dict[within_what],
             commit_hash=commit_hash
@@ -210,9 +212,7 @@ class gs_blame_refresh(BlameMixin):
                 cursor_layout = self.view.text_to_layout(self.view.sel()[0].begin())
                 self.view.set_viewport_position((0, cursor_layout[1] - yoffset), animate=False)
 
-    def get_content(self, ignore_whitespace=False, detect_options=None, commit_hash=None):
-        file_path = self.file_path
-        assert file_path
+    def get_content(self, file_path, ignore_whitespace=False, detect_options=None, commit_hash=None):
         if commit_hash and self.savvy_settings.get("blame_follow_rename"):
             filename_at_commit = self.filename_at_commit(file_path, commit_hash)
         else:

--- a/core/commands/blame.py
+++ b/core/commands/blame.py
@@ -347,8 +347,8 @@ class gs_blame_refresh(BlameMixin):
                     left=left,
                     left_pad=left_pad,
                     lineno=lineno,
-                    right=right)
-                output = output.strip() + "\n"
+                    right=right
+                )
 
             yield output
 

--- a/core/commands/blame.py
+++ b/core/commands/blame.py
@@ -442,10 +442,12 @@ class gs_blame_action(BlameMixin, PanelActionMixin):
             lineno = self.find_matching_lineno(
                 settings.get("git_savvy.commit_hash"), commit_hash, lineno)
 
+        assert self.file_path
+        file_path = self.filename_at_commit(self.file_path, commit_hash)
+
         self.window.run_command("gs_show_file_at_commit", {
             "commit_hash": commit_hash,
-            "filepath": self.file_path,
-            "check_for_renames": True,
+            "filepath": file_path,
             "position": Position(lineno - 1, 0, None),
             "lang": settings.get('git_savvy.original_syntax', None)
         })

--- a/core/commands/blame.py
+++ b/core/commands/blame.py
@@ -19,6 +19,7 @@ __all__ = (
     "gs_blame_refresh",
     "gs_blame_action",
     "gs_blame_toggle_setting",
+    "gs_blame_open_graph_context",
     "gs_blame_navigate_chunk",
     "gs_blame_navigate_head",
 )
@@ -452,6 +453,16 @@ class gs_blame_action(BlameMixin, PanelActionMixin):
     def pick_new_commit(self):
         self.view.run_command("gs_blame_current_file", {
             "file_path": self.file_path
+        })
+
+
+class gs_blame_open_graph_context(BlameMixin):
+    def run(self, edit):
+        # type: (...) -> None
+        commit_hash = self.find_selected_commit_hash()
+        self.window.run_command("gs_graph", {
+            "all": True,
+            "follow": self.get_short_hash(commit_hash) if commit_hash else "HEAD",
         })
 
 

--- a/core/commands/blame.py
+++ b/core/commands/blame.py
@@ -231,8 +231,8 @@ class gs_blame_refresh(BlameMixin):
         blamed_lines, commits = self.parse_blame(blame_porcelain.split('\n'))
 
         commit_infos = {
-            commit_hash: self.short_commit_info(commit)
-            for commit_hash, commit in commits.items()
+            commit_hash_: self.short_commit_info(commit, current_commit_hash=commit_hash)
+            for commit_hash_, commit in commits.items()
         }
 
         partitions = tuple(self.partition(blamed_lines))
@@ -316,8 +316,7 @@ class gs_blame_refresh(BlameMixin):
             current_hunk.append(line)
         yield current_hunk
 
-    @staticmethod
-    def short_commit_info(commit):
+    def short_commit_info(self, commit, current_commit_hash):
         if commit["long_hash"] == NOT_COMMITED_HASH:
             return ("Not committed yet.", )
 
@@ -329,7 +328,10 @@ class gs_blame_refresh(BlameMixin):
             author_info = author_info[:37] + "..."
         time_stamp = util.dates.fuzzy(commit["author-time"]) if commit["author-time"] else ""
 
-        return (summary, commit["short_hash"], author_info, time_stamp)
+        commit_hash = commit["short_hash"]
+        if commit["long_hash"] == current_commit_hash:
+            commit_hash += "  (CURRENT COMMIT)"
+        return (summary, commit_hash, author_info, time_stamp)
 
     @staticmethod
     def couple_partitions_and_commits(partitions, commit_infos, left_pad):

--- a/core/commands/blame.py
+++ b/core/commands/blame.py
@@ -135,10 +135,9 @@ class gs_blame_current_file(LogMixin, GsTextCommand):
 
     def do_action(self, commit_hash, **kwargs):
         self._commit_hash = commit_hash
-        sublime.set_timeout(
-            lambda: self.window.run_command(
-                "gs_blame", {"commit_hash": commit_hash, "file_path": self._file_path}),
-            100)
+        self.window.run_command("gs_blame", {
+            "commit_hash": commit_hash, "file_path": self._file_path
+        })
 
     def selected_index(self, commit_hash):
         return self._commit_hash == commit_hash

--- a/core/commands/show_file_at_commit.py
+++ b/core/commands/show_file_at_commit.py
@@ -43,7 +43,8 @@ def compute_identifier_for_view(view):
 
 class gs_show_file_at_commit(WindowCommand, GitCommand):
 
-    def run(self, commit_hash, filepath, check_for_renames=False, position=None, lang=None):
+    def run(self, commit_hash, filepath, position=None, lang=None):
+        # type: (str, str, Optional[Position], Optional[str]) -> None
         this_id = (
             self.repo_path,
             filepath,
@@ -60,19 +61,17 @@ class gs_show_file_at_commit(WindowCommand, GitCommand):
                 self.run_impl,
                 commit_hash,
                 filepath,
-                check_for_renames,
                 position,
                 lang,
             )
 
-    def run_impl(self, commit_hash, file_path, check_for_renames, position, lang):
+    def run_impl(self, commit_hash, file_path, position, lang):
+        # type: (str, str, Optional[Position], Optional[str]) -> None
         # need to get repo_path before the new view is created.
         repo_path = self.repo_path
         view = util.view.get_scratch_view(self, "show_file_at_commit")
         settings = view.settings()
         settings.set("git_savvy.repo_path", repo_path)
-        if check_for_renames:
-            file_path = self.filename_at_commit(file_path, commit_hash)
         settings.set("git_savvy.file_path", file_path)
         settings.set("git_savvy.show_file_at_commit_view.commit", commit_hash)
         for key, value in {
@@ -113,9 +112,11 @@ class gs_show_file_at_commit_refresh(TextCommand, GitCommand):
         enqueue_on_worker(self.update_reference_document, commit_hash, file_path)
 
     def update_reference_document(self, commit_hash, file_path):
+        # type: (str, str) -> None
         self.view.set_reference_document(self.previous_file_version(commit_hash, file_path))
 
     def update_title(self, commit_hash, file_path):
+        # type: (str, str) -> None
         title = SHOW_COMMIT_TITLE.format(
             os.path.basename(file_path),
             self.get_short_hash(commit_hash),

--- a/core/commands/show_file_at_commit.py
+++ b/core/commands/show_file_at_commit.py
@@ -71,6 +71,8 @@ class gs_show_file_at_commit(WindowCommand, GitCommand):
         view = util.view.get_scratch_view(self, "show_file_at_commit")
         settings = view.settings()
         settings.set("git_savvy.repo_path", repo_path)
+        if check_for_renames:
+            file_path = self.filename_at_commit(file_path, commit_hash)
         settings.set("git_savvy.file_path", file_path)
         settings.set("git_savvy.show_file_at_commit_view.commit", commit_hash)
         for key, value in {
@@ -89,9 +91,6 @@ class gs_show_file_at_commit(WindowCommand, GitCommand):
 
         view.set_syntax_file(lang)
         view.set_name(title)
-
-        if check_for_renames:
-            file_path = self.filename_at_commit(file_path, commit_hash)
 
         view.run_command("gs_show_file_at_commit_refresh", {
             "position": position

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -594,7 +594,11 @@ class _GitCommand(SettingsMixin):
         """
         fpath = self.file_path if abs_path is NOT_SET else abs_path
         assert fpath
-        rel_path = os.path.relpath(resolve_path(fpath), start=resolve_path(self.repo_path))
+        rel_path = (
+            os.path.relpath(resolve_path(fpath), start=resolve_path(self.repo_path))
+            if os.path.isabs(fpath) else
+            fpath
+        )
         if os.name == "nt":
             return rel_path.replace("\\", "/")
         return rel_path

--- a/popups/blame_view.html
+++ b/popups/blame_view.html
@@ -7,25 +7,24 @@
 
 <h3>Actions</h3>
 <div>
-  <div><code><span class="shortcut-key">enter&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>show all commands</code></div>
-  <div><code><span class="shortcut-key">w&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>ignore white space</code></div>
-  <div><code><span class="shortcut-key">f&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>detect moved or copied lines within same file</code></div>
-  <div><code><span class="shortcut-key">c&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>detect moved or copied lines within same commit</code></div>
-  <div><code><span class="shortcut-key">a&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>detect moved or copied lines within all commits</code></div>
-  <div><code><span class="shortcut-key">,&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>go to next chunk</code></div>
-  <div><code><span class="shortcut-key">.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>go to previous chunk</code></div>
+  <div><code><span class="shortcut-key">enter&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>show all commands</code></div>
+  <div><code><span class="shortcut-key">w&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>ignore white space</code></div>
+  <div><code><span class="shortcut-key">f&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>detect moved or copied lines within same file</code></div>
+  <div><code><span class="shortcut-key">c&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>detect moved or copied lines within same commit</code></div>
+  <div><code><span class="shortcut-key">a&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>detect moved or copied lines within all commits</code></div>
 
-  <div><code><span class="shortcut-key">&lt;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>Blame previous commit</code></div>
-  <div><code><span class="shortcut-key">&gt;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>Blame next commit</code></div>
-  <div><code><span class="shortcut-key">alt+&lt;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>Blame a commit before this line's commit</code></div>
-  <div><code><span class="shortcut-key">alt+&gt;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>Blame next commit</code></div>
-  <div><code><span class="shortcut-key">?&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>show this help popup</code></div>
+  <div><code><span class="shortcut-key">&lt;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>Blame previous commit</code></div>
+  <div><code><span class="shortcut-key">&gt;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>Blame next commit</code></div>
+  <div><code><span class="shortcut-key">alt+&lt;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>Blame a commit before this line's commit</code></div>
+  <div><code><span class="shortcut-key">alt+&gt;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>Blame next commit</code></div>
+  <div><code><span class="shortcut-key">?&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>show this help popup</code></div>
 </div>
 
-<h3>Vintageous friendly mode</h3>
+<h3>Navigation</h3>
 <div>
-  <div><code><span class="shortcut-key">j&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>go to next chunk</code></div>
-  <div><code><span class="shortcut-key">k&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>go to previous chunk</code></div>
+  <div><code><span class="shortcut-key">g&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>show (commit under cursor) in graph</code></div>
+  <div><code><span class="shortcut-key">h&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>move through the current chunks</code></div>
+  <div><code><span class="shortcut-key">,</span>/<span class="shortcut-key">.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>go to next/previous chunk (also: <span class="shortcut-key">j</span>/<span class="shortcut-key">k</span> in vintageous mode)</code></div>
 </div>
 
 <h3>Settings</h3>

--- a/syntax/blame.sublime-syntax
+++ b/syntax/blame.sublime-syntax
@@ -14,11 +14,16 @@ contexts:
         2: comment.block.git-savvy.splitter.vertical
         3: comment.block.git-savvy.splitter.horizontal.source
 
-    - match: ^([0-9a-f]{12})\s+
+    - match: ^Not committed yet.+?\s+
+      scope: meta.not-committed.blame.git-savvy
+      push: right-column
+
+    - match: ^([0-9a-f]{12})\s+ (\(CURRENT COMMIT\))?
       comment: SHA
       scope: meta.blame-line.git-savvy
       captures:
         1: constant.numeric.commit-hash.git-savvy
+        2: meta.current-commit.blame.git-savvy
       push: right-column
 
     - match: ^([^|]+) (<)(\S*?)(>|\.{3})\s+


### PR DESCRIPTION
This is basically refactoring and fixing the blame view.  

-  Following file renames was disfunctional.  It is still not really working, we can only follow *one* rename.  After that `file_path` is out of sync with what we actually show, and calling `previous_commit` with `(original file name>, <new commit hash>)` cannot work anymore.

- Removed all (🤞) wait times (`set_timeout_async` with a `delay`) because why.  For example why fixing the viewport postition 100ms after drawing?

- Mark chunk from the current blamed commit visually; here with `(CURRENT COMMIT)`
- Support blaming the workdir (checked out, "live") revision of the file
- Actually start with that "live" version when using the command in the Command Palette.  Why asking for a commit here?  We wouldn't call blame if we actually knew a good revision to look at.
- Bind `[h]` to move the cursor to a current change.
- Bind `[g]` to open the graph showing the commit under the cursor

Blaming is still too slow; usually `git log --follow` being the slowest call here.  This looks misleading because `git blame` gives us a correct filename for each chunk it finds.  (A comment here states that "blame" would *not* follow renames; but in fact "blame" *always* follows renames.)  We should use all the information `git` gives us.


 