### PR TITLE
Remove lock during `just_render`

### DIFF
--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -282,11 +282,7 @@ class StatusInterface(ui.Interface, GitCommand):
 
     @distinct_until_state_changed
     def just_render(self):
-        # TODO: Rewrite to "pureness" so that we don't need a lock here
-        # Note: It is forbidden to `update_state` during render, e.g. in
-        # any `ui.section`.
-        with self._lock:
-            content, regions = self._render_template()
+        content, regions = self._render_template()
         self.draw(self.title(), content, regions)
 
         on_special_symbol = any(


### PR DESCRIPTION
Since #1622 rendering the template is pure so we can safely remove locking here.

It is still forbidden to call `update_state` in the render ("section") functions because it likely yields to a confusing output mixing old and new data portions.  But since we do not acquire the lock, the program will not dead-lock in that case anymore.

Aside: we keep the lock in `update_state` because we cannot guarantee it is called only from one thread sequentially.