### PR TITLE
Learn usage of `--rebase-merges` and `--update-refs`

### DIFF
--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -37,7 +37,7 @@ from ..view import (
 )
 from ..ui_mixins.input_panel import show_single_line_input_panel
 from ..ui_mixins.quick_panel import show_branch_panel
-from ..utils import add_selection_to_jump_history, focus_view, show_toast, Cache
+from ..utils import add_selection_to_jump_history, focus_view, show_toast, Cache, SEPARATOR
 from ...common import util
 from ...common.theme_generator import ThemeGenerator
 
@@ -2275,7 +2275,7 @@ class gs_log_graph_action(WindowCommand, GitCommand):
                 ("Fetch", partial(self.fetch, info["HEAD"])),
                 ("Pull", self.pull),
                 ("Push", partial(self.push, info["HEAD"])),
-                ("-" * 75, self.noop),
+                SEPARATOR,
             ]
 
         actions += [
@@ -2436,9 +2436,6 @@ class gs_log_graph_action(WindowCommand, GitCommand):
             "remote": remote,
             "refspec": "{}:{}".format(remote_name, local_name)
         })
-
-    def noop(self):
-        return
 
     def checkout(self, commit_hash):
         self.window.run_command("gs_checkout_branch", {"branch": commit_hash})

--- a/core/commands/log_graph_rebase_actions.py
+++ b/core/commands/log_graph_rebase_actions.py
@@ -239,7 +239,14 @@ class gs_rebase_action(GsWindowCommand):
                 else ""
             )
             previous_tip = "{}@{{1}}".format(current_branch)
-            if previous_tip not in filters:
+            if previous_tip in filters:
+                actions += [
+                    (
+                        "Hide {} in the graph".format(previous_tip),
+                        partial(self.remove_previous_tip, view, previous_tip)
+                    )
+                ]
+            else:
                 actions += [
                     (
                         "Show previous tip of {} in the graph".format(current_branch),
@@ -326,6 +333,13 @@ class gs_rebase_action(GsWindowCommand):
             settings.set("git_savvy.log_graph_view.paths", [])
             settings.set("git_savvy.log_graph_view.filter_by_author", "")
 
+        view.run_command("gs_log_graph_refresh")
+
+    def remove_previous_tip(self, view, previous_tip):
+        settings = view.settings()
+        filters = settings.get("git_savvy.log_graph_view.filters", "")
+        new_filters = ' '.join(s for s in shlex.split(filters) if s != previous_tip)
+        settings.set("git_savvy.log_graph_view.filters", new_filters)
         view.run_command("gs_log_graph_refresh")
 
 

--- a/core/commands/log_graph_rebase_actions.py
+++ b/core/commands/log_graph_rebase_actions.py
@@ -533,7 +533,7 @@ class gs_rebase_quick_action(GsTextCommand, RebaseCommand):
             return
 
         def program():
-            with await_todo_list(action):
+            with await_todo_list(partial(action, commit_hash)):
                 self.rebase(
                     '--interactive',
                     "--autostash",
@@ -567,8 +567,8 @@ def format_rebase_items(items):
     )
 
 
-def change_first_action(new_action, buffer_content):
-    # type: (str, str) -> str
+def change_first_action(new_action, base_commit, buffer_content):
+    # type: (str, str, str) -> str
     items = _parse_buffer(buffer_content)
     return format_rebase_items(_change_first_action(new_action, items))
 
@@ -578,8 +578,8 @@ def _change_first_action(new_action, items):
     return [items[0]._replace(action=new_action)] + items[1:]
 
 
-def fixup_commits(fixup_commits, buffer_content):
-    # type: (List[Commit], str) -> str
+def fixup_commits(fixup_commits, base_commit, buffer_content):
+    # type: (List[Commit], str, str) -> str
     items = _parse_buffer(buffer_content)
     return format_rebase_items(_fixup_commits(fixup_commits, items))
 

--- a/core/commands/log_graph_rebase_actions.py
+++ b/core/commands/log_graph_rebase_actions.py
@@ -682,7 +682,7 @@ class gs_rebase_just_autosquash(GsTextCommand, RebaseCommand):
                     if self.git_version >= VERSION_WITH_UPDATE_REFS else
                     None
                 ),
-                "{}".format(commitish),
+                commitish,
                 custom_environ={"GIT_SEQUENCE_EDITOR": ":"}
             )
 
