### PR TITLE
Change one type ignore line because mypy update

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -273,7 +273,7 @@ def focus_view(view):
 
 
 if int(sublime.version()) < 4000:
-    from Default import history_list  # type: ignore[attr-defined]
+    from Default import history_list  # type: ignore
 
     def add_selection_to_jump_history(view):
         history_list.get_jump_history_for_view(view).push_selection(view)


### PR DESCRIPTION
The newer mypy 0.991 wants an `ignore[attr-defined]` on my local machine where "Default" has some local overrides.

On CI there are no overrides and mypy wants `ignore[import]` then.

Just use a wildcard ignore as this is for a compatibility layer anyway.

Fixes #1684 