### PR TITLE
Tune the new recent commits tagging

### DIFF
--- a/core/git_mixins/active_branch.py
+++ b/core/git_mixins/active_branch.py
@@ -83,11 +83,7 @@ def format_and_limit(commits, max_items, current_upstream=None, branches=[]):
     }
     for idx, (h, d, s) in enumerate(commits):
         decorations_ = d.strip("( )").split(", ") if d else []
-        refs_ = [
-            p[8:] if p.startswith("HEAD ->") else p
-            for p in decorations_
-            if p != "HEAD" and not p.startswith("tag: ")
-        ]
+        refs_ = only_refs(decorations_)
         decorations = [
             part for part in decorations_
             if (
@@ -113,6 +109,18 @@ def format_and_limit(commits, max_items, current_upstream=None, branches=[]):
 KONTINUATION = "\u200B ⋮"
 
 
+def only_refs(decorations):
+    return [
+        p[8:] if p.startswith("HEAD ->") else p
+        for p in decorations
+        if p != "HEAD" and not p.startswith("tag: ")
+    ]
+
+
+def only_tags(decorations):
+    return [d[5:] for d in decorations if d.startswith("tag: ")]
+
+
 def commit(h, s, decorations):
     yield commit_line(h, s)
     if decorations:
@@ -136,8 +144,4 @@ def format_decorations(decorations):
 
 
 def decorations_include_semver_tag(decorations):
-    return decorations and any(
-        is_semver_tag(d[5:])
-        for d in decorations
-        if d.startswith("tag: ")
-    )
+    return decorations and any(map(is_semver_tag, only_tags(decorations)))

--- a/core/git_mixins/active_branch.py
+++ b/core/git_mixins/active_branch.py
@@ -97,9 +97,9 @@ def format_and_limit(commits, max_items, current_upstream=None, branches=[]):
                 and remote_to_local_names.get(part) not in refs_
             )
         ]
-        decoration_that_breaks = set(decorations) - {current_upstream}
+        decorations_that_break = set(decorations) - {current_upstream}
 
-        if decoration_that_breaks and idx > 0:
+        if decorations_that_break and idx > 0:
             if idx > max_items:
                 yield KONTINUATION
             yield stand_alone_decoration_line(h, decorations)

--- a/core/git_mixins/active_branch.py
+++ b/core/git_mixins/active_branch.py
@@ -82,7 +82,7 @@ def format_and_limit(commits, max_items, current_upstream=None, branches=[]):
         if not b.is_remote and b.upstream
     }
     for idx, (h, d, s) in enumerate(commits):
-        decorations_ = d.strip("( )").split(", ")
+        decorations_ = d.strip("( )").split(", ") if d else []
         refs_ = [
             p[8:] if p.startswith("HEAD ->") else p
             for p in decorations_
@@ -91,8 +91,7 @@ def format_and_limit(commits, max_items, current_upstream=None, branches=[]):
         decorations = [
             part for part in decorations_
             if (
-                part
-                and part != "HEAD"
+                part != "HEAD"
                 and not part.startswith("HEAD ->")
                 and not part.endswith("/HEAD")
                 and remote_to_local_names.get(part) not in refs_

--- a/core/git_mixins/active_branch.py
+++ b/core/git_mixins/active_branch.py
@@ -2,6 +2,7 @@ from collections import namedtuple
 
 from GitSavvy.core.git_command import mixin_base
 from .. import store
+from GitSavvy.core.git_mixins.tags import is_semver_tag
 
 
 MYPY = False
@@ -98,6 +99,7 @@ def format_and_limit(commits, max_items, current_upstream=None, branches=[]):
             )
         ]
         decoration_that_breaks = set(decorations) - {current_upstream}
+
         if decoration_that_breaks and idx > 0:
             if idx > max_items:
                 yield KONTINUATION
@@ -105,6 +107,8 @@ def format_and_limit(commits, max_items, current_upstream=None, branches=[]):
             break
         elif idx < max_items:
             yield from commit(h, s, decorations)
+            if decorations_include_semver_tag(decorations):
+                break
 
 
 KONTINUATION = "\u200B ⋮"
@@ -130,3 +134,11 @@ def stand_alone_decoration_line(h, decorations):
 
 def format_decorations(decorations):
     return "({})".format(", ".join(decorations))
+
+
+def decorations_include_semver_tag(decorations):
+    return decorations and any(
+        is_semver_tag(d[5:])
+        for d in decorations
+        if d.startswith("tag: ")
+    )

--- a/core/git_mixins/active_branch.py
+++ b/core/git_mixins/active_branch.py
@@ -82,7 +82,7 @@ def format_and_limit(commits, max_items, current_upstream=None, branches=[]):
         if not b.is_remote and b.upstream
     }
     for idx, (h, d, s) in enumerate(commits):