@@ -762,7 +762,7 @@ class gs_rebase_interactive(GsTextCommand, RebaseCommand):
                 None
             ),
             yes_no_switch("--update-refs", update_refs),
-            "{}".format(commitish),
+            commitish,
             offer_autostash=True,
         )
 
@@ -789,7 +789,7 @@ class gs_rebase_interactive_onto_branch(GsTextCommand, RebaseCommand):
                 None
             ),
             yes_no_switch("--update-refs", update_refs),
-            "{}".format(commitish),
+            commitish,
             "--onto",
             onto,
             offer_autostash=True,

--- a/core/commands/log_graph_rebase_actions.py
+++ b/core/commands/log_graph_rebase_actions.py
@@ -676,6 +676,13 @@ class gs_rebase_skip(sublime_plugin.WindowCommand, RebaseCommand):
         self.rebase('--skip')
 
 
+ask_for_local_branch = ask_for_branch(
+    local_branches_only=True,
+    ignore_current_branch=True,
+    memorize_key="last_local_branch_for_rebase"
+)
+
+
 class gs_rebase_interactive(GsTextCommand, RebaseCommand):
     defaults = {
         "commitish": extract_parent_symbol_from_graph,
@@ -689,13 +696,6 @@ class gs_rebase_interactive(GsTextCommand, RebaseCommand):
             "{}".format(commitish),
             offer_autostash=True,
         )
-
-
-ask_for_local_branch = ask_for_branch(
-    local_branches_only=True,
-    ignore_current_branch=True,
-    memorize_key="last_local_branch_for_rebase"
-)
 
 
 class gs_rebase_interactive_onto_branch(GsTextCommand, RebaseCommand):

--- a/core/commands/log_graph_rebase_actions.py
+++ b/core/commands/log_graph_rebase_actions.py
@@ -512,6 +512,7 @@ class AwaitTodoListView(sublime_plugin.EventListener):
 class gs_rebase_quick_action(GsTextCommand, RebaseCommand):
     action = None  # type: QuickAction
     autosquash = False
+    rebase_merges = False
     defaults = {
         "commit_hash": extract_commit_hash_from_graph,
     }
@@ -530,6 +531,7 @@ class gs_rebase_quick_action(GsTextCommand, RebaseCommand):
             with await_todo_list(partial(action, commit_hash)):
                 self.rebase(
                     '--interactive',
+                    "--rebase-merges" if self.rebase_merges else "--no-rebase-merges",
                     "--autostash",
                     "--autosquash" if self.autosquash else "--no-autosquash",
                     "{}^".format(commit_hash),
@@ -576,21 +578,25 @@ def fixup_commits(fixup_commits, base_commit, buffer_content):
 class gs_rebase_edit_commit(gs_rebase_quick_action):
     action = partial(change_first_action, "edit")
     autosquash = False
+    rebase_merges = True
 
 
 class gs_rebase_drop_commit(gs_rebase_quick_action):
     action = partial(change_first_action, "drop")
     autosquash = False
+    rebase_merges = True
 
 
 class gs_rebase_reword_commit(gs_rebase_quick_action):
     action = partial(change_first_action, "reword")
     autosquash = False
+    rebase_merges = True
 
 
 class gs_rebase_apply_fixup(gs_rebase_quick_action):
     action = partial(fixup_commits)
     autosquash = False
+    rebase_merges = True
 
     def run(self, edit, base_commit, fixes):
         self.action = partial(self.action, [Commit(*fix) for fix in fixes])
@@ -613,6 +619,7 @@ class gs_rebase_just_autosquash(GsTextCommand, RebaseCommand):
                 '--interactive',
                 "--autostash",
                 "--autosquash",
+                "--rebase-merges",
                 "{}".format(commitish),
                 custom_environ={"GIT_SEQUENCE_EDITOR": ":"}
             )

