### PR TITLE
Snappy reactive dashboards

### DIFF
--- a/common/ui.py
+++ b/common/ui.py
@@ -194,8 +194,25 @@ class Interface(metaclass=_PrepareInterface):
 
     def render(self):
         self.pre_render()
+        self.just_render()
+
+    def just_render(self) -> None:
         content, regions = self._render_template()
-        self.draw(self.title(), content, regions)
+        with self.keep_cursor_on_something():
+            self.draw(self.title(), content, regions)
+
+    @contextmanager
+    def keep_cursor_on_something(self):
+        # type: () -> Iterator[None]
+        yield
+
+    def cursor_is_on_something(self, what):
+        # type: (str) -> bool
+        view = self.view
+        return any(
+            view.match_selector(s.begin(), what)
+            for s in view.sel()
+        )
 
     def draw(self, title, content, regions):
         # type: (str, str, SectionRegions) -> None
@@ -328,10 +345,6 @@ class ReactiveInterface(Interface, _base, GitCommand):
         content, regions = self._render_template()
         with self.keep_cursor_on_something():
             self.draw(self.title(), content, regions)
-
-    @contextmanager
-    def keep_cursor_on_something(self):
-        yield
 
     def on_create(self):
         self._unsubscribe = store.subscribe(

--- a/common/ui.py
+++ b/common/ui.py
@@ -196,7 +196,8 @@ class Interface(metaclass=_PrepareInterface):
         self.pre_render()
         self.just_render()
 
-    def just_render(self) -> None:
+    def just_render(self):
+        # type: () -> None
         content, regions = self._render_template()
         with self.keep_cursor_on_something():
             self.draw(self.title(), content, regions)
@@ -315,10 +316,12 @@ class ReactiveInterface(Interface, _base, GitCommand):
         self._lock = threading.Lock()
         super().__init__(*args, **kwargs)
 
-    def refresh_view_state(self) -> None:
+    def refresh_view_state(self):
+        # type: () -> None
         raise NotImplementedError
 
     def update_state(self, data, then=None):
+        # type: (...) -> None
         """Update internal view state and maybe invoke a callback.
 
         `data` can be a mapping or a callable ("thunk") which returns
@@ -336,17 +339,20 @@ class ReactiveInterface(Interface, _base, GitCommand):
             then()
 
     def render(self):
+        # type: () -> None
         """Refresh view state and render."""
         self.refresh_view_state()
         self.just_render()
 
     @distinct_until_state_changed
     def just_render(self):
+        # type: () -> None
         content, regions = self._render_template()
         with self.keep_cursor_on_something():
             self.draw(self.title(), content, regions)
 
     def on_create(self):
+        # type: () -> None
         self._unsubscribe = store.subscribe(
             self.repo_path,
             self.subscribe_to,
@@ -354,9 +360,11 @@ class ReactiveInterface(Interface, _base, GitCommand):
         )
 
     def on_close(self):
+        # type: () -> None
         self._unsubscribe()
 
     def on_status_update(self, _repo_path, state):
+        # type: (...) -> None
         new_state = {}
         for topic in self.subscribe_to:
             try:

--- a/common/ui.py
+++ b/common/ui.py
@@ -368,10 +368,7 @@ class ReactiveInterface(Interface, _base, GitCommand):
         new_state = {}
         for topic in self.subscribe_to:
             try:
-                if topic == "status":
-                    new_state.update(state["status"]._asdict())
-                else:
-                    new_state[topic] = state[topic]
+                new_state[topic] = state[topic]
             except KeyError:
                 pass
 

--- a/common/ui.py
+++ b/common/ui.py
@@ -183,9 +183,6 @@ class Interface(metaclass=_PrepareInterface):
     def pre_render(self):
         pass
 
-    def reset_cursor(self):
-        pass
-
     def render(self):
         self.pre_render()
         content, regions = self._render_template()

--- a/common/ui.py
+++ b/common/ui.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from copy import deepcopy
 from functools import wraps
 import re
 from textwrap import dedent
@@ -276,7 +277,7 @@ def distinct_until_state_changed(just_render_fn):
         current_state = self.state
         if current_state != previous_states.get(self):
             just_render_fn(self, *args, **kwargs)
-            previous_states[self] = current_state.copy()
+            previous_states[self] = deepcopy(current_state)
 
     return wrapper
 

--- a/common/ui.py
+++ b/common/ui.py
@@ -358,6 +358,9 @@ class ReactiveInterface(Interface, _base, GitCommand):
             self.subscribe_to,
             self.on_status_update
         )
+        state = store.current_state(self.repo_path)
+        new_state = self._pick_subscribed_topics_from_store(state)
+        self.update_state(new_state)
 
     def on_close(self):
         # type: () -> None
@@ -365,14 +368,17 @@ class ReactiveInterface(Interface, _base, GitCommand):
 
     def on_status_update(self, _repo_path, state):
         # type: (...) -> None
+        new_state = self._pick_subscribed_topics_from_store(state)
+        self.update_state(new_state, then=self.just_render)
+
+    def _pick_subscribed_topics_from_store(self, state):
         new_state = {}
         for topic in self.subscribe_to:
             try:
                 new_state[topic] = state[topic]
             except KeyError:
                 pass
-
-        self.update_state(new_state, then=self.just_render)
+        return new_state
 
 
 def section(key):

--- a/core/commands/status_bar.py
+++ b/core/commands/status_bar.py
@@ -50,7 +50,7 @@ class gs_draw_status_bar(TextCommand, GitCommand):
             return
 
         try:
-            short_status = store.current_state(repo_path)["status"].short_status
+            short_status = store.current_state(repo_path)["short_status"]
         except Exception:
             ...
         else:
@@ -63,4 +63,4 @@ def on_status_update(repo_path, state):
         view.run_command("gs_draw_status_bar", {"repo_path": repo_path})
 
 
-store.subscribe("*", {"status"}, on_status_update)
+store.subscribe("*", {"short_status"}, on_status_update)

--- a/core/exceptions.py
+++ b/core/exceptions.py
@@ -32,3 +32,7 @@ class FailedGithubRequest(GitSavvyError):
 
 class FailedGitLabRequest(GitSavvyError):
     pass
+
+
+class DetachedView(RuntimeError):
+    pass

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -271,9 +271,10 @@ class _GitCommand(SettingsMixin):
         if not working_dir:
             try:
                 working_dir = self.repo_path
-            except RuntimeError as e:
+            except DetachedView as e:
                 # do not show panel when the window does not exist
-                raise GitSavvyError(str(e), show_panel=False, window=window)
+                GitSavvyError(str(e), show_panel=False, window=window)  # just for logging
+                raise
             except Exception as e:
                 raise GitSavvyError(str(e), show_panel=show_panel_on_error, window=window)
 
@@ -555,7 +556,7 @@ class _GitCommand(SettingsMixin):
 
         window = self._current_window()
         if not window:
-            raise RuntimeError("View already closed.")
+            raise DetachedView("View already closed.")
 
         if window.folders():
             enqueue_on_worker(window.run_command, "gs_offer_init")
@@ -658,7 +659,7 @@ from .git_mixins.tags import TagsMixin  # noqa: E402
 from .git_mixins.history import HistoryMixin  # noqa: E402
 from .git_mixins.rewrite import RewriteMixin  # noqa: E402
 from .git_mixins.merge import MergeMixin  # noqa: E402
-from .exceptions import GitSavvyError  # noqa: E402
+from .exceptions import DetachedView, GitSavvyError  # noqa: E402
 
 
 class GitCommand(

--- a/core/git_mixins/active_branch.py
+++ b/core/git_mixins/active_branch.py
@@ -18,6 +18,8 @@ if MYPY:
 else:
     Commit = namedtuple("Commit", "hash decoration message")
 
+NullRecentCommits = []  # type: List
+
 
 class ActiveBranchMixin(mixin_base):
 

--- a/core/git_mixins/active_branch.py
+++ b/core/git_mixins/active_branch.py
@@ -18,8 +18,6 @@ if MYPY:
 else:
     Commit = namedtuple("Commit", "hash decoration message")
 
-NullRecentCommits = []  # type: List
-
 
 class ActiveBranchMixin(mixin_base):
 

--- a/core/git_mixins/branches.py
+++ b/core/git_mixins/branches.py
@@ -139,6 +139,7 @@ class BranchesMixin(mixin_base):
 
             branch_name, description = match.group(1), match.group(2)
             rv[branch_name] = description
+        store.update_state(self.repo_path, {"descriptions": rv})
         return rv
 
     def _parse_branch_line(self, line):

--- a/core/git_mixins/remotes.py
+++ b/core/git_mixins/remotes.py
@@ -1,6 +1,7 @@
 import re
 from collections import OrderedDict
 
+from GitSavvy.core import store
 from GitSavvy.core.fns import filter_
 
 
@@ -32,7 +33,11 @@ class RemotesMixin(mixin_base):
         url/resource.
         """
         entries = self.git("remote", "-v").splitlines()
-        return OrderedDict(entry.split()[:2] for entry in entries)
+        rv = OrderedDict(entry.split()[:2] for entry in entries)
+        store.update_state(self.repo_path, {
+            "remotes": rv,
+        })
+        return rv
 
     def fetch(self, remote=None, refspec=None, prune=True, local_branch=None, remote_branch=None):
         # type: (str, str, bool, str, str) -> None

--- a/core/git_mixins/status.py
+++ b/core/git_mixins/status.py
@@ -75,6 +75,7 @@ class WorkingDirState(_WorkingDirState):
         )
 
 