-        decorations_ = d.lstrip()[1:-1].split(", ")
+        decorations_ = d.strip("( )").split(", ")
         refs_ = [
             p[8:] if p.startswith("HEAD ->") else p
             for p in decorations_

--- a/core/git_mixins/active_branch.py
+++ b/core/git_mixins/active_branch.py
@@ -77,7 +77,12 @@ def format_and_limit(commits, max_items, current_upstream=None):
     for idx, (h, d, s) in enumerate(commits):
         decorations = [
             part for part in d.lstrip()[1:-1].split(", ")
-            if part and part != "HEAD" and "HEAD ->" not in part
+            if (
+                part
+                and part != "HEAD"
+                and not part.startswith("HEAD ->")
+                and not part.endswith("/HEAD")
+            )
         ]
         decoration_that_breaks = set(decorations) - {current_upstream}
         if decoration_that_breaks and idx > 0:

--- a/core/git_mixins/branches.py
+++ b/core/git_mixins/branches.py
@@ -25,7 +25,6 @@ if MYPY:
         ("commit_msg", str),
         ("active", bool),
         ("is_remote", bool),
-        ("description", str),
         ("upstream", Optional[Upstream]),
     ])
 else:
@@ -38,7 +37,6 @@ else:
         "commit_msg",
         "active",
         "is_remote",
-        "description",
         "upstream",
     ))
 
@@ -93,10 +91,9 @@ class BranchesMixin(mixin_base):
     def get_branches(
         self, *,
         sort_by_recent=False,
-        fetch_descriptions=False,
         refs=["refs/heads", "refs/remotes"]
     ):
-        # type: (bool, bool, Sequence[str]) -> Iterable[Branch]
+        # type: (bool, Sequence[str]) -> Iterable[Branch]
         """
         Return a list of all local and remote branches.
         """
@@ -123,14 +120,7 @@ class BranchesMixin(mixin_base):
             )
             if branch.name != "HEAD"
         )
-        if not fetch_descriptions:
-            return branches
-
-        descriptions = self.fetch_branch_description_subjects()
-        return (
-            branch._replace(description=descriptions.get(branch.canonical_name, ""))
-            for branch in branches
-        )
+        return branches
 
     def fetch_branch_description_subjects(self):
         # type: () -> Dict[str, str]
@@ -183,7 +173,6 @@ class BranchesMixin(mixin_base):
             commit_msg,
             active,
             is_remote,
-            description="",
             upstream=ups
         )
 

--- a/core/git_mixins/tags.py
+++ b/core/git_mixins/tags.py
@@ -12,6 +12,9 @@ if MYPY:
     from typing import List, Optional, Tuple
 
 
+SEMVER_TEST = re.compile(r'\d+\.\d+\.?\d*')
+
+
 class TagsMixin(mixin_base):
 
     def get_local_tags(self):
@@ -65,12 +68,9 @@ class TagsMixin(mixin_base):
         """
         Sorts tags using LooseVersion if there's a tag matching the semver format.
         """
-
-        semver_test = re.compile(r'\d+\.\d+\.?\d*')
-
         semver_entries, regular_entries = [], []
         for entry in entries:
-            if semver_test.search(entry.tag):
+            if SEMVER_TEST.search(entry.tag):
                 semver_entries.append(entry)
             else:
                 regular_entries.append(entry)
@@ -89,9 +89,14 @@ class TagsMixin(mixin_base):
                 semver_entries = sorted(
                     semver_entries,
                     key=lambda entry: LooseVersion(
-                        semver_test.search(entry.tag).group()  # type: ignore[union-attr]
+                        SEMVER_TEST.search(entry.tag).group()  # type: ignore[union-attr]
                     ),
                     reverse=True
                 )
 
         return (regular_entries, semver_entries)
