### PR TITLE
Add "create branch" and "move branch" commands to the graph view

### DIFF
--- a/core/commands/branch.py
+++ b/core/commands/branch.py
@@ -20,6 +20,7 @@ __all__ = (
 MYPY = False
 if MYPY:
     from typing import Callable, TypeVar
+    from GitSavvy.core.base_commands import Args, Kont
     T = TypeVar("T")
 
 
@@ -41,7 +42,7 @@ def just(value):
 
 def ask_for_name(caption=just(NEW_BRANCH_PROMPT), initial_text=just("")):
     def handler(cmd, args, done, initial_text_=None):
-        # type: (GsWindowCommand, push.Args, push.Kont, str) -> None
+        # type: (GsWindowCommand, Args, Kont, str) -> None
         def done_(branch_name):
             branch_name = branch_name.strip().replace(" ", "-")
             if not branch_name:

--- a/core/commands/branch.py
+++ b/core/commands/branch.py
@@ -1,7 +1,6 @@
 import re
 import sublime
 
-from . import checkout
 from . import push
 from ..git_command import GitSavvyError
 from ..ui_mixins.input_panel import show_single_line_input_panel
@@ -24,6 +23,8 @@ if MYPY:
     T = TypeVar("T")
 
 
+NEW_BRANCH_PROMPT = "Branch name:"
+NEW_BRANCH_INVALID = "`{}` is a invalid branch name.\nRead more on $(man git-check-ref-format)"
 DELETE_UNDO_MESSAGE = """\
 GitSavvy: Deleted branch ({0}), in case you want to undo, run:
   $ git branch {0} {1}
@@ -46,7 +47,7 @@ def ask_for_name(caption, initial_text=just("")):
             if not branch_name:
                 return None
             if not cmd.validate_branch_name(branch_name):
-                sublime.error_message(checkout.NEW_BRANCH_INVALID.format(branch_name))
+                sublime.error_message(NEW_BRANCH_INVALID.format(branch_name))
                 handler(cmd, args, done, initial_text_=branch_name)
                 return None
             done(branch_name)
@@ -62,7 +63,7 @@ def ask_for_name(caption, initial_text=just("")):
 class gs_create_branch(GsWindowCommand):
     defaults = {
         "branch_name": ask_for_name(
-            caption=just(checkout.NEW_BRANCH_PROMPT),
+            caption=just(NEW_BRANCH_PROMPT),
         ),
     }
 

--- a/core/commands/branch.py
+++ b/core/commands/branch.py
@@ -39,7 +39,7 @@ def just(value):
     return lambda *args, **kwargs: value
 
 
-def ask_for_name(caption, initial_text=just("")):
+def ask_for_name(caption=just(NEW_BRANCH_PROMPT), initial_text=just("")):
     def handler(cmd, args, done, initial_text_=None):
         # type: (GsWindowCommand, push.Args, push.Kont, str) -> None
         def done_(branch_name):
@@ -62,9 +62,7 @@ def ask_for_name(caption, initial_text=just("")):
 
 class gs_create_branch(GsWindowCommand):
     defaults = {
-        "branch_name": ask_for_name(
-            caption=just(NEW_BRANCH_PROMPT),
-        ),
+        "branch_name": ask_for_name(),
     }
 
     def run(self, branch_name, start_point=None):

--- a/core/commands/checkout.py
+++ b/core/commands/checkout.py
@@ -4,7 +4,7 @@ import sublime
 from sublime_plugin import WindowCommand
 
 from . import intra_line_colorizer
-from . import branch
+from .branch import ask_for_name
 from .log import LogMixin
 from ..git_command import GitCommand, GitSavvyError
 from ..ui_mixins.quick_panel import show_branch_panel
@@ -75,7 +75,7 @@ class gs_checkout_new_branch(GsWindowCommand):
     Prompt the user for a new branch name, create it, and check it out.
     """
     defaults = {
-        "branch_name": branch.ask_for_name(),
+        "branch_name": ask_for_name(),
     }
 
     def run(self, branch_name, start_point=None, force=False, merge=False):
@@ -119,7 +119,7 @@ class gs_checkout_remote_branch(GsWindowCommand):
     """
     defaults = {
         "remote_branch": ask_for_branch(remote_branches_only=True),
-        "branch_name": branch.ask_for_name(
+        "branch_name": ask_for_name(
             initial_text=lambda args: args["remote_branch"].split("/", 1)[1],
         ),
     }

--- a/core/commands/checkout.py
+++ b/core/commands/checkout.py
@@ -75,9 +75,7 @@ class gs_checkout_new_branch(GsWindowCommand):
     Prompt the user for a new branch name, create it, and check it out.
     """
     defaults = {
-        "branch_name": branch.ask_for_name(
-            caption=branch.just(branch.NEW_BRANCH_PROMPT),
-        ),
+        "branch_name": branch.ask_for_name(),
     }
 
     def run(self, branch_name, start_point=None, force=False, merge=False):
@@ -122,7 +120,6 @@ class gs_checkout_remote_branch(GsWindowCommand):
     defaults = {
         "remote_branch": ask_for_branch(remote_branches_only=True),
         "branch_name": branch.ask_for_name(
-            caption=branch.just(branch.NEW_BRANCH_PROMPT),
             initial_text=lambda args: args["remote_branch"].split("/", 1)[1],
         ),
     }

--- a/core/commands/checkout.py
+++ b/core/commands/checkout.py
@@ -4,6 +4,7 @@ import sublime
 from sublime_plugin import WindowCommand
 
 from . import intra_line_colorizer
+from . import branch
 from .log import LogMixin
 from ..git_command import GitCommand, GitSavvyError
 from ..ui_mixins.quick_panel import show_branch_panel
@@ -21,10 +22,6 @@ __all__ = (
     "gs_checkout_current_file_at_commit",
     "gs_show_file_diff",
 )
-
-
-NEW_BRANCH_PROMPT = "Branch name:"
-NEW_BRANCH_INVALID = "`{}` is a invalid branch name.\nRead more on $(man git-check-ref-format)"
 
 
 class gs_checkout_branch(WindowCommand, GitCommand):
@@ -127,13 +124,13 @@ class gs_checkout_remote_branch(WindowCommand, GitCommand):
         if not local_name:
             local_name = remote_branch.split("/", 1)[1]
         show_single_line_input_panel(
-            NEW_BRANCH_PROMPT,
+            branch.NEW_BRANCH_PROMPT,
             local_name,
             self.on_enter_local_name)
 
     def on_enter_local_name(self, branch_name):
         if not self.validate_branch_name(branch_name):
-            sublime.error_message(NEW_BRANCH_INVALID.format(branch_name))
+            sublime.error_message(branch.NEW_BRANCH_INVALID.format(branch_name))
             sublime.set_timeout_async(
                 lambda: self.on_branch_selection(self.remote_branch, branch_name), 100)
             return None

--- a/core/commands/checkout.py
+++ b/core/commands/checkout.py
@@ -120,7 +120,7 @@ class gs_checkout_remote_branch(GsWindowCommand):
     defaults = {
         "remote_branch": ask_for_branch(remote_branches_only=True),
         "branch_name": ask_for_name(
-            initial_text=lambda args: args["remote_branch"].split("/", 1)[1],
+            initial_text=lambda remote_branch: remote_branch.split("/", 1)[1],
         ),
     }
 

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -2460,9 +2460,12 @@ class gs_log_graph_action(WindowCommand, GitCommand):
     def checkout(self, commit_hash):
         self.window.run_command("gs_checkout_branch", {"branch": commit_hash})
 
-    def checkout_b(self, branch_name):
-        self.git("checkout", "-B", branch_name)
-        util.view.refresh_gitsavvy_interfaces(self.window, refresh_sidebar=True)
+    def checkout_b(self, branch_name, start_point=None):
+        self.window.run_command("gs_checkout_new_branch", {
+            "branch_name": branch_name,
+            "start_point": start_point,
+            "force": True,
+        })
 
     def move_branch(self, branch_name, target):
         self.git("branch", "-f", branch_name, target)

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -2345,6 +2345,10 @@ class gs_log_graph_action(WindowCommand, GitCommand):
             ]
 
         actions += [
+            (
+                "Create branch at '{}'".format(good_commit_name),
+                partial(self.create_branch, commit_hash)
+            ),
             ("Create tag", partial(self.create_tag, commit_hash))
         ]
         actions += [
@@ -2469,6 +2473,9 @@ class gs_log_graph_action(WindowCommand, GitCommand):
 
     def show_commit(self, commit_hash):
         self.window.run_command("gs_show_commit", {"commit_hash": commit_hash})
+
+    def create_branch(self, commit_hash):
+        self.window.run_command("gs_create_branch", {"start_point": commit_hash})
 
     def create_tag(self, commit_hash):
         self.window.run_command("gs_tag_create", {"target_commit": commit_hash})

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -303,7 +303,7 @@ class gs_branches_create_new(BranchInterfaceCommand):
         if branch.is_remote:
             self.window.run_command("gs_checkout_remote_branch", {"remote_branch": branch.canonical_name})
         else:
-            self.window.run_command("gs_checkout_new_branch", {"base_branch": branch.name})
+            self.window.run_command("gs_checkout_new_branch", {"start_point": branch.name})
 
 
 class gs_branches_delete(BranchInterfaceCommand):


### PR DESCRIPTION
Fixes #1683

The create branch is similar to create tag, it labels the commit without 
checking out the branch which was not possible within GitSavvy before.

We actually had a "move" action which was a bit awkward.  Restrict the
latter to show up only when HEAD is detached and you basically pull
a branch to your position.

That was the only useful function of the feature anyway:  you checked
out the upstream and then wanted to move the local branch label to it.

Or you tested out a previous commit and then "reset" a branch to that
position.