+NullHeadState = HeadState(True, None, None, True, None, None, False)
 NullWorkingDirState = WorkingDirState([], [], [], [])
 MERGE_CONFLICT_PORCELAIN_STATUSES = (
     ("A", "A"),  # unmerged, both added

--- a/core/git_mixins/status.py
+++ b/core/git_mixins/status.py
@@ -75,8 +75,6 @@ class WorkingDirState(_WorkingDirState):
         )
 
 
-NullHeadState = HeadState(True, None, None, True, None, None, False)
-NullWorkingDirState = WorkingDirState([], [], [], [])
 MERGE_CONFLICT_PORCELAIN_STATUSES = (
     ("A", "A"),  # unmerged, both added
     ("U", "U"),  # unmerged, both modified

--- a/core/git_mixins/status.py
+++ b/core/git_mixins/status.py
@@ -118,13 +118,15 @@ class StatusMixin(mixin_base):
             unstaged_files,
             untracked_files,
             merge_conflicts) = self._group_status_entries(files)
+        short_status = self._format_branch_status_short(branch_status)
+        long_status = self._format_branch_status(branch_status)
         rv = WorkingDirState(
             staged_files=staged_files,
             unstaged_files=unstaged_files,
             untracked_files=untracked_files,
             merge_conflicts=merge_conflicts,
-            short_status=self._format_branch_status_short(branch_status),
-            long_status=self._format_branch_status(branch_status)
+            short_status=short_status,
+            long_status=long_status
         )
         current_branch = branch_status.branch
         last_branches = store.current_state(self.repo_path)["last_branches"]
@@ -133,7 +135,9 @@ class StatusMixin(mixin_base):
         store.update_state(self.repo_path, {
             "status": rv,
             "head": branch_status,
-            "last_branches": last_branches
+            "last_branches": last_branches,
+            "long_status": long_status,
+            "short_status": short_status,
         })
         return rv
 

--- a/core/git_mixins/status.py
+++ b/core/git_mixins/status.py
@@ -48,17 +48,13 @@ if MYPY:
         ("unstaged_files", List[FileStatus]),
         ("untracked_files", List[FileStatus]),
         ("merge_conflicts", List[FileStatus]),
-        ("short_status", str),
-        ("long_status", str),
     ])
 
 else:
     HeadState = namedtuple("HeadState", "detached branch remote clean ahead behind gone")
     FileStatus = namedtuple("FileStatus", "path path_alt index_status working_status")
     _WorkingDirState = namedtuple(
-        "_WorkingDirState",
-        "staged_files unstaged_files untracked_files merge_conflicts "
-        "short_status long_status"
+        "_WorkingDirState", "staged_files unstaged_files untracked_files merge_conflicts "
     )
 
 
@@ -125,8 +121,6 @@ class StatusMixin(mixin_base):
             unstaged_files=unstaged_files,
             untracked_files=untracked_files,
             merge_conflicts=merge_conflicts,
-            short_status=short_status,
-            long_status=long_status
         )
         current_branch = branch_status.branch
         last_branches = store.current_state(self.repo_path)["last_branches"]

--- a/core/git_mixins/status.py
+++ b/core/git_mixins/status.py
@@ -75,6 +75,7 @@ class WorkingDirState(_WorkingDirState):
         )
 
 
+NullWorkingDirState = WorkingDirState([], [], [], [])
 MERGE_CONFLICT_PORCELAIN_STATUSES = (
     ("A", "A"),  # unmerged, both added
     ("U", "U"),  # unmerged, both modified

--- a/core/git_mixins/tags.py
+++ b/core/git_mixins/tags.py
@@ -32,7 +32,6 @@ class TagList(_TagList):
         return chain(*self)
 
 
-NullTagList = TagList([], [])
 SEMVER_TEST = re.compile(r'\d+\.\d+\.?\d*')
 
 

--- a/core/git_mixins/tags.py
+++ b/core/git_mixins/tags.py
@@ -3,6 +3,7 @@ from distutils.version import LooseVersion
 from itertools import chain
 import re
 
+from GitSavvy.core import store
 from GitSavvy.core.git_command import mixin_base
 
 
@@ -56,7 +57,11 @@ class TagsMixin(mixin_base):
             for line in stdout.splitlines()
             if line
         )
-        return self.handle_semver_tags(entries)
+        rv = self.handle_semver_tags(entries)
+        store.update_state(self.repo_path, {
+            "local_tags": rv,
+        })
+        return rv
 
     def get_remote_tags(self, remote):
         # type: (str) -> TagList

--- a/core/git_mixins/tags.py
+++ b/core/git_mixins/tags.py
@@ -32,6 +32,7 @@ class TagList(_TagList):
         return chain(*self)
 
 
+NullTagList = TagList([], [])
 SEMVER_TEST = re.compile(r'\d+\.\d+\.?\d*')
 
 

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -180,14 +180,12 @@ class BranchInterface(ui.ReactiveInterface, GitCommand):
                     "meta.git-savvy.branches.branch.active-branch"
                 )
             )
+        on_special_symbol = partial(self.cursor_is_on_something, "meta.git-savvy.branches.branch")
 
         cursor_was_on_active_branch = cursor_is_on_active_branch()
         yield
-        if cursor_was_on_active_branch and not cursor_is_on_active_branch():
+        if cursor_was_on_active_branch and not cursor_is_on_active_branch() or not on_special_symbol():
             self.view.run_command("gs_branches_navigate_to_active_branch")
-
-    def on_new_dashboard(self):
-        self.view.run_command("gs_branches_navigate_to_active_branch")
 
     @ui.section("branch_status")
     def render_branch_status(self):

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -166,6 +166,7 @@ class BranchInterface(ui.Interface, GitCommand):
             'git_root': self.short_repo_path,
             'branches': state.get("branches", []),
             'recent_commits': state.get("recent_commits", []),
+            'descriptions': state.get("descriptions", {}),
             'show_help': not self.view.settings().get("git_savvy.help_hidden"),
         })
 
@@ -221,11 +222,14 @@ class BranchInterface(ui.Interface, GitCommand):
             new_state = {}
         new_state["branches"] = state.get("branches")
         new_state["recent_commits"] = state.get("recent_commits")
+        new_state["descriptions"] = state.get("descriptions")
         self.update_state(new_state, then=self.just_render)
 
     def on_create(self):
         self._unsubscribe = store.subscribe(
-            self.repo_path, {"status", "branches", "recent_commits"}, self.on_status_update
+            self.repo_path,
+            {"status", "branches", "recent_commits", "descriptions"},
+            self.on_status_update
         )
 
     def on_close(self):

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -11,7 +11,6 @@ from ..git_command import GitCommand
 from ..git_mixins.active_branch import NullRecentCommits
 from ..ui_mixins.quick_panel import show_remote_panel, show_branch_panel
 from ..ui_mixins.input_panel import show_single_line_input_panel
-from GitSavvy.core import store
 from GitSavvy.core.fns import filter_
 from GitSavvy.core.utils import flash
 from GitSavvy.core.runtime import enqueue_on_worker, on_worker
@@ -143,14 +142,8 @@ class BranchInterface(ui.ReactiveInterface, GitCommand):
         enqueue_on_worker(self.get_remotes)
         self.view.run_command("gs_update_status")
 