+
+
+def is_semver_tag(tag):
+    # type: (str) -> bool
+    return bool(SEMVER_TEST.search(tag))

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -110,9 +110,7 @@ class BranchInterface(ui.Interface, GitCommand):
 
     def pre_render(self):
         sort_by_recent = self.savvy_settings.get("sort_by_recent_in_branch_dashboard")
-        self._branches = tuple(self.get_branches(
-            sort_by_recent=sort_by_recent,
-        ))
+        self._branches = self.get_branches(sort_by_recent=sort_by_recent)
         self.descriptions = self.fetch_branch_description_subjects()
         if self.show_remotes is None:
             self.show_remotes = self.savvy_settings.get("show_remotes_in_branch_dashboard")

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -112,8 +112,8 @@ class BranchInterface(ui.Interface, GitCommand):
         sort_by_recent = self.savvy_settings.get("sort_by_recent_in_branch_dashboard")
         self._branches = tuple(self.get_branches(
             sort_by_recent=sort_by_recent,
-            fetch_descriptions=True
         ))
+        self.descriptions = self.fetch_branch_description_subjects()
         if self.show_remotes is None:
             self.show_remotes = self.savvy_settings.get("show_remotes_in_branch_dashboard")
         self.remotes = self.get_remotes() if self.show_remotes else {}
@@ -166,7 +166,7 @@ class BranchInterface(ui.Interface, GitCommand):
                 indicator="▸" if branch.active else " ",
                 hash=branch.commit_hash,
                 name=branch.canonical_name[remote_name_l:],
-                description=" " + branch.description if branch.description else "",
+                description=(" " + self.descriptions.get(branch.canonical_name, "")).rstrip(),
                 tracking=(" ({branch}{status})".format(
                     branch=branch.upstream.canonical_name,
                     status=", " + branch.upstream.status if branch.upstream.status else ""

--- a/core/interfaces/rebase.py
+++ b/core/interfaces/rebase.py
@@ -342,7 +342,7 @@ class RebaseInterface(ui.Interface, NearestBranchMixin, GitCommand):
                     default=(upstream and upstream.canonical_name) or "master")
                 util.debug.add_to_log('Found base ref {}'.format(base_ref))
 
-            branches = list(self.get_branches())
+            branches = self.get_branches()
 
             # Check that the base_ref we return is a valid branch
             if base_ref not in [branch.canonical_name for branch in branches]:

--- a/core/store.py
+++ b/core/store.py
@@ -12,6 +12,7 @@ if MYPY:
         AbstractSet, Callable, DefaultDict, Deque, Dict, List, Optional, Tuple, TypedDict
     )
     from GitSavvy.core.git_mixins.active_branch import Commit
+    from GitSavvy.core.git_mixins.branches import Branch
     from GitSavvy.core.git_mixins.stash import Stash
     from GitSavvy.core.git_mixins.status import HeadState, WorkingDirState
 
@@ -21,6 +22,7 @@ if MYPY:
         {
             "status": WorkingDirState,
             "head": HeadState,
+            "branches": List[Branch],
             "last_branches": Deque[Optional[str]],
             "last_local_branch_for_rebase": Optional[str],
             "last_remote_used": Optional[str],

--- a/core/ui_mixins/quick_panel.py
+++ b/core/ui_mixins/quick_panel.py
@@ -291,7 +291,7 @@ class BranchPanel(GitCommand):
             self.select_branch(remote=None)
 
     def select_branch(self, remote=None):
-        branches = list(self.get_branches())
+        branches = self.get_branches()
         if self.local_branches_only:
             self.all_branches = [b.canonical_name for b in branches if not b.is_remote]
         elif self.remote_branches_only:

--- a/tests/test_git_mixins.py
+++ b/tests/test_git_mixins.py
@@ -77,7 +77,6 @@ class TestGetBranchesParsing(TestGitMixinsUsage):
                 "The Subject",
                 False,
                 False,
-                "",
                 git_mixins.branches.Upstream(
                     "origin", "master", "origin/master", ""
                 )
@@ -100,7 +99,6 @@ class TestGetBranchesParsing(TestGitMixinsUsage):
                 "The Subject",
                 True,
                 False,
-                "",
                 git_mixins.branches.Upstream(
                     "origin", "master", "origin/master", ""
                 )
@@ -123,7 +121,6 @@ class TestGetBranchesParsing(TestGitMixinsUsage):
                 "The Subject",
                 False,
                 True,
-                "",
                 None
             )
         ])