--- a/core/commands/log_graph_rebase_actions.py
+++ b/core/commands/log_graph_rebase_actions.py
@@ -10,14 +10,12 @@ import sublime
 import sublime_plugin
 
 from GitSavvy.common import util
-from GitSavvy.core import store
-from GitSavvy.core.base_commands import GsTextCommand, GsWindowCommand
+from GitSavvy.core.base_commands import GsTextCommand, GsWindowCommand, ask_for_branch
 from GitSavvy.core.commands import log_graph
 from GitSavvy.core.fns import filter_
 from GitSavvy.core.git_command import GitCommand, GitSavvyError
 from GitSavvy.core.parse_diff import TextRange
 from GitSavvy.core.runtime import on_new_thread, run_on_new_thread, throttled
-from GitSavvy.core.ui_mixins.quick_panel import show_branch_panel
 from GitSavvy.core.utils import flash, noop, show_actions_panel, yes_no_switch, SEPARATOR
 from GitSavvy.core.view import replace_view_content
 
@@ -693,19 +691,11 @@ class gs_rebase_interactive(GsTextCommand, RebaseCommand):
         )
 
 
-def ask_for_local_branch(self, args, done):
-    # type: (GsCommand, Args, Kont) -> None
-    def on_done(branch):
-        store.update_state(self.repo_path, {"last_local_branch_for_rebase": branch})
-        done(branch)
-
-    selected_branch = store.current_state(self.repo_path).get("last_local_branch_for_rebase")
-    show_branch_panel(
-        on_done,
-        local_branches_only=True,
-        ignore_current_branch=True,
-        selected_branch=selected_branch
-    )
+ask_for_local_branch = ask_for_branch(
+    local_branches_only=True,
+    ignore_current_branch=True,
+    memorize_key="last_local_branch_for_rebase"
+)
 
 
 class gs_rebase_interactive_onto_branch(GsTextCommand, RebaseCommand):

--- a/core/commands/log_graph_rebase_actions.py
+++ b/core/commands/log_graph_rebase_actions.py
@@ -188,7 +188,6 @@ class gs_rebase_action(GsWindowCommand):
                 "Make fixup commit for {}".format(commit_hash),
                 partial(self.create_fixup_commit, commit_hash)
             ),
-            SEPARATOR,
         ]
 
         head_info = log_graph.describe_head(view, {})
