### PR TITLE
Stage deleted lines before or after the triangle marker

### DIFF
--- a/core/commands/stage_hunk.py
+++ b/core/commands/stage_hunk.py
@@ -99,10 +99,14 @@ def hunk_containing_line(hunks, line):
     for hunk in hunks:
         if line < hunk.b_start:
             break
-        # Assume a length of "1" for removal only hunks so the
-        # user can actually grab them exactly on the line above the
-        # removal gutter mark.
-        b_end = hunk.b_start + max(hunk.b_length, 1)
+        # Assume a length of "2" for removal only hunks so the
+        # user can actually grab them exactly on the line above
+        # *or* below the removal gutter mark which is a triangle
+        # between two lines.
+        if hunk_of_removals_only(hunk):
+            b_end = hunk.b_start + 2
+        else:
+            b_end = hunk.b_start + max(hunk.b_length, 1)
         if hunk_with_no_newline_marker(hunk):
             # Make the hit area one line longer so that the user
             # can stage being on the last line of the view (if the


### PR DESCRIPTION
For deletions only regions, Sublime draws a triangle in the gutter which naturally sits between two lines.  

![image](https://user-images.githubusercontent.com/8558/206807072-3c4b3921-87b0-421a-8901-cca65f0bba8e.png)

Obviously a user cannot be exactly on such a region.

We needed to special case here but choose to only mark this region when the cursor was right above the triangle.  This is actually annoying so we now enable marking such regions from above or below.

It is unclear if the prior - a bit akward? - implementation was actually required by some means.