-        state = store.current_state(self.repo_path)
         self.update_state({
             'git_root': self.short_repo_path,
-            'branches': state.get("branches", []),
-            'descriptions': state.get("descriptions", {}),
-            'long_status': state.get("long_status", ''),
-            'recent_commits': state.get("recent_commits", NullRecentCommits),
-            'remotes': state.get("remotes", {}),
             'sort_by_recent': self.savvy_settings.get("sort_by_recent_in_branch_dashboard"),
             'show_help': not self.view.settings().get("git_savvy.help_hidden"),
         })

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -125,18 +125,12 @@ class BranchInterface(ui.ReactiveInterface, GitCommand):
     {remote_branch_list}"""
 
     subscribe_to = {"branches", "descriptions", "long_status", "recent_commits", "remotes"}
+    state = {}  # type: BranchViewState
 
     def __init__(self, *args, **kwargs):
         self.state = {
-            'git_root': '',
-            'long_status': '',
-            'recent_commits': [],
-            'branches': [],
-            'descriptions': {},
-            'remotes': {},
             'show_remotes': self.savvy_settings.get("show_remotes_in_branch_dashboard"),
-            'show_help': True,
-        }  # type: BranchViewState
+        }
         super().__init__(*args, **kwargs)
 
     def title(self):

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -187,11 +187,13 @@ class BranchInterface(ui.ReactiveInterface, GitCommand):
         return "{0.hash} {0.message}".format(recent_commits[0])
 
     @ui.section("branch_list")
-    def render_branch_list(self, branches, sort_by_recent, descriptions):
-        # type: (List[Branch], bool, Dict[str, str]) -> str
+    def render_branch_list(self, branches, sort_by_recent):
+        # type: (List[Branch], bool) -> str
         local_branches = [branch for branch in branches if not branch.is_remote]
         if sort_by_recent:
             local_branches = sorted(local_branches, key=lambda branch: -branch.committerdate)
+        # Manually get `descriptions` to not delay the first render.
+        descriptions = self.state.get("descriptions", {})
         return self._render_branch_list(None, local_branches, descriptions)
 
     def _render_branch_list(self, remote_name, branches, descriptions):

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -41,7 +41,7 @@ __all__ = (
 
 MYPY = False
 if MYPY:
-    from typing import Dict, List, Optional, TypedDict
+    from typing import Dict, Iterator, List, Optional, TypedDict
     from ..git_mixins.active_branch import Commit
     from ..git_mixins.branches import Branch
 
@@ -132,9 +132,11 @@ class BranchInterface(ui.ReactiveInterface, GitCommand):
         super().__init__(*args, **kwargs)
 
     def title(self):
+        # type: () -> str
         return "BRANCHES: {}".format(os.path.basename(self.repo_path))
 
     def refresh_view_state(self):
+        # type: () -> None
         enqueue_on_worker(self.get_branches)
         enqueue_on_worker(self.fetch_branch_description_subjects)
         enqueue_on_worker(self.get_latest_commits)
@@ -149,6 +151,7 @@ class BranchInterface(ui.ReactiveInterface, GitCommand):
 
     @contextmanager
     def keep_cursor_on_something(self):
+        # type: () -> Iterator[None]
         def cursor_is_on_active_branch():
             sel = self.view.sel()
             return (
@@ -167,14 +170,17 @@ class BranchInterface(ui.ReactiveInterface, GitCommand):
 
     @ui.section("branch_status")
     def render_branch_status(self, long_status):
+        # type: (str) -> str
         return long_status
 
     @ui.section("git_root")
     def render_git_root(self, git_root):
+        # type: (str) -> str
         return git_root
 
     @ui.section("head")
     def render_head(self, recent_commits):
+        # type: (List[Commit]) -> str
         if not recent_commits:
             return "No commits yet."
 
@@ -206,21 +212,25 @@ class BranchInterface(ui.ReactiveInterface, GitCommand):
 
     @ui.section("remotes")
     def render_remotes(self, show_remotes):
+        # type: (bool) -> ui.RenderFnReturnType
         return (self.render_remotes_on()
                 if show_remotes else
                 self.render_remotes_off())
 
     @ui.section("help")
     def render_help(self, show_help):
+        # type: (bool) -> str
         if not show_help:
             return ""
         return self.template_help
 
     def render_remotes_off(self):
+        # type: () -> str
         return "\n\n  ** Press [e] to toggle display of remote branches. **\n"
 
     @ui.inject_state()
     def render_remotes_on(self, branches, sort_by_recent, remotes):
+        # type: (List[Branch], bool, Dict[str, str]) -> ui.RenderFnReturnType
         output_tmpl = "\n"
         render_fns = []
         remote_branches = [b for b in branches if b.is_remote]
@@ -233,7 +243,7 @@ class BranchInterface(ui.ReactiveInterface, GitCommand):
             branches = [b for b in remote_branches if b.canonical_name.startswith(remote_name + "/")]
 
             @ui.section(key)
-            def render(remote_name=remote_name, branches=branches):
+            def render(remote_name=remote_name, branches=branches) -> str:
                 return self.template_remote.format(
                     remote_name=remote_name,
                     remote_branch_list=self._render_branch_list(remote_name, branches, {})

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -220,9 +220,9 @@ class BranchInterface(ui.Interface, GitCommand):
             new_state = state["status"]._asdict()
         except KeyError:
             new_state = {}
-        new_state["branches"] = state.get("branches")
-        new_state["recent_commits"] = state.get("recent_commits")
-        new_state["descriptions"] = state.get("descriptions")
+        new_state["branches"] = state.get("branches", [])
+        new_state["recent_commits"] = state.get("recent_commits", [])
+        new_state["descriptions"] = state.get("descriptions", {})
         self.update_state(new_state, then=self.just_render)
 
     def on_create(self):

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -123,7 +123,7 @@ class BranchInterface(ui.ReactiveInterface, GitCommand):
       REMOTE ({remote_name}):
     {remote_branch_list}"""
 
-    subscribe_to = {"branches", "descriptions", "recent_commits", "remotes", "status"}
+    subscribe_to = {"branches", "descriptions", "long_status", "recent_commits", "remotes"}
 
     def __init__(self, *args, **kwargs):
         self.state = {
@@ -156,13 +156,11 @@ class BranchInterface(ui.ReactiveInterface, GitCommand):
             )
 
         self.view.run_command("gs_update_status")
-        # These are cheap to compute, so we just do it!
+
         state = store.current_state(self.repo_path)
