### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - run: pip install "flake8<6.0.0"
     - uses: TrueBrain/actions-flake8@v2
 
   mypy:

--- a/mypy.ini
+++ b/mypy.ini
@@ -7,6 +7,7 @@ mypy_path =
     stubs,
     ..
 sqlite_cache = True
+implicit_optional = True
 
 [mypy-yaml]
 ignore_missing_imports = True


### PR DESCRIPTION
- Pin flake8 to `<6.0.0` as the newer version doesn't support type comments anymore.  (Unfortunately there was never a deprecation.)
- mypy 0.991 sets a new default for implicit optionals.  Revert that to get green again quickly.