### PR TITLE
Colorize graph art directly at the cursor

### DIFF
--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -1068,7 +1068,7 @@ class gs_log_graph_navigate_wide(TextCommand):
         # type: (sublime.Edit, bool) -> None
         view = self.view
         try:
-            cur_dot = next(_find_dots(view))
+            cur_dot = next(chain(find_graph_art_at_cursor(view), _find_dots(view)))
         except StopIteration:
             view.run_command("gs_log_graph_navigate", {"forward": forward})
             return

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -1745,8 +1745,24 @@ def line_start_of_region(view, region):
 
 def colorize_dots(view):
     # type: (sublime.View) -> None
-    dots = tuple(find_dots(view))
+    dots = find_graph_art_at_cursor(view) or tuple(find_dots(view))
     _colorize_dots(view.id(), dots)
+
+
+def find_graph_art_at_cursor(view):
+    # type: (sublime.View) -> Tuple[colorizer.Char, ...]
+    if len(view.sel()) != 1:
+        return ()
+    cursor = view.sel()[0].b
+    if not view.match_selector(cursor, "meta.graph.branch-art"):
+        return ()
+
+    c = colorizer.Char(view, cursor)
+    for get_char in (lambda: c, lambda: c.w):
+        c_ = get_char()
+        if c_ != " ":
+            return (c_,)
+    return ()
 
 
 def find_dots(view):


### PR DESCRIPTION
Until now, we always searched for the commit dot on the line of the
cursor.  But often we ask: where does this line here begin or end?

Therefore, allow putting the cursor exactly *on* or into the graph art
and follow that graph from there.  E.g. place the cursor on the right
or left of a `|` symbol.

![image](https://user-images.githubusercontent.com/8558/206806328-bf9be1ee-e85d-4dc1-9e8a-f94e232eab24.png)
![image](https://user-images.githubusercontent.com/8558/206806365-b58ed1b3-e8a9-418a-bc32-a79edb70f415.png)