-        status = state.get("status")
-        if status:
-            self.update_state(status._asdict())
         self.update_state({
             'git_root': self.short_repo_path,
+            'long_status': state.get("long_status", ''),
             'branches': state.get("branches", []),
             'remotes': state.get("remotes", {}),
             'recent_commits': state.get("recent_commits", []),

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -123,7 +123,7 @@ class BranchInterface(ui.ReactiveInterface, GitCommand):
       REMOTE ({remote_name}):
     {remote_branch_list}"""
 
-    subscribe_to = {"status", "branches", "recent_commits", "descriptions"}
+    subscribe_to = {"branches", "descriptions", "recent_commits", "remotes", "status"}
 
     def __init__(self, *args, **kwargs):
         self.state = {
@@ -164,6 +164,7 @@ class BranchInterface(ui.ReactiveInterface, GitCommand):
         self.update_state({
             'git_root': self.short_repo_path,
             'branches': state.get("branches", []),
+            'remotes': state.get("remotes", {}),
             'recent_commits': state.get("recent_commits", []),
             'descriptions': state.get("descriptions", {}),
             'show_help': not self.view.settings().get("git_savvy.help_hidden"),

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -1,13 +1,19 @@
+from contextlib import contextmanager
+from functools import partial
 import os
+import threading
 
+import sublime
 from sublime_plugin import WindowCommand
 
+from .status import distinct_until_state_changed
 from ...common import ui, util
 from ..commands import GsNavigate
 from ..commands.log import LogMixin
 from ..git_command import GitCommand
 from ..ui_mixins.quick_panel import show_remote_panel, show_branch_panel
 from ..ui_mixins.input_panel import show_single_line_input_panel
+from GitSavvy.core import store
 from GitSavvy.core.fns import filter_
 from GitSavvy.core.utils import flash
 from GitSavvy.core.runtime import on_worker
@@ -39,8 +45,24 @@ __all__ = (
 
 MYPY = False
 if MYPY:
-    from typing import List, Optional
-    from GitSavvy.core.git_mixins.branches import Branch
+    from typing import Dict, List, Optional, TypedDict
+    from ..git_mixins.active_branch import Commit
+    from ..git_mixins.branches import Branch
+
+    BranchViewState = TypedDict(
+        "BranchViewState",
+        {
+            "git_root": str,
+            "long_status": str,
+            "branches": List[Branch],
+            "descriptions": Dict[str, str],
+            "remotes": Dict[str, str],
+            "recent_commits": List[Commit],
+            "show_remotes": bool,
+            "show_help": bool,
+        },
+        total=False
+    )
 
 
 class gs_show_branch(WindowCommand, GitCommand):
@@ -61,8 +83,6 @@ class BranchInterface(ui.Interface, GitCommand):
 
     interface_type = "branch"
     syntax_file = "Packages/GitSavvy/syntax/branch.sublime-syntax"
-
-    show_remotes = None
 
     template = """\
 
@@ -105,18 +125,80 @@ class BranchInterface(ui.Interface, GitCommand):
       REMOTE ({remote_name}):
     {remote_branch_list}"""
 
+    def __init__(self, *args, **kwargs):
+        self._lock = threading.Lock()
+        self.state = {
+            'git_root': '',
+            'long_status': '',
+            'recent_commits': [],
+            'branches': [],
+            'descriptions': {},
+            'remotes': {},
+            'show_remotes': self.savvy_settings.get("show_remotes_in_branch_dashboard"),
+            'show_help': True,
+        }  # type: BranchViewState
+        super().__init__(*args, **kwargs)
+
     def title(self):
         return "BRANCHES: {}".format(os.path.basename(self.repo_path))
 
-    def pre_render(self):
+    def refresh_view_state(self):
         sort_by_recent = self.savvy_settings.get("sort_by_recent_in_branch_dashboard")
-        self._branches = self.get_branches(sort_by_recent=sort_by_recent)
-        self.descriptions = self.fetch_branch_description_subjects()
-        if self.show_remotes is None:
-            self.show_remotes = self.savvy_settings.get("show_remotes_in_branch_dashboard")
-        self.remotes = self.get_remotes() if self.show_remotes else {}
+        for thunk in (
+            lambda: {'recent_commits': self.get_latest_commits()},
+            lambda: {
+                'branches': self.get_branches(sort_by_recent=sort_by_recent),
+                'descriptions': self.fetch_branch_description_subjects(),
+            },
+            lambda: {'remotes': self.get_remotes()},
+        ):
+            sublime.set_timeout_async(
+                partial(self.update_state, thunk, then=self.just_render)
+            )
+
+        self.view.run_command("gs_update_status")
+        # These are cheap to compute, so we just do it!
+        state = store.current_state(self.repo_path)
+        status = state.get("status")
+        if status:
+            self.update_state(status._asdict())
+        self.update_state({
+            'git_root': self.short_repo_path,
+            'branches': state.get("branches", []),
+            'recent_commits': state.get("recent_commits", []),
+            'show_help': not self.view.settings().get("git_savvy.help_hidden"),
+        })
+
+    def update_state(self, data, then=None):
+        """Update internal view state and maybe invoke a callback.
+
+        `data` can be a mapping or a callable ("thunk") which returns
+        a mapping.
+
+        Note: We invoke the "sink" without any arguments. TBC.
+        """
+        if callable(data):
+            data = data()
+
+        with self._lock:
+            self.state.update(data)
+
+        if callable(then):
+            then()
 
     def render(self):
+        """Refresh view state and render."""
+        self.refresh_view_state()
+        self.just_render()
+
+    @distinct_until_state_changed
+    def just_render(self):
+        content, regions = self._render_template()
+        with self.keep_cursor_on_something():
+            self.draw(self.title(), content, regions)
+
+    @contextmanager
+    def keep_cursor_on_something(self):
         def cursor_is_on_active_branch():
             sel = self.view.sel()
             return (
@@ -128,29 +210,50 @@ class BranchInterface(ui.Interface, GitCommand):
             )
 
         cursor_was_on_active_branch = cursor_is_on_active_branch()
-        super().render()
+        yield
         if cursor_was_on_active_branch and not cursor_is_on_active_branch():
             self.view.run_command("gs_branches_navigate_to_active_branch")
+
+    def on_status_update(self, _repo_path, state):
+        try:
+            new_state = state["status"]._asdict()
+        except KeyError:
+            new_state = {}
+        new_state["branches"] = state.get("branches")
+        new_state["recent_commits"] = state.get("recent_commits")
+        self.update_state(new_state, then=self.just_render)
+
+    def on_create(self):
+        self._unsubscribe = store.subscribe(
+            self.repo_path, {"status", "branches", "recent_commits"}, self.on_status_update
+        )
+
+    def on_close(self):
+        self._unsubscribe()
 
     def on_new_dashboard(self):
         self.view.run_command("gs_branches_navigate_to_active_branch")
 
     @ui.section("branch_status")
     def render_branch_status(self):
-        return self.get_working_dir_status().long_status
+        return self.state['long_status']
 
     @ui.section("git_root")
     def render_git_root(self):
-        return self.short_repo_path
+        return self.state['git_root']
 
     @ui.section("head")
     def render_head(self):
-        return self.get_latest_commit_msg_for_head()
+        recent_commits = self.state['recent_commits']
+        if not recent_commits:
+            return "No commits yet."
+
+        return "{0.hash} {0.message}".format(recent_commits[0])
 
     @ui.section("branch_list")
     def render_branch_list(self):
         # type: () -> str
-        branches = [branch for branch in self._branches if not branch.is_remote]
+        branches = [branch for branch in self.state["branches"] if not branch.is_remote]
         return self._render_branch_list(None, branches)
 
     def _render_branch_list(self, remote_name, branches):
@@ -161,7 +264,7 @@ class BranchInterface(ui.Interface, GitCommand):
                 indicator="▸" if branch.active else " ",
                 hash=branch.commit_hash,
                 name=branch.canonical_name[remote_name_l:],
-                description=(" " + self.descriptions.get(branch.canonical_name, "")).rstrip(),
+                description=(" " + self.state["descriptions"].get(branch.canonical_name, "")).rstrip(),
                 tracking=(" ({branch}{status})".format(
                     branch=branch.upstream.canonical_name,
                     status=", " + branch.upstream.status if branch.upstream.status else ""
@@ -172,16 +275,15 @@ class BranchInterface(ui.Interface, GitCommand):
     @ui.section("remotes")
     def render_remotes(self):
         return (self.render_remotes_on()
-                if self.show_remotes else
+                if self.state["show_remotes"] else
                 self.render_remotes_off())
 
     @ui.section("help")
     def render_help(self):
-        help_hidden = self.view.settings().get("git_savvy.help_hidden")
-        if help_hidden:
+        show_help = self.state['show_help']
+        if not show_help:
             return ""
-        else:
-            return self.template_help
+        return self.template_help
 
     def render_remotes_off(self):
         return "\n\n  ** Press [e] to toggle display of remote branches. **\n"
@@ -189,9 +291,9 @@ class BranchInterface(ui.Interface, GitCommand):
     def render_remotes_on(self):
         output_tmpl = "\n"
         render_fns = []
-        remote_branches = [b for b in self._branches if b.is_remote]
+        remote_branches = [b for b in self.state["branches"] if b.is_remote]
 
-        for remote_name in self.remotes:
+        for remote_name in self.state["remotes"]:
             key = "branch_list_" + remote_name
             output_tmpl += "{" + key + "}\n"
             branches = [b for b in remote_branches if b.canonical_name.startswith(remote_name + "/")]
@@ -228,7 +330,7 @@ class BranchInterfaceCommand(ui.InterfaceCommand):
         def select_branch(remote_name, branch_name):
             # type: (str, str) -> Branch
             canonical_name = "/".join(filter_((remote_name, branch_name)))
-            for branch in self.interface._branches:
+            for branch in self.interface.state["branches"]:
                 if branch.canonical_name == canonical_name:
                     return (
                         branch._replace(
@@ -260,7 +362,7 @@ class BranchInterfaceCommand(ui.InterfaceCommand):
             )
         ] + [
             select_branch(remote_name, branch_name)
-            for remote_name in self.interface.remotes
+            for remote_name in self.interface.state["remotes"]
             for branch_name in ui.extract_by_selector(
                 self.view,
                 "meta.git-savvy.branches.branch.name",
@@ -525,9 +627,9 @@ class gs_branches_toggle_remotes(BranchInterfaceCommand):
 
     def run(self, edit, show=None):
         if show is None:
-            self.interface.show_remotes = not self.interface.show_remotes
+            self.interface.update_state({"show_remotes": not self.interface.state["show_remotes"]})
         else:
-            self.interface.show_remotes = show
+            self.interface.update_state({"show_remotes": show})
         self.interface.render()
 
 

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -641,14 +641,10 @@ class gs_branches_navigate_branch(GsNavigate):
     """
     Move cursor to the next (or previous) selectable branch in the dashboard.
     """
+    offset = 0
 
     def get_available_regions(self):
-        return [
-            branch_region
-            for region in self.view.find_by_selector(
-                "meta.git-savvy.branches.branch"
-            )
-            for branch_region in self.view.lines(region)]
+        return self.view.find_by_selector("meta.git-savvy.branches.branch.sha1")
 
 
 class gs_branches_navigate_to_active_branch(GsNavigate):
@@ -656,14 +652,11 @@ class gs_branches_navigate_to_active_branch(GsNavigate):
     """
     Move cursor to the active branch.
     """
+    offset = 0
 
     def get_available_regions(self):
-        return [
-            branch_region
-            for region in self.view.find_by_selector(
-                "meta.git-savvy.branches.branch.active-branch meta.git-savvy.branches.branch.sha1"
-            )
-            for branch_region in self.view.lines(region)]
+        return self.view.find_by_selector(
+            "meta.git-savvy.branches.branch.active-branch meta.git-savvy.branches.branch.sha1")
 
 
 class gs_branches_log(LogMixin, BranchInterfaceCommand):

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -8,6 +8,7 @@ from ...common import ui, util
 from ..commands import GsNavigate
 from ..commands.log import LogMixin
 from ..git_command import GitCommand
+from ..git_mixins.active_branch import NullRecentCommits
 from ..ui_mixins.quick_panel import show_remote_panel, show_branch_panel
 from ..ui_mixins.input_panel import show_single_line_input_panel
 from GitSavvy.core import store
@@ -148,7 +149,7 @@ class BranchInterface(ui.ReactiveInterface, GitCommand):
             'branches': state.get("branches", []),
             'descriptions': state.get("descriptions", {}),
             'long_status': state.get("long_status", ''),
-            'recent_commits': state.get("recent_commits", []),
+            'recent_commits': state.get("recent_commits", NullRecentCommits),
             'remotes': state.get("remotes", {}),
             'sort_by_recent': self.savvy_settings.get("sort_by_recent_in_branch_dashboard"),
             'show_help': not self.view.settings().get("git_savvy.help_hidden"),
@@ -183,6 +184,8 @@ class BranchInterface(ui.ReactiveInterface, GitCommand):
     @ui.section("head")
     def render_head(self):
         recent_commits = self.state['recent_commits']
+        if recent_commits is NullRecentCommits:
+            return ""
         if not recent_commits:
             return "No commits yet."
 

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -135,9 +135,6 @@ class BranchInterface(ui.Interface, GitCommand):
     def on_new_dashboard(self):
         self.view.run_command("gs_branches_navigate_to_active_branch")
 
-    def reset_cursor(self):
-        self.view.run_command("gs_branches_navigate_to_active_branch")
-
     @ui.section("branch_status")
     def render_branch_status(self):
         return self.get_working_dir_status().long_status

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -8,7 +8,6 @@ from ...common import ui, util
 from ..commands import GsNavigate
 from ..commands.log import LogMixin
 from ..git_command import GitCommand
-from ..git_mixins.active_branch import NullRecentCommits
 from ..ui_mixins.quick_panel import show_remote_panel, show_branch_panel
 from ..ui_mixins.input_panel import show_single_line_input_panel
 from GitSavvy.core.fns import filter_
@@ -176,8 +175,6 @@ class BranchInterface(ui.ReactiveInterface, GitCommand):
 
     @ui.section("head")
     def render_head(self, recent_commits):
-        if recent_commits is NullRecentCommits:
-            return ""
         if not recent_commits:
             return "No commits yet."
 

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -249,31 +249,30 @@ class StatusInterface(ui.ReactiveInterface, GitCommand):
         view.settings().set("result_base_dir", self.repo_path)
 
     @ui.section("branch_status")
-    def render_branch_status(self):
-        return self.state['long_status']
+    def render_branch_status(self, long_status):
+        return long_status
 
     @ui.section("git_root")
-    def render_git_root(self):
-        return self.state['git_root']
+    def render_git_root(self, git_root):
+        return git_root
 
     @ui.section("head")
-    def render_head(self):
-        # type: () -> str
-        recent_commits = self.state['recent_commits']
+    def render_head(self, recent_commits, head, branches):
+        # type: (List[Commit], HeadState, List[Branch]) -> str
         if recent_commits is NullRecentCommits:
             return ""
         if not recent_commits:
             return "No commits yet."
 
-        current_upstream = self.state['head'].remote
-        branches = self.state['branches']
+        current_upstream = head.remote
+        branches = branches
         return "\n           ".join(
             format_and_limit(recent_commits, ITEMS_IN_THE_RECENT_LIST, current_upstream, branches)
         )
 
     @ui.section("staged_files")
-    def render_staged_files(self):
-        staged_files = self.state['status'].staged_files
+    def render_staged_files(self, status):
+        staged_files = status.staged_files
         if not staged_files:
             return ""
 
@@ -289,8 +288,8 @@ class StatusInterface(ui.ReactiveInterface, GitCommand):
         ))
 
     @ui.section("unstaged_files")
-    def render_unstaged_files(self):
-        unstaged_files = self.state['status'].unstaged_files
+    def render_unstaged_files(self, status):
+        unstaged_files = status.unstaged_files
         if not unstaged_files:
             return ""
 
@@ -300,8 +299,8 @@ class StatusInterface(ui.ReactiveInterface, GitCommand):
         ))
 
     @ui.section("untracked_files")
-    def render_untracked_files(self):
-        untracked_files = self.state['status'].untracked_files
+    def render_untracked_files(self, status):
+        untracked_files = status.untracked_files
         if not untracked_files:
             return ""
 
@@ -309,20 +308,19 @@ class StatusInterface(ui.ReactiveInterface, GitCommand):
             "\n".join("    " + f.path for f in untracked_files))
 
     @ui.section("merge_conflicts")
-    def render_merge_conflicts(self):
-        merge_conflicts = self.state['status'].merge_conflicts
+    def render_merge_conflicts(self, status):
+        merge_conflicts = status.merge_conflicts
         if not merge_conflicts:
             return ""
         return self.template_merge_conflicts.format(
             "\n".join("    " + f.path for f in merge_conflicts))
 
     @ui.section("conflicts_bindings")
-    def render_conflicts_bindings(self):
-        return self.conflicts_keybindings if self.state['status'].merge_conflicts else ""
+    def render_conflicts_bindings(self, status):
+        return self.conflicts_keybindings if status.merge_conflicts else ""
 
     @ui.section("no_status_message")
-    def render_no_status_message(self):
-        status = self.state['status']
+    def render_no_status_message(self, status):
         return (
             "\n    Your working directory is clean.\n"
             if status is not NullWorkingDirState and status.clean
@@ -330,17 +328,15 @@ class StatusInterface(ui.ReactiveInterface, GitCommand):
         )
 
     @ui.section("stashes")
-    def render_stashes(self):
-        stash_list = self.state['stashes']
-        if not stash_list:
+    def render_stashes(self, stashes):
+        if not stashes:
             return ""
 
         return self.template_stashes.format("\n".join(
-            "    ({}) {}".format(stash.id, stash.description) for stash in stash_list))
+            "    ({}) {}".format(stash.id, stash.description) for stash in stashes))
 
     @ui.section("help")
-    def render_help(self):
-        show_help = self.state['show_help']
+    def render_help(self, show_help):
         if not show_help:
             return ""
 

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -206,7 +206,7 @@ class StatusInterface(ui.ReactiveInterface, GitCommand):
     {}
     """
 
-    subscribe_to = {"status", "head", "branches"}
+    subscribe_to = {"branches", "head", "long_status", "status"}
 
     def __init__(self, *args, **kwargs):
         self.state = {
@@ -253,6 +253,7 @@ class StatusInterface(ui.ReactiveInterface, GitCommand):
             self.update_state(status._asdict())
         self.update_state({
             'git_root': self.short_repo_path,
+            'long_status': state.get("long_status", ''),
             'show_help': not self.view.settings().get("git_savvy.help_hidden"),
             'stashes': state.get("stashes", []),
             'head': state.get("head", None),

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -5,8 +5,8 @@ import os
 import sublime
 from sublime_plugin import WindowCommand
 
-from ..git_mixins.status import FileStatus, NullWorkingDirState
-from ..git_mixins.active_branch import format_and_limit, NullRecentCommits
+from ..git_mixins.status import FileStatus
+from ..git_mixins.active_branch import format_and_limit
 from ..commands import GsNavigate
 from ...common import ui
 from ..git_command import GitCommand
@@ -259,8 +259,6 @@ class StatusInterface(ui.ReactiveInterface, GitCommand):
     @ui.section("head")
     def render_head(self, recent_commits, head, branches):
         # type: (List[Commit], HeadState, List[Branch]) -> str
-        if recent_commits is NullRecentCommits:
-            return ""
         if not recent_commits:
             return "No commits yet."
 
@@ -323,7 +321,7 @@ class StatusInterface(ui.ReactiveInterface, GitCommand):
     def render_no_status_message(self, status):
         return (
             "\n    Your working directory is clean.\n"
-            if status is not NullWorkingDirState and status.clean
+            if status.clean
             else ""
         )
 

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -41,7 +41,7 @@ __all__ = (
 
 MYPY = False
 if MYPY:
-    from typing import Iterable, List, Optional, TypedDict
+    from typing import Iterable, Iterator, List, Optional, TypedDict
     from ..git_mixins.active_branch import Commit
     from ..git_mixins.branches import Branch
     from ..git_mixins.stash import Stash
@@ -205,9 +205,11 @@ class StatusInterface(ui.ReactiveInterface, GitCommand):
     state = {}  # type: StatusViewState
 
     def title(self):
+        # type: () -> str
         return "STATUS: {}".format(os.path.basename(self.repo_path))
 
     def refresh_view_state(self):
+        # type: () -> None
         """Update all view state.
 
         Note: For every possible long running process, we enqueue a task
@@ -227,6 +229,7 @@ class StatusInterface(ui.ReactiveInterface, GitCommand):
 
     @contextmanager
     def keep_cursor_on_something(self):
+        # type: () -> Iterator[None]
         on_a_file = partial(self.cursor_is_on_something, 'meta.git-savvy.entity.filename')
         on_special_symbol = partial(self.cursor_is_on_something, 'meta.git-savvy.section.body.row')
 
@@ -236,6 +239,7 @@ class StatusInterface(ui.ReactiveInterface, GitCommand):
             self.view.run_command("gs_status_navigate_goto")
 
     def refresh_repo_status_and_render(self):
+        # type: () -> None
         """Refresh `git status` state and render.
 
         Most actions in the status dashboard only affect the `git status`.
@@ -245,15 +249,18 @@ class StatusInterface(ui.ReactiveInterface, GitCommand):
         self.update_working_dir_status()
 
     def after_view_creation(self, view):
+        # type: (sublime.View) -> None
         view.settings().set("result_file_regex", EXTRACT_FILENAME_RE)
         view.settings().set("result_base_dir", self.repo_path)
 
     @ui.section("branch_status")
     def render_branch_status(self, long_status):
+        # type: (str) -> str
         return long_status
 
     @ui.section("git_root")
     def render_git_root(self, git_root):
+        # type: (str) -> str
         return git_root
 
     @ui.section("head")
@@ -270,6 +277,7 @@ class StatusInterface(ui.ReactiveInterface, GitCommand):
 
     @ui.section("staged_files")
     def render_staged_files(self, status):
+        # type: (WorkingDirState) -> str
         staged_files = status.staged_files
         if not staged_files:
             return ""
@@ -287,6 +295,7 @@ class StatusInterface(ui.ReactiveInterface, GitCommand):
 
     @ui.section("unstaged_files")
     def render_unstaged_files(self, status):
+        # type: (WorkingDirState) -> str
         unstaged_files = status.unstaged_files
         if not unstaged_files:
             return ""
@@ -298,6 +307,7 @@ class StatusInterface(ui.ReactiveInterface, GitCommand):
 
     @ui.section("untracked_files")
     def render_untracked_files(self, status):
+        # type: (WorkingDirState) -> str
         untracked_files = status.untracked_files
         if not untracked_files:
             return ""
@@ -307,6 +317,7 @@ class StatusInterface(ui.ReactiveInterface, GitCommand):
 
     @ui.section("merge_conflicts")
     def render_merge_conflicts(self, status):
+        # type: (WorkingDirState) -> str
         merge_conflicts = status.merge_conflicts
         if not merge_conflicts:
             return ""
@@ -315,10 +326,12 @@ class StatusInterface(ui.ReactiveInterface, GitCommand):
 
     @ui.section("conflicts_bindings")
     def render_conflicts_bindings(self, status):
+        # type: (WorkingDirState) -> str
         return self.conflicts_keybindings if status.merge_conflicts else ""
 
     @ui.section("no_status_message")
     def render_no_status_message(self, status):
+        # type: (WorkingDirState) -> str
         return (
             "\n    Your working directory is clean.\n"
             if status.clean
@@ -327,6 +340,7 @@ class StatusInterface(ui.ReactiveInterface, GitCommand):
 
     @ui.section("stashes")
     def render_stashes(self, stashes):
+        # type: (List[Stash]) -> str
         if not stashes:
             return ""
 
@@ -335,6 +349,7 @@ class StatusInterface(ui.ReactiveInterface, GitCommand):
 
     @ui.section("help")
     def render_help(self, show_help):
+        # type: (bool) -> str
         if not show_help:
             return ""
 

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -203,19 +203,7 @@ class StatusInterface(ui.ReactiveInterface, GitCommand):
     """
 
     subscribe_to = {"branches", "head", "long_status", "status"}
-
-    def __init__(self, *args, **kwargs):
-        self.state = {
-            'status': WorkingDirState([], [], [], []),
-            'long_status': '',
-            'git_root': '',
-            'show_help': True,
-            'head': None,
-            'branches': [],
-            'recent_commits': [],
-            'stashes': []
-        }  # type: StatusViewState
-        super().__init__(*args, **kwargs)
+    state = {}  # type: StatusViewState
 
     def title(self):
         return "STATUS: {}".format(os.path.basename(self.repo_path))

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -94,13 +94,6 @@ EXTRACT_FILENAME_RE = (
 ITEMS_IN_THE_RECENT_LIST = 5
 
 
-def cursor_is_on_something(view, what):
-    return any(
-        view.match_selector(s.begin(), what)
-        for s in view.sel()
-    )
-
-
 class gs_show_status(WindowCommand, GitCommand):
 
     """
@@ -269,9 +262,8 @@ class StatusInterface(ui.ReactiveInterface, GitCommand):
 
     @contextmanager
     def keep_cursor_on_something(self):
-        on_something = partial(cursor_is_on_something, self.view)
-        on_a_file = partial(on_something, 'meta.git-savvy.entity.filename')
-        on_special_symbol = partial(on_something, 'meta.git-savvy.section.body.row')
+        on_a_file = partial(self.cursor_is_on_something, 'meta.git-savvy.entity.filename')
+        on_special_symbol = partial(self.cursor_is_on_something, 'meta.git-savvy.section.body.row')
 
         was_on_a_file = on_a_file()
         yield

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -30,7 +30,7 @@ __all__ = (
 
 MYPY = False
 if MYPY:
-    from typing import Dict, List, Literal, Optional, Union, TypedDict
+    from typing import Dict, Iterator, List, Literal, Optional, Union, TypedDict
     from ..git_mixins.active_branch import Commit
     from ..git_mixins.tags import TagDetails
 
@@ -133,9 +133,11 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
         super().__init__(*args, **kwargs)
 
     def title(self):
+        # type: () -> str
         return "TAGS: {}".format(os.path.basename(self.repo_path))
 
     def refresh_view_state(self):
+        # type: () -> None
         enqueue_on_worker(self.get_local_tags)
         enqueue_on_worker(self.get_latest_commits)
         enqueue_on_worker(self.get_remotes)
@@ -149,6 +151,7 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
 
     @contextmanager
     def keep_cursor_on_something(self):
+        # type: () -> Iterator[None]
         on_special_symbol = partial(self.cursor_is_on_something, "meta.git-savvy.tags.tag")
 
         yield
@@ -157,14 +160,17 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
 
     @ui.section("branch_status")
     def render_branch_status(self, long_status):
+        # type: (str) -> ui.RenderFnReturnType
         return long_status
 
     @ui.section("git_root")
     def render_git_root(self, git_root):
+        # type: (str) -> ui.RenderFnReturnType
         return git_root
 
     @ui.section("head")
     def render_head(self, recent_commits):
+        # type: (List[Commit]) -> ui.RenderFnReturnType
         if not recent_commits:
             return "No commits yet."
 
@@ -172,6 +178,7 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
 
     @ui.section("local_tags")
     def render_local_tags(self, local_tags, max_items):
+        # type: (TagList, int) -> ui.RenderFnReturnType
         if not any(local_tags.all):
             return NO_LOCAL_TAGS_MESSAGE
 
@@ -200,6 +207,7 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
 
     @ui.section("remote_tags")
     def render_remote_tags(self, remotes, show_remotes):
+        # type: (Dict[str, str], bool) -> ui.RenderFnReturnType
         if not remotes:
             return "\n"
 
@@ -223,6 +231,7 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
 
     @ui.section("help")
     def render_help(self, show_help):
+        # type: (bool) -> ui.RenderFnReturnType
         if not show_help:
             return ""
         return self.template_help
@@ -278,6 +287,7 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
         )
 
     def render_remote_tags_off(self):
+        # type: () -> str
         return "\n\n  ** Press [e] to toggle display of remote branches. **\n"
 
 

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -9,7 +9,7 @@ from ..commands import GsNavigate
 from ...common import ui
 from ..git_command import GitCommand, GitSavvyError
 from ..git_mixins.active_branch import NullRecentCommits
-from ..git_mixins.tags import TagList
+from ..git_mixins.tags import NullTagList, TagList
 from ...common import util
 from GitSavvy.core import store
 from GitSavvy.core.fns import filter_
@@ -146,7 +146,7 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
         state = store.current_state(self.repo_path)
         self.update_state({
             'git_root': self.short_repo_path,
-            'local_tags': state.get("local_tags", TagList([], [])),
+            'local_tags': state.get("local_tags", NullTagList),
             'long_status': state.get("long_status", ''),
             'recent_commits': state.get("recent_commits", NullRecentCommits),
             'remotes': state.get("remotes", {}),
@@ -183,6 +183,8 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
     @ui.section("local_tags")
     def render_local_tags(self):
         local_tags = self.state["local_tags"]
+        if local_tags is NullTagList:
+            return ""
         if not any(local_tags.all):
             return NO_LOCAL_TAGS_MESSAGE
 

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -124,7 +124,7 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
       REMOTE ({remote_name}):
     {remote_tags_list}"""
 
-    subscribe_to = {"local_tags", "recent_commits", "remotes", "status"}
+    subscribe_to = {"local_tags", "long_status", "recent_commits", "remotes"}
 
     def __init__(self, *args, **kwargs):
         self.state = {
@@ -154,13 +154,11 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
             )
 
         self.view.run_command("gs_update_status")
-        # These are cheap to compute, so we just do it!
+
         state = store.current_state(self.repo_path)
-        status = state.get("status")
-        if status:
-            self.update_state(status._asdict())
         self.update_state({
             'git_root': self.short_repo_path,
+            'long_status': state.get("long_status", ''),
             'local_tags': state.get("local_tags", TagList([], [])),
             'remotes': state.get("remotes", {}),
             'recent_commits': state.get("recent_commits", []),

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -124,7 +124,7 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
       REMOTE ({remote_name}):
     {remote_tags_list}"""
 
-    subscribe_to = {"status", "recent_commits"}
+    subscribe_to = {"status", "local_tags", "recent_commits"}
 
     def __init__(self, *args, **kwargs):
         self.state = {
@@ -161,6 +161,7 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
             self.update_state(status._asdict())
         self.update_state({
             'git_root': self.short_repo_path,
+            'local_tags': state.get("local_tags", TagList([], [])),
             'recent_commits': state.get("recent_commits", []),
             'max_items': self.savvy_settings.get("max_items_in_tags_dashboard", None),
             'show_help': not self.view.settings().get("git_savvy.help_hidden"),

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -485,8 +485,7 @@ class gs_tags_navigate_tag(GsNavigate):
     """
     Move cursor to the next (or previous) selectable file in the dashboard.
     """
+    offset = 0
 
     def get_available_regions(self):
-        return [file_region
-                for region in self.view.find_by_selector("meta.git-savvy.tag.name")
-                for file_region in self.view.lines(region)]
+        return self.view.find_by_selector("constant.other.git-savvy.tags.sha1")

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -99,7 +99,8 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
       HEAD:    {head}
 
       LOCAL:
-    {local_tags}{remote_tags}
+    {local_tags}
+    {remote_tags}
     {< help}
     """
     template_help = """
@@ -238,7 +239,7 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
         if not show_remotes:
             return self.render_remote_tags_off()
 
-        output_tmpl = "\n"
+        output_tmpl = ""
         render_fns = []
 
         for remote_name in remotes:
@@ -296,7 +297,7 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
 
     def render_remote_tags_off(self):
         # type: () -> str
-        return "\n\n  ** Press [e] to toggle display of remote branches. **\n"
+        return "\n  ** Press [e] to toggle display of remote branches. **\n"
 
 
 TAGS_SELECTOR = "meta.git-savvy.tag.name"

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -125,19 +125,13 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
     {remote_tags_list}"""
 
     subscribe_to = {"local_tags", "long_status", "recent_commits", "remotes"}
+    state = {}  # type: TagsViewState
 
     def __init__(self, *args, **kwargs):
         self.state = {
-            'git_root': '',
-            'long_status': '',
-            'local_tags': TagList([], []),
-            'remotes': {},
-            'remote_tags': {},
-            'recent_commits': [],
-            'max_items': self.savvy_settings.get("max_items_in_tags_dashboard", None),
             'show_remotes': self.savvy_settings.get("show_remotes_in_branch_dashboard"),
-            'show_help': True,
-        }  # type: TagsViewState
+            'remote_tags': {}
+        }
         super().__init__(*args, **kwargs)
 
     def title(self):

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -124,7 +124,7 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
       REMOTE ({remote_name}):
     {remote_tags_list}"""
 
-    subscribe_to = {"status", "local_tags", "recent_commits"}
+    subscribe_to = {"local_tags", "recent_commits", "remotes", "status"}
 
     def __init__(self, *args, **kwargs):
         self.state = {
@@ -162,6 +162,7 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
         self.update_state({
             'git_root': self.short_repo_path,
             'local_tags': state.get("local_tags", TagList([], [])),
+            'remotes': state.get("remotes", {}),
             'recent_commits': state.get("recent_commits", []),
             'max_items': self.savvy_settings.get("max_items_in_tags_dashboard", None),
             'show_help': not self.view.settings().get("git_savvy.help_hidden"),

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -8,6 +8,7 @@ from sublime_plugin import WindowCommand
 from ..commands import GsNavigate
 from ...common import ui
 from ..git_command import GitCommand, GitSavvyError
+from ..git_mixins.active_branch import NullRecentCommits
 from ..git_mixins.tags import TagList
 from ...common import util
 from GitSavvy.core import store
@@ -147,7 +148,7 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
             'git_root': self.short_repo_path,
             'local_tags': state.get("local_tags", TagList([], [])),
             'long_status': state.get("long_status", ''),
-            'recent_commits': state.get("recent_commits", []),
+            'recent_commits': state.get("recent_commits", NullRecentCommits),
             'remotes': state.get("remotes", {}),
             'max_items': self.savvy_settings.get("max_items_in_tags_dashboard", None),
             'show_help': not self.view.settings().get("git_savvy.help_hidden"),
@@ -172,6 +173,8 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
     @ui.section("head")
     def render_head(self):
         recent_commits = self.state['recent_commits']
+        if recent_commits is NullRecentCommits:
+            return ""
         if not recent_commits:
             return "No commits yet."
 

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -157,16 +157,15 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
             self.view.run_command("gs_tags_navigate_tag")
 
     @ui.section("branch_status")
-    def render_branch_status(self):
-        return self.state['long_status']
+    def render_branch_status(self, long_status):
+        return long_status
 
     @ui.section("git_root")
-    def render_git_root(self):
-        return self.state['git_root']
+    def render_git_root(self, git_root):
+        return git_root
 
     @ui.section("head")
-    def render_head(self):
-        recent_commits = self.state['recent_commits']
+    def render_head(self, recent_commits):
         if recent_commits is NullRecentCommits:
             return ""
         if not recent_commits:
@@ -175,15 +174,13 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
         return "{0.hash} {0.message}".format(recent_commits[0])
 
     @ui.section("local_tags")
-    def render_local_tags(self):
-        local_tags = self.state["local_tags"]
+    def render_local_tags(self, local_tags, max_items):
         if local_tags is NullTagList:
             return ""
         if not any(local_tags.all):
             return NO_LOCAL_TAGS_MESSAGE
 
         regular_tags, versions = local_tags
-        max_items = self.state["max_items"]
         return "\n{}\n".format(" " * 60).join(  # need some spaces on the separator line otherwise
                                                 # the syntax expects the remote section begins
             filter_((
@@ -207,17 +204,17 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
         )
 
     @ui.section("remote_tags")
-    def render_remote_tags(self):
-        if not self.state["remotes"]:
+    def render_remote_tags(self, remotes, show_remotes):
+        if not remotes:
             return "\n"
 
-        if not self.state["show_remotes"]:
+        if not show_remotes:
             return self.render_remote_tags_off()
 
         output_tmpl = "\n"
         render_fns = []
 
-        for remote_name in self.state["remotes"]:
+        for remote_name in remotes:
             tmpl_key = "remote_tags_list_" + remote_name
             output_tmpl += "{" + tmpl_key + "}\n"
 
@@ -230,8 +227,7 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
         return output_tmpl, render_fns
 
     @ui.section("help")
-    def render_help(self):
-        show_help = self.state['show_help']
+    def render_help(self, show_help):
         if not show_help:
             return ""
         return self.template_help

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -264,11 +264,12 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
             return ""
         return self.template_help
 
-    def get_remote_tags_list(self, remote_name, remote_info):
-        # type: (str, FetchStateMachine) -> str
+    @ui.inject_state()
+    def get_remote_tags_list(self, remote_name, remote_info, local_tags, max_items):
+        # type: (str, FetchStateMachine, TagList, int) -> str
         if remote_info["state"] == "succeeded":
             if remote_info["tags"]:
-                seen = {tag.sha: tag.tag for tag in self.state["local_tags"].all}
+                seen = {tag.sha: tag.tag for tag in local_tags.all}
                 tags_list = [
                     tag
                     for tag in remote_info["tags"]
@@ -276,7 +277,7 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
                 ]
                 msg = "\n".join(
                     "    {} {}".format(self.get_short_hash(tag.sha), tag.tag)
-                    for tag in tags_list[:self.state["max_items"]]
+                    for tag in tags_list[:max_items]
                 ) or NO_MORE_TAGS_MESSAGE
 
             else:

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -11,7 +11,6 @@ from ..git_command import GitCommand, GitSavvyError
 from ..git_mixins.active_branch import NullRecentCommits
 from ..git_mixins.tags import NullTagList, TagList
 from ...common import util
-from GitSavvy.core import store
 from GitSavvy.core.fns import filter_
 from GitSavvy.core.runtime import enqueue_on_worker, on_worker, run_on_new_thread
 from GitSavvy.core.utils import flash, uprint
@@ -143,13 +142,8 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
         enqueue_on_worker(self.get_remotes)
         self.view.run_command("gs_update_status")
 
-        state = store.current_state(self.repo_path)
         self.update_state({
             'git_root': self.short_repo_path,
-            'local_tags': state.get("local_tags", NullTagList),
-            'long_status': state.get("long_status", ''),
-            'recent_commits': state.get("recent_commits", NullRecentCommits),
-            'remotes': state.get("remotes", {}),
             'max_items': self.savvy_settings.get("max_items_in_tags_dashboard", None),
             'show_help': not self.view.settings().get("git_savvy.help_hidden"),
         })

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -8,8 +8,7 @@ from sublime_plugin import WindowCommand
 from ..commands import GsNavigate
 from ...common import ui
 from ..git_command import GitCommand, GitSavvyError
-from ..git_mixins.active_branch import NullRecentCommits
-from ..git_mixins.tags import NullTagList, TagList
+from ..git_mixins.tags import TagList
 from ...common import util
 from GitSavvy.core.fns import filter_
 from GitSavvy.core.runtime import enqueue_on_worker, on_worker, run_on_new_thread
@@ -166,8 +165,6 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
 
     @ui.section("head")
     def render_head(self, recent_commits):
-        if recent_commits is NullRecentCommits:
-            return ""
         if not recent_commits:
             return "No commits yet."
 
@@ -175,8 +172,6 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
 
     @ui.section("local_tags")
     def render_local_tags(self, local_tags, max_items):
-        if local_tags is NullTagList:
-            return ""
         if not any(local_tags.all):
             return NO_LOCAL_TAGS_MESSAGE
 

--- a/core/store.py
+++ b/core/store.py
@@ -15,6 +15,7 @@ if MYPY:
     from GitSavvy.core.git_mixins.branches import Branch
     from GitSavvy.core.git_mixins.stash import Stash
     from GitSavvy.core.git_mixins.status import HeadState, WorkingDirState
+    from GitSavvy.core.git_mixins.tags import TagList
 
     RepoPath = str
     RepoStore = TypedDict(
@@ -23,6 +24,7 @@ if MYPY:
             "status": WorkingDirState,
             "head": HeadState,
             "branches": List[Branch],
+            "local_tags": TagList,
             "last_branches": Deque[Optional[str]],
             "last_local_branch_for_rebase": Optional[str],
             "last_remote_used": Optional[str],

--- a/core/store.py
+++ b/core/store.py
@@ -47,20 +47,8 @@ if MYPY:
 
 def initial_state():
     # type: () -> RepoStore
-    from GitSavvy.core.git_mixins.active_branch import NullRecentCommits
-    from GitSavvy.core.git_mixins.status import NullHeadState, NullWorkingDirState
-    from GitSavvy.core.git_mixins.tags import NullTagList
     return {
-        "branches": [],
-        "descriptions": {},
-        "head": NullHeadState,
         "last_branches": deque([None] * 2, 2),
-        "local_tags": NullTagList,
-        "long_status": "",
-        "recent_commits": NullRecentCommits,
-        "remotes": {},
-        "stashes": [],
-        "status": NullWorkingDirState,
     }
 
 

--- a/core/store.py
+++ b/core/store.py
@@ -23,6 +23,8 @@ if MYPY:
         {
             "status": WorkingDirState,
             "head": HeadState,
+            "long_status": str,
+            "short_status": str,
             "branches": List[Branch],
             "remotes": Dict[str, str],
             "local_tags": TagList,

--- a/core/store.py
+++ b/core/store.py
@@ -32,6 +32,7 @@ if MYPY:
             "short_hash_length": int,
             "stashes": List[Stash],
             "recent_commits": List[Commit],
+            "descriptions": Dict[str, str],
         },
         total=False
     )

--- a/core/store.py
+++ b/core/store.py
@@ -47,7 +47,21 @@ if MYPY:
 
 def initial_state():
     # type: () -> RepoStore
-    return {"last_branches": deque([None] * 2, 2)}
+    from GitSavvy.core.git_mixins.active_branch import NullRecentCommits
+    from GitSavvy.core.git_mixins.status import NullHeadState, NullWorkingDirState
+    from GitSavvy.core.git_mixins.tags import NullTagList
+    return {
+        "branches": [],
+        "descriptions": {},
+        "head": NullHeadState,
+        "last_branches": deque([None] * 2, 2),
+        "local_tags": NullTagList,
+        "long_status": "",
+        "recent_commits": NullRecentCommits,
+        "remotes": {},
+        "stashes": [],
+        "status": NullWorkingDirState,
+    }
 
 
 state = defaultdict(initial_state)  # type: DefaultDict[RepoPath, RepoStore]

--- a/core/store.py
+++ b/core/store.py
@@ -24,6 +24,7 @@ if MYPY:
             "status": WorkingDirState,
             "head": HeadState,
             "branches": List[Branch],
+            "remotes": Dict[str, str],
             "local_tags": TagList,
             "last_branches": Deque[Optional[str]],
             "last_local_branch_for_rebase": Optional[str],

--- a/tests/test_fetch_branch_descriptions.py
+++ b/tests/test_fetch_branch_descriptions.py
@@ -4,7 +4,7 @@ from unittesting import DeferrableTestCase
 from GitSavvy.tests.mockito import when
 from GitSavvy.tests.parameterized import parameterized as p
 
-from GitSavvy.core.git_mixins.branches import BranchesMixin
+from GitSavvy.core.git_command import GitCommand
 
 
 examples = [
@@ -32,6 +32,7 @@ examples = [
 class TestFetchBranchDescriptions(DeferrableTestCase):
     @p.expand(examples)
     def test_description_subjects(self, git_output, expected):
-        test = BranchesMixin()
+        test = GitCommand()
+        when(test).get_repo_path().thenReturn("probably/here")
         when(test, strict=False).git("config", ...).thenReturn(git_output)
         self.assertEqual(expected, test.fetch_branch_description_subjects())

--- a/tests/test_graph_view.py
+++ b/tests/test_graph_view.py
@@ -34,7 +34,7 @@ else:
 THIS_DIRNAME = os.path.dirname(os.path.realpath(__file__))
 COMMIT_1 = 'This is commit fec0aca'
 COMMIT_2 = 'This is commit f461ea1'
-CLEAN_WORKING_DIR = WorkingDirState([], [], [], [], '', '')
+CLEAN_WORKING_DIR = WorkingDirState([], [], [], [])
 
 
 def fixture(name):

--- a/tests/test_inject_state.py
+++ b/tests/test_inject_state.py
@@ -1,0 +1,76 @@
+from GitSavvy.common import ui
+
+from unittesting import DeferrableTestCase
+from GitSavvy.tests.parameterized import parameterized as p
+from GitSavvy.tests.parameterized import param
+
+
+class TestAutoInjectingState(DeferrableTestCase):
+    @p.expand([
+        (
+            "fills in argument from state",
+            lambda self, status: status,
+            {"status": "ok"},
+            param(),
+            "ok"
+        ),
+        (
+            "fills in two arguments from state",
+            lambda self, status, code: (status, code),
+            {"status": "ok", "code": 202},
+            param(),
+            ("ok", 202)
+        ),
+        (
+            "given first arg (positional), fill in the second",
+            lambda self, status, code: (status, code),
+            {"status": "ok", "code": 202},
+            param("erred"),
+            ("erred", 202)
+        ),
+        (
+            "`given first arg (per keyword), fill in the second",
+            lambda self, status, code: (status, code),
+            {"status": "ok", "code": 202},
+            param(status="erred"),
+            ("erred", 202)
+        ),
+        (
+            "given second arg, fill in the first",
+            lambda self, status, code: (status, code),
+            {"status": "ok", "code": 202},
+            param(code=303),
+            ("ok", 303)
+        ),
+        (
+            "do not fill in args which have defaults",
+            lambda self, status, code=202: (status, code),
+            {"status": "ok", "code": "xxx"},
+            param(),
+            ("ok", 202)
+        ),
+
+        (
+            "okay if fn takes no arguments",
+            lambda self: "ok",
+            {"status": "ok", "code": "xxx"},
+            param(),
+            "ok"
+        ),
+    ])
+    def test_success_cases(self, _, fn, state, call_sig, return_value):
+
+        self.state = state
+        self.assertEqual(
+            ui.section("branch")(fn)
+            (self, *call_sig.args, **call_sig.kwargs),
+            return_value)
+
+    def test_return_empty_string_if_val_not_present(self):
+        self.state = {}
+
+        @ui.section("branch")
+        def fn(self, status):
+            return status
+
+        self.assertEqual(fn(self), "")

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -503,6 +503,7 @@ class TestRecentCommitsFormat(DeferrableTestCase):
                 "The Subject",
                 False,
                 False,
+                0,
                 git_mixins.branches.Upstream(
                     "origin", "master", "origin/master", ""
                 )

--- a/tests/test_status_dashboard.py
+++ b/tests/test_status_dashboard.py
@@ -54,6 +54,7 @@ class TestStatusDashboard(DeferrableTestCase):
         # by a `when` to just fake the specific check for REPO_PATH.
         spy2('os.path.exists')
         when(os.path).exists(repo_path).thenReturn(True)
+        when(GitCommand).get_repo_path().thenReturn(repo_path)
         when(GitCommand).in_merge().thenReturn(False)
         when(GitCommand).in_cherry_pick().thenReturn(False)
         when(GitCommand).git('status', ...).thenReturn(file_status)
@@ -176,7 +177,7 @@ class TestStatusDashboard(DeferrableTestCase):
     def test_extract_subjects(self, SELECTED_FILE, SECTION, EXPECTED):
         interface, view = yield from self.await_std_interface()
 
-        region = view.find(SELECTED_FILE, 0, sublime.LITERAL)
+        region = yield lambda: view.find(SELECTED_FILE, 0, sublime.LITERAL)
         view.sel().clear()
         view.sel().add(region.begin())
         self.assertEqual(StatusInterfaceCommand(view).get_selected_subjects(SECTION), EXPECTED)


### PR DESCRIPTION
Since I deprecated the rebase dashboard, move the (easier) remaining ones, branches and tags, to match the status dashboard ("reactive") style.  

T.i. basically decouple state fetching/getting from drawing.  Then also cache most of the data needed to render the dashboards, especially the data we share between all of the them (everything in the header element).

The goal is that on `tab` we immediately draw the next dashboard and then eventually refresh that if the caches are outdated.

Mildly fancy we now inject state into the render functions.  I do this to avoid null objects all over the place, or `except KeyError` catchers.  Now the render functions just don't run if their dependencies are not present.         

