### PR TITLE
Fix `blame` not rendering anything

### DIFF
--- a/common/ui.py
+++ b/common/ui.py
@@ -290,8 +290,13 @@ class gs_new_content_and_regions(TextCommand):
             else:
                 return content[a:b]
 
-        if regions.keys() - self.current_region_names:
+        if (
+            not regions
+            or not self.current_region_names
+            or regions.keys() - self.current_region_names
+        ):
             replace_view_content(self.view, content)
+
         else:
             current_regions = [
                 (region, key)

--- a/core/commands/blame.py
+++ b/core/commands/blame.py
@@ -11,6 +11,7 @@ from ...common import util
 from .log import LogMixin
 from ..ui_mixins.quick_panel import PanelActionMixin
 from GitSavvy.core.base_commands import GsTextCommand
+from GitSavvy.core.view import replace_view_content
 
 
 __all__ = (
@@ -202,10 +203,7 @@ class gs_blame_refresh(BlameMixin):
         else:
             yoffset = 0
 
-        self.view.run_command("gs_new_content_and_regions", {
-            "content": content,
-            "regions": {}
-        })
+        replace_view_content(self.view, content)
 
         if settings.get("git_savvy.lineno", None) is not None:
             self.select_line(settings.get("git_savvy.lineno"))


### PR DESCRIPTION
Fixes #1717

`gs_blame_refresh` draws using `gs_new_content_and_regions` but not using the `regions` part.  That was not implemented since the optimizations in 6a04d2bb (Draw only the changed parts of a view).

Fix that but also change the caller (`gs_blame_refresh`) to use the raw `replace_view_content` function which is what all the other non-dashboard views do.