### PR TITLE
Tune navigating in views showing patches

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1825,7 +1825,7 @@
     },
     {
         "keys": ["."],
-        "command": "gs_diff_navigate",
+        "command": "gs_line_history_navigate",
         "args": { "forward": true },
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
@@ -1834,7 +1834,7 @@
     },
     {
         "keys": [","],
-        "command": "gs_diff_navigate",
+        "command": "gs_line_history_navigate",
         "args": { "forward": false },
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
@@ -1843,7 +1843,7 @@
     },
     {
         "keys": ["j"],
-        "command": "gs_diff_navigate",
+        "command": "gs_line_history_navigate",
         "args": { "forward": true },
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
@@ -1853,7 +1853,7 @@
     },
     {
         "keys": ["k"],
-        "command": "gs_diff_navigate",
+        "command": "gs_line_history_navigate",
         "args": { "forward": false },
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -14,7 +14,7 @@ from sublime_plugin import WindowCommand, TextCommand, EventListener
 from . import intra_line_colorizer
 from . import stage_hunk
 from .navigate import GsNavigate
-from ..fns import filter_, flatten, unique
+from ..fns import filter_, flatten, pairwise, unique
 from ..parse_diff import SplittedDiff
 from ..git_command import GitCommand
 from ..runtime import enqueue_on_ui, enqueue_on_worker
@@ -880,7 +880,17 @@ class gs_diff_navigate(GsNavigate):
     wrap_with_force = True
 
     def get_available_regions(self):
-        return self.view.find_by_selector("meta.diff.range.unified, meta.commit-info.header")
+        return [
+            sublime.Region(a.a, b.a - 1)
+            for a, b in pairwise(
+                chain(
+                    self.view.find_by_selector(
+                        "meta.diff.range.unified, meta.commit-info.header"
+                    ),
+                    [sublime.Region(self.view.size())]
+                )
+            )
+        ]
 
 
 class gs_diff_undo(TextCommand, GitCommand):

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -877,6 +877,7 @@ class gs_diff_navigate(GsNavigate):
     """
 
     offset = 0
+    wrap_with_force = True
 
     def get_available_regions(self):
         return self.view.find_by_selector("meta.diff.range.unified, meta.commit-info.header")

--- a/core/commands/navigate.py
+++ b/core/commands/navigate.py
@@ -16,7 +16,7 @@ class GsNavigate(TextCommand, GitCommand):
     """
 
     offset = 4
-    show_at_center = True
+    show_at_center = False
     wrap = True
     wrap_with_force = False
     _just_jumped = 0

--- a/core/commands/navigate.py
+++ b/core/commands/navigate.py
@@ -22,6 +22,7 @@ class GsNavigate(TextCommand, GitCommand):
     _just_jumped = 0
 
     def run(self, edit, forward=True):
+        self.forward = forward
         sel = self.view.sel()
         current_position = sel[0].a
 
@@ -30,9 +31,9 @@ class GsNavigate(TextCommand, GitCommand):
             return
 
         wanted_section = (
-            self.forward(current_position, available_regions)
+            self.next_region(current_position, available_regions)
             if forward
-            else self.backward(current_position, available_regions)
+            else self.previous_region(current_position, available_regions)
         )
         if wanted_section is None:
             if self._just_jumped == 1:
@@ -63,7 +64,7 @@ class GsNavigate(TextCommand, GitCommand):
         # type: () -> Sequence[sublime.Region]
         raise NotImplementedError()
 
-    def forward(self, current_position, regions):
+    def next_region(self, current_position, regions):
         # type: (sublime.Point, Sequence[sublime.Region]) -> Optional[sublime.Region]
         for region in regions:
             if region.a > current_position:
@@ -71,7 +72,7 @@ class GsNavigate(TextCommand, GitCommand):
 
         return regions[0] if self._wrap_around_now() else None
 
-    def backward(self, current_position, regions):
+    def previous_region(self, current_position, regions):
         # type: (sublime.Point, Sequence[sublime.Region]) -> Optional[sublime.Region]
         for region in reversed(regions):
             if region.a < current_position:

--- a/core/commands/navigate.py
+++ b/core/commands/navigate.py
@@ -51,7 +51,13 @@ class GsNavigate(TextCommand, GitCommand):
         if self.show_at_center:
             self.view.show_at_center(new_cursor_position)
         else:
-            show_region(self.view, wanted_section)
+            # For the first entry, try to show the beginning of the buffer.
+            # (Usually we have some info/help text there.)
+            if wanted_section == available_regions[0]:
+                wanted_section = sublime.Region(0, wanted_section.a)
+                show_region(self.view, wanted_section, context=2, prefer_end=True)
+            else:
+                show_region(self.view, wanted_section, context=2)
 
     def get_available_regions(self):
         # type: () -> Sequence[sublime.Region]

--- a/core/commands/navigate.py
+++ b/core/commands/navigate.py
@@ -74,7 +74,7 @@ class GsNavigate(TextCommand, GitCommand):
     def backward(self, current_position, regions):
         # type: (sublime.Point, Sequence[sublime.Region]) -> Optional[sublime.Region]
         for region in reversed(regions):
-            if region.b < current_position:
+            if region.a < current_position:
                 return region
 
         return regions[-1] if self._wrap_around_now() else None

--- a/core/commands/navigate.py
+++ b/core/commands/navigate.py
@@ -28,6 +28,7 @@ class GsNavigate(TextCommand, GitCommand):
         available_regions = self.get_available_regions()
         if not available_regions:
             return
+
         wanted_section = (
             self.forward(current_position, available_regions)
             if forward


### PR DESCRIPTION
Do not blindly focus the first line of the next/previous hunk.  Instead try to show the whole hunk the user is navigating to.  Try to scroll as minimal as possible.  

Special case the navigation in the Line History as here a commit header is always followed by exactly one hunk.  
So it is natural to try to show whole commits.  

Lastly when wrapping around the edges, ask for some force as it too confusing to jump from the last hunk to BOF.  Often it is not clear that you're on the last hunk even.  So when you're on the first or last commit you need to press multiple times before wrap-around jump actually happens.  A status bar text actually informs the user that the keypress has been registered and the user needs to repeat the key binding.
   