### PR TITLE
nit stashes

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -398,6 +398,15 @@
         ]
     },
     {
+        "keys": ["o"],
+        "command": "gs_status_stash",
+        "args": { "action": "show" },
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "selector", "operand": "git-savvy.status meta.git-savvy.section.body.row.stash" }
+        ]
+    },
+    {
         "keys": ["t", "s"],
         "command": "gs_status_stash",
         "args": { "action": "show" },
@@ -406,6 +415,7 @@
             { "key": "setting.git_savvy.status_view", "operator": "equal", "operand": true }
         ]
     },
+
 
     //////////////////////////////
     // STATUS VIEW - NAVIGATION //

--- a/core/commands/stash.py
+++ b/core/commands/stash.py
@@ -11,6 +11,7 @@ from ..ui_mixins.input_panel import show_single_line_input_panel
 from ..utils import flash, hprint, uprint
 from ..view import replace_view_content
 from ...common import util
+from GitSavvy.core import store
 
 
 MYPY = False
@@ -192,12 +193,22 @@ class GsStashShowCommand(WindowCommand, GitCommand):
         repo_path = self.repo_path
         stash_view = util.view.get_scratch_view(self, "stash", read_only=True)
         title = "stash@{{{}}}".format(stash_id)
+        description = self.description_of_stash(str(stash_id))
+        if description:
+            title += " - " + description
         stash_view.set_name(title)
         stash_view.set_syntax_file("Packages/GitSavvy/syntax/diff.sublime-syntax")
         stash_view.settings().set("git_savvy.repo_path", repo_path)
         stash_view.settings().set("git_savvy.stash_view.stash_id", stash_id)
         stash_view.settings().set("git_savvy.stash_view.status", "valid")
         return stash_view
+
+    def description_of_stash(self, stash_id):
+        # type: (str) -> str
+        for stash in store.current_state(self.repo_path).get("stashes", []):
+            if stash.id == stash_id:
+                return stash.description
+        return ""
 
 
 class GsStashSaveCommand(WindowCommand, GitCommand):

--- a/core/git_mixins/stash.py
+++ b/core/git_mixins/stash.py
@@ -2,6 +2,7 @@ from collections import namedtuple
 import re
 
 from GitSavvy.core.git_command import mixin_base
+from GitSavvy.core import store
 
 
 MYPY = False
@@ -30,6 +31,10 @@ class StashMixin(mixin_base):
             assert match
             num, _, description = match.groups()
             stashes.append(Stash(num, description))
+
+        store.update_state(self.repo_path, {
+            "stashes": stashes,
+        })
         return stashes
 
     def show_stash(self, id):

--- a/core/git_mixins/stash.py
+++ b/core/git_mixins/stash.py
@@ -4,12 +4,20 @@ import re
 from GitSavvy.core.git_command import mixin_base
 
 
-Stash = namedtuple("Stash", ("id", "description"))
+MYPY = False
+if MYPY:
+    from typing import List, NamedTuple, Union
+    Stash = NamedTuple("Stash", [("id", str), ("description", str)])
+    StashId = Union[str, int]
+
+else:
+    Stash = namedtuple("Stash", ("id", "description"))
 
 
 class StashMixin(mixin_base):
 
     def get_stashes(self):
+        # type: () -> List[Stash]
         """
         Return a list of stashes in the repo.
         """
@@ -25,28 +33,33 @@ class StashMixin(mixin_base):
         return stashes
 
     def show_stash(self, id):
+        # type: (StashId) -> str
         stash_name = "stash@{{{}}}".format(id)
         return self.git("stash", "show", "--no-color", "-p", stash_name)
 
     def apply_stash(self, id):
+        # type: (StashId) -> None
         """
         Apply stash with provided id.
         """
         self.git("stash", "apply", "stash@{{{}}}".format(id))
 
     def pop_stash(self, id):
+        # type: (StashId) -> None
         """
         Pop stash with provided id.
         """
         self.git("stash", "pop", "stash@{{{}}}".format(id))
 
     def create_stash(self, description, include_untracked=False):
+        # type: (str, bool) -> None
         """
         Create stash with provided description from working files.
         """
         self.git("stash", "save", "-k", "-u" if include_untracked else None, description)
 
     def drop_stash(self, id):
+        # type: (StashId) -> str
         """
         Drop stash with provided id.
         """

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -261,9 +261,11 @@ class StatusInterface(ui.Interface, GitCommand):
         status = store.current_state(self.repo_path).get("status")
         if status:
             self.update_state(status._asdict())
+        stashes = store.current_state(self.repo_path).get("stashes", [])
         self.update_state({
             'git_root': self.short_repo_path,
-            'show_help': not self.view.settings().get("git_savvy.help_hidden")
+            'show_help': not self.view.settings().get("git_savvy.help_hidden"),
+            'stashes': stashes,
         })
 
     def update_state(self, data, then=None):

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -165,7 +165,7 @@ class StatusInterface(ui.Interface, GitCommand):
 
       [c] commit                            [t][a] apply stash
       [C] commit, including unstaged        [t][p] pop stash
-      [m] amend previous commit             [t][s] show stash
+      [m] amend previous commit             [o]    open stash
       [p] push current branch               [t][c] create stash
                                             [t][u] create stash including untracked files
       [i] ignore file                       [t][g] create stash of staged changes only

--- a/core/store.py
+++ b/core/store.py
@@ -8,7 +8,10 @@ from .utils import eat_but_log_errors
 
 MYPY = False
 if MYPY:
-    from typing import AbstractSet, Callable, DefaultDict, Deque, Dict, Optional, Tuple, TypedDict
+    from typing import (
+        AbstractSet, Callable, DefaultDict, Deque, Dict, List, Optional, Tuple, TypedDict
+    )
+    from GitSavvy.core.git_mixins.stash import Stash
     from GitSavvy.core.git_mixins.status import WorkingDirState
 
     RepoPath = str
@@ -23,6 +26,7 @@ if MYPY:
             "last_remote_used_with_option_all": Optional[str],
             "last_reset_mode_used": Optional[str],
             "short_hash_length": int,
+            "stashes": List[Stash],
         },
         total=False
     )


### PR DESCRIPTION
- Bind `[o]` to open/show a stash (deprecate `[t][s]` therefore. 
- Show the stash description in the title of the stash view.

Likely we can simplify more bindings at a later time.

- cache the stashes info which makes to make the initial render of the status dashboard snappy.  But we also read the description from the store.