@@ -208,6 +207,7 @@ class gs_rebase_action(GsWindowCommand):
             ]
 
         actions += [
+            SEPARATOR,
             (
                 "[R]ebase from {} on interactive".format(parent_commitish),
                 partial(self.rebase_interactive, view, parent_commitish)
@@ -228,6 +228,10 @@ class gs_rebase_action(GsWindowCommand):
             else None
         )
         if current_branch:
+            actions += [
+                SEPARATOR,
+            ]
+
             settings = view.settings()
             applying_filters = settings.get("git_savvy.log_graph_view.apply_filters")
             filters = (

--- a/core/commands/log_graph_rebase_actions.py
+++ b/core/commands/log_graph_rebase_actions.py
@@ -513,30 +513,6 @@ class AwaitTodoListView(sublime_plugin.EventListener):
             view.close()
 
 
-def extract_rebase_items_from_view(view):
-    # type: (sublime.View) -> List[RebaseItem]
-    buffer_content = view.substr(sublime.Region(0, view.size()))
-    return [
-        RebaseItem(*line.split(" ", 2))
-        for line in takewhile(
-            lambda line: bool(line.strip()),
-            buffer_content.splitlines(keepends=True)
-        )
-    ]
-
-
-def ensure_newline(text):
-    # type: (str) -> str
-    return text if text.endswith("\n") else "{}\n".format(text)
-
-
-def format_rebase_items(items):
-    # type: (List[RebaseItem]) -> str
-    return "".join(
-        ensure_newline(" ".join(item)) for item in items
-    )
-
-
 class gs_rebase_quick_action(GsTextCommand, RebaseCommand):
     action = None  # type: QuickAction
     autosquash = False
@@ -564,6 +540,30 @@ class gs_rebase_quick_action(GsTextCommand, RebaseCommand):
                 )
 
         run_on_new_thread(program)
+
+
+def extract_rebase_items_from_view(view):
+    # type: (sublime.View) -> List[RebaseItem]
+    buffer_content = view.substr(sublime.Region(0, view.size()))
+    return [
+        RebaseItem(*line.split(" ", 2))
+        for line in takewhile(
+            lambda line: bool(line.strip()),
+            buffer_content.splitlines(keepends=True)
+        )
+    ]
+
+
+def ensure_newline(text):
+    # type: (str) -> str
+    return text if text.endswith("\n") else "{}\n".format(text)
+
+
+def format_rebase_items(items):
+    # type: (List[RebaseItem]) -> str
+    return "".join(
+        ensure_newline(" ".join(item)) for item in items
+    )
 
 
 def change_first_action(new_action, items):

--- a/core/commands/log_graph_rebase_actions.py
+++ b/core/commands/log_graph_rebase_actions.py
@@ -18,7 +18,7 @@ from GitSavvy.core.git_command import GitCommand, GitSavvyError
 from GitSavvy.core.parse_diff import TextRange
 from GitSavvy.core.runtime import on_new_thread, run_on_new_thread, throttled
 from GitSavvy.core.ui_mixins.quick_panel import show_branch_panel
-from GitSavvy.core.utils import flash, noop, show_actions_panel
+from GitSavvy.core.utils import flash, noop, show_actions_panel, SEPARATOR
 from GitSavvy.core.view import replace_view_content
 
 
@@ -129,9 +129,6 @@ def get_view_for_command(cmd):
         return cmd.window.active_view()
     else:
         return sublime.active_window().active_view()
-
-
-SEPARATOR = ("-" * 75, lambda: None)
 
 
 class gs_rebase_action(GsWindowCommand):

--- a/core/commands/log_graph_rebase_actions.py
+++ b/core/commands/log_graph_rebase_actions.py
@@ -18,7 +18,7 @@ from GitSavvy.core.git_command import GitCommand, GitSavvyError
 from GitSavvy.core.parse_diff import TextRange
 from GitSavvy.core.runtime import on_new_thread, run_on_new_thread, throttled
 from GitSavvy.core.ui_mixins.quick_panel import show_branch_panel
-from GitSavvy.core.utils import flash, noop, show_actions_panel, SEPARATOR
+from GitSavvy.core.utils import flash, noop, show_actions_panel, yes_no_switch, SEPARATOR
 from GitSavvy.core.view import replace_view_content
 
 
@@ -546,9 +546,9 @@ class gs_rebase_quick_action(GsTextCommand, RebaseCommand):
             with await_todo_list(partial(action, commit_hash)):
                 self.rebase(
                     '--interactive',
-                    "--rebase-merges" if self.rebase_merges else "--no-rebase-merges",
+                    yes_no_switch("--rebase-merges", self.rebase_merges),
                     "--autostash",
-                    "--autosquash" if self.autosquash else "--no-autosquash",
+                    yes_no_switch("--autosquash", self.autosquash),
                     "{}^".format(commit_hash),
                 )
 

--- a/core/commands/log_graph_rebase_actions.py
+++ b/core/commands/log_graph_rebase_actions.py
@@ -563,8 +563,8 @@ class AwaitTodoListView(sublime_plugin.EventListener):
 class gs_rebase_quick_action(GsTextCommand, RebaseCommand):
     action = None  # type: QuickAction
     autosquash = False
-    rebase_merges = False
-    update_refs = False
+    rebase_merges = True
+    update_refs = True
     defaults = {
         "commit_hash": extract_commit_hash_from_graph,
     }
@@ -642,30 +642,18 @@ def fixup_commits(fixup_commits, base_commit, buffer_content):
 
 class gs_rebase_edit_commit(gs_rebase_quick_action):
     action = partial(change_first_action, "edit")
-    autosquash = False
-    rebase_merges = True
-    update_refs = True
 
 
 class gs_rebase_drop_commit(gs_rebase_quick_action):
     action = partial(change_first_action, "drop")
-    autosquash = False
-    rebase_merges = True
-    update_refs = True
 
 
 class gs_rebase_reword_commit(gs_rebase_quick_action):
     action = partial(change_first_action, "reword")
-    autosquash = False
-    rebase_merges = True
-    update_refs = True
 
 
 class gs_rebase_apply_fixup(gs_rebase_quick_action):
     action = partial(fixup_commits)
-    autosquash = False
-    rebase_merges = True
-    update_refs = True
 
     def run(self, edit, base_commit, fixes):
         self.action = partial(self.action, [Commit(*fix) for fix in fixes])

--- a/core/utils.py
+++ b/core/utils.py
@@ -284,6 +284,9 @@ def noop(description):
     return Action(description, lambda: None)
 
 
+SEPARATOR = noop("_" * 74)
+
+
 def focus_view(view):
     # type: (sublime.View) -> None
     window = view.window()

--- a/core/utils.py
+++ b/core/utils.py
@@ -19,7 +19,7 @@ from .runtime import throttled
 
 MYPY = False
 if MYPY:
-    from typing import Callable, Dict, Iterator, Tuple, Type
+    from typing import Callable, Dict, Iterator, Optional, Tuple, Type
 
 
 @contextmanager
@@ -285,6 +285,16 @@ def noop(description):
 
 
 SEPARATOR = noop("_" * 74)
+
+
+def yes_no_switch(name, value):
+    # type: (str, Optional[bool]) -> Optional[str]
+    assert name.startswith("--")
+    if value is None:
+        return None
+    if value:
+        return name
+    return "--no-{}".format(name[2:])
 
 
 def focus_view(view):

--- a/tests/test_graph_rebase_actions.py
+++ b/tests/test_graph_rebase_actions.py
@@ -1,0 +1,104 @@
+from textwrap import dedent
+
+from unittesting import DeferrableTestCase
+from GitSavvy.tests.parameterized import parameterized as p
+
+from GitSavvy.core.commands.log_graph_rebase_actions import (
+    change_first_action, fixup_commits, Commit
+)
+
+
+fixup_examples = [
+    (
+        [Commit("6c8cb2e7", "fixup! Look upwards in the graph for potential fixup..")],
+        "056c8f6d",
+        dedent("""\
+        pick 056c8f6d Look upwards in the graph for potential fixup commits
+        pick 496d0266 Remove the padding as it has no effect
+        pick 2ed5650d fixup! Look upwards in the graph for potential fixup commits
+        pick 0d721988 fixup! Look upwards in the graph for potential fixup commits
+        pick fc5da4c3 Simplify `gs_reset_branch`
+        pick 8e5e700b Fix typo in `reverse_adjust_line_according_to_hunks`
+        pick 6c8cb2e7 fixup! Look upwards in the graph for potential fixup commits
+        pick 19978225 Check `returncode` to decide if `git log` failed
+
+        # Rebase 6bd508b2..0b0409f8 onto 6bd508b2 (8 commands)
+        """),
+        dedent("""\
+        pick 056c8f6d Look upwards in the graph for potential fixup commits
+        fixup 6c8cb2e7 fixup! Look upwards in the graph for potential fixup..
+        pick 496d0266 Remove the padding as it has no effect
+        pick 2ed5650d fixup! Look upwards in the graph for potential fixup commits
+        pick 0d721988 fixup! Look upwards in the graph for potential fixup commits
+        pick fc5da4c3 Simplify `gs_reset_branch`
+        pick 8e5e700b Fix typo in `reverse_adjust_line_according_to_hunks`
+        pick 19978225 Check `returncode` to decide if `git log` failed
+
+        """),
+    ),
+]
+
+quick_examples = [
+    (
+        "reword",
+        "0b0409f8",
+        dedent("""\
+        pick 0b0409f8 Let `QuickAction` be a function `str -> str` for flexibility
+
+        # Rebase fee0447b..0b0409f8 onto fee0447b (1 command)
+        """),
+        dedent("""\
+        reword 0b0409f8 Let `QuickAction` be a function `str -> str` for flexibility
+
+        """)
+    ),
+    (
+        "edit",
+        "142972fd",
+        dedent("""\
+        pick 142972fd Mark first arg of continuation function "positional only"
+        pick fee0447b Simplify `ask_for_local_branch`
+        pick 0b0409f8 Let `QuickAction` be a function `str -> str` for flexibility
+
+        # Rebase 2bcb7211..0b0409f8 onto 2bcb7211 (3 commands)
+        """),
+        dedent("""\
+        edit 142972fd Mark first arg of continuation function "positional only"
+        pick fee0447b Simplify `ask_for_local_branch`
+        pick 0b0409f8 Let `QuickAction` be a function `str -> str` for flexibility
+
+        """)
+    ),
+    (
+        "drop",
+        "fee0447b",
+        dedent("""\
+        label onto
+
+        reset onto
+        pick fee0447b Simplify `ask_for_local_branch`
+        pick 0b0409f8 Let `QuickAction` be a function `str -> str` for flexibility
+        """),
+        dedent("""\
+        label onto
+
+        reset onto
+        drop fee0447b Simplify `ask_for_local_branch`
+        pick 0b0409f8 Let `QuickAction` be a function `str -> str` for flexibility
+        """)
+    ),
+]
+
+
+class TestRebaseActions(DeferrableTestCase):
+    @p.expand(fixup_examples)
+    def test_applying_fixups(self, fixups, base_commit, input, expected):
+        actual = fixup_commits(fixups, base_commit, input)
+        self.maxDiff = None
+        self.assertEqual(expected, actual)
+
+    @p.expand(quick_examples)
+    def test_applying_quick_actions(self, action, base_commit, input, expected):
+        actual = change_first_action(action, base_commit, input)
+        self.maxDiff = None
+        self.assertEqual(expected, actual)


### PR DESCRIPTION
The rebase now looks like this

![image](https://user-images.githubusercontent.com/8558/206800817-92cea44e-f4f3-4376-b423-1b40dad66f22.png)

For the quick actions (like re[W]ord, [D]rop) the flags are not switchable but GitSavvy will use whatever is needed- and supported because `update-refs` requires git to be >=2.38.0.

For the other commands we have the checkboxes but of course you don't have to deselect `rebase-merges` if there aren't any merge commits in the commit range you actually reapply here.  Or no refs to update. 

The update-refs feature is pretty awesome, you can put multiple feature branches on top of each other and apply fixes to older (not checked out) branches and it will put the other branch labels (refs) in place.  Or you can extract a branch from a series of commits.  

For example: for the just now sprint this PR is part of I worked basically on a `pu` (`dev`) branch:

![image](https://user-images.githubusercontent.com/8558/206801751-d81ac033-6d7d-43f2-acc8-6f5004f8c13f.png)

T.i. I have several branches which mark different features.  All features are checked out and the fixups etc can be moved to the feature branch while the top branch is still checked out. 

I can also extract one feature branch and make a PR.  

E.g. extracting one branch

![image](https://user-images.githubusercontent.com/8558/206802408-f4d38ce4-54e9-4dd0-88d8-2f7d004d2544.png)


Being on top of the pu series I can even `rebase master` and it moves the complete `pu` branch - all its branches - at once.