@@ -144,7 +141,6 @@ class TestGetBranchesParsing(TestGitMixinsUsage):
                 "The Subject",
                 False,
                 False,
-                "",
                 git_mixins.branches.Upstream(
                     "orig/in", "master", "orig/in/master", ""
                 )
@@ -167,7 +163,6 @@ class TestGetBranchesParsing(TestGitMixinsUsage):
                 "The Subject",
                 False,
                 False,
-                "",
                 git_mixins.branches.Upstream(
                     "origin", "master", "origin/master", "gone"
                 )
@@ -190,7 +185,6 @@ class TestGetBranchesParsing(TestGitMixinsUsage):
                 "The Subject",
                 False,
                 False,
-                "",
                 git_mixins.branches.Upstream(
                     ".", "update-branch-from-upstream", "update-branch-from-upstream", ""
                 )
@@ -259,7 +253,6 @@ class TestBranchParsing(EndToEndTestCase):
                 "Initial commit",
                 True,
                 False,
-                "",
                 None
             )
         ])
@@ -279,7 +272,6 @@ class TestBranchParsing(EndToEndTestCase):
                 "Initial commit",
                 True,
                 False,
-                "",
                 git_mixins.branches.Upstream(
                     ".", "master", "master", ""
                 )

--- a/tests/test_git_mixins.py
+++ b/tests/test_git_mixins.py
@@ -67,7 +67,8 @@ class TestGetBranchesParsing(TestGitMixinsUsage):
             [" ", "refs/heads/master", "refs/remotes/origin/master", "origin", ""]
             + sha_and_subject)
         when(repo).git("for-each-ref", ...).thenReturn(git_output)
-        actual = list(repo.get_branches())
+        when(repo).get_repo_path().thenReturn("yeah/sure")
+        actual = repo.get_branches()
         self.assertEqual(actual, [
             git_mixins.branches.Branch(
                 "master",
@@ -89,7 +90,8 @@ class TestGetBranchesParsing(TestGitMixinsUsage):
             ["*", "refs/heads/master", "refs/remotes/origin/master", "origin", ""]
             + sha_and_subject)
         when(repo).git("for-each-ref", ...).thenReturn(git_output)
-        actual = list(repo.get_branches())
+        when(repo).get_repo_path().thenReturn("yeah/sure")
+        actual = repo.get_branches()
         self.assertEqual(actual, [
             git_mixins.branches.Branch(
                 "master",
@@ -111,7 +113,8 @@ class TestGetBranchesParsing(TestGitMixinsUsage):
             [" ", "refs/remotes/origin/dev", "", "", ""]
             + sha_and_subject)
         when(repo).git("for-each-ref", ...).thenReturn(git_output)
-        actual = list(repo.get_branches())
+        when(repo).get_repo_path().thenReturn("yeah/sure")
+        actual = repo.get_branches()
         self.assertEqual(actual, [
             git_mixins.branches.Branch(
                 "dev",
@@ -131,7 +134,8 @@ class TestGetBranchesParsing(TestGitMixinsUsage):
             [" ", "refs/heads/master", "refs/remotes/orig/in/master", "orig/in", ""]
             + sha_and_subject)
         when(repo).git("for-each-ref", ...).thenReturn(git_output)
-        actual = list(repo.get_branches())
+        when(repo).get_repo_path().thenReturn("yeah/sure")
+        actual = repo.get_branches()
         self.assertEqual(actual, [
             git_mixins.branches.Branch(
                 "master",
@@ -153,7 +157,8 @@ class TestGetBranchesParsing(TestGitMixinsUsage):
             [" ", "refs/heads/master", "refs/remotes/origin/master", "origin", "gone"]
             + sha_and_subject)
         when(repo).git("for-each-ref", ...).thenReturn(git_output)
-        actual = list(repo.get_branches())
+        when(repo).get_repo_path().thenReturn("yeah/sure")
+        actual = repo.get_branches()
         self.assertEqual(actual, [
             git_mixins.branches.Branch(
                 "master",
@@ -175,7 +180,8 @@ class TestGetBranchesParsing(TestGitMixinsUsage):
             [" ", "refs/heads/test", "refs/heads/update-branch-from-upstream", ".", ""]
             + sha_and_subject)
         when(repo).git("for-each-ref", ...).thenReturn(git_output)
-        actual = list(repo.get_branches())
+        when(repo).get_repo_path().thenReturn("yeah/sure")
+        actual = repo.get_branches()
         self.assertEqual(actual, [
             git_mixins.branches.Branch(
                 "test",
@@ -243,7 +249,7 @@ class TestBranchParsing(EndToEndTestCase):
     def test_active_local_branch(self):
         repo = self.init_repo()
         commit_hash = repo.get_commit_hash_for_head()
-        actual = list(repo.get_branches())
+        actual = repo.get_branches()
         self.assertEqual(actual, [
             git_mixins.branches.Branch(
                 "master",

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -349,6 +349,16 @@ class TestRecentCommitsFormat(DeferrableTestCase):
                 "abc message",
             ]
         ),
+        (
+            "ignore `*/HEAD` refs",
+            [
+                ["abc", " (HEAD -> feature-branch, origin/HEAD)", "message"],
+            ],
+            [
+                "abc message",
+            ]
+
+        ),
 
         (
             "special format decorated commit: "

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -4,6 +4,7 @@ from unittesting import DeferrableTestCase
 from GitSavvy.tests.mockito import unstub, when
 from GitSavvy.tests.parameterized import parameterized as p
 
+from GitSavvy.core import git_mixins
 from GitSavvy.core.git_command import GitCommand
 from GitSavvy.core.git_mixins import active_branch
 
@@ -455,6 +456,17 @@ class TestRecentCommitsFormat(DeferrableTestCase):
         ),
 
         (
+            "suppress upstream on HEAD",
+            # because the header already starts with:
+            # On branch `master` tracking `origin/master`
+            [
+                ["abc", " (HEAD -> master, origin/master)", "message"],
+            ],
+            [
+                "abc message",
+            ]
+        ),
+        (
             "do not stop after the upstream branch decoration (on HEAD)",
             [
                 ["abc", " (HEAD -> master, origin/master)", "message"],
@@ -462,7 +474,6 @@ class TestRecentCommitsFormat(DeferrableTestCase):
             ],
             [
                 "abc message",
-                "` \u200B(origin/master)",
                 "abc message",
             ]
         ),
@@ -483,5 +494,19 @@ class TestRecentCommitsFormat(DeferrableTestCase):
 
     ])
     def test_formatting_and_limiting(self, _, lines, expected):
-        actual = list(active_branch.format_and_limit(lines, 5, "origin/master"))
+        branches = [
+            git_mixins.branches.Branch(
+                "master",
+                None,
+                "master",
+                "89b79cd737465ed308ecc00289d00a6f923f2da5",
+                "The Subject",
+                False,
+                False,
+                git_mixins.branches.Upstream(
+                    "origin", "master", "origin/master", ""
+                )
+            )
+        ]
+        actual = list(active_branch.format_and_limit(lines, 5, "origin/master", branches))
         self.assertEqual(actual, expected)

--- a/tests/test_status_dashboard.py
+++ b/tests/test_status_dashboard.py
@@ -57,8 +57,10 @@ class TestStatusDashboard(DeferrableTestCase):
         when(GitCommand).in_merge().thenReturn(False)
         when(GitCommand).in_cherry_pick().thenReturn(False)
         when(GitCommand).git('status', ...).thenReturn(file_status)
-        when(GitCommand).git('log', ...).thenReturn(last_commit)
+        when(GitCommand).git('log', ...).thenReturn(
+            "{0}%00%00{1}".format(*last_commit.split(" ", 1)))
         when(GitCommand).git('stash', 'list').thenReturn(stash_list)
+        when(GitCommand).git('for-each-ref', ...).thenReturn("")
 
         interface = ui.create_interface(self.window, repo_path, "status")
         view = interface.view


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/8558/208526248-23f63287-d3ee-4bd4-b954-2c1c066f73ad.png)

![image](https://user-images.githubusercontent.com/8558/208526293-f698ae60-5ea2-4786-b998-bd8ef8dc7da5.png)

-  T.i. generally remove the `origin/HEAD` ref (we do this in the graph view too!)
- if on par with the upstream, do not show it here again as it already state "On master tracking origin/master" right above
- If on a semver tag, do not follow up to the next semver.  (What's the nearest tag? The one you're on.)
