### PR TITLE
Fix upwards navigation in the dashboards

### DIFF
--- a/core/commands/navigate.py
+++ b/core/commands/navigate.py
@@ -75,7 +75,7 @@ class GsNavigate(TextCommand, GitCommand):
     def previous_region(self, current_position, regions):
         # type: (sublime.Point, Sequence[sublime.Region]) -> Optional[sublime.Region]
         for region in reversed(regions):
-            if region.a < current_position:
+            if min(region.a + self.offset, region.b) < current_position:
                 return region
 
         return regions[-1] if self._wrap_around_now() else None


### PR DESCRIPTION
Fixes #1712

When comparing `region.a < current_position` we must account for possible offset we apply automatically.

E.g. if the user is exactly on position `region.a + 4` in one of the dashboards (4 being the offset there), she is of course *on* the jump point and wants to go to the line above.

Just to be correct, do the `min` dance with `region.b`.