### PR TITLE
Two commits for the diff view

### DIFF
--- a/syntax/diff_view.sublime-syntax
+++ b/syntax/diff_view.sublime-syntax
@@ -11,5 +11,8 @@ contexts:
 
   header:
     - meta_scope: comment.header.git_savvy
+    - match: '  STAGED CHANGES \(Will commit\)'
+      scope: markup.deleted.diff
+    - match: '  UNSTAGED CHANGES'
     - match: '^--$\n'
       set: 'scope:git-savvy.diff'


### PR DESCRIPTION
- Colorize the status information when we're in show-stage-mode.  
- Switch between stage/unstage modes when we for example stage the last remaining hunk.

This comes in very handy when you for example want to initiate a Line History of one the staged hunks.  Maybe to search for the commit you want to fixup.  