### PR TITLE
Iter tags dashboard

### DIFF
--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -139,10 +139,14 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
 
     def refresh_view_state(self):
         # type: () -> None
-        self.maybe_populate_remote_tags()
         enqueue_on_worker(self.get_local_tags)
         enqueue_on_worker(self.get_latest_commits)
         enqueue_on_worker(self.get_remotes)
+        if self.state.get("remotes") is None:
+            # run after the `self.get_remotes` above!
+            enqueue_on_worker(self.maybe_populate_remote_tags)
+        else:
+            self.maybe_populate_remote_tags()
         self.view.run_command("gs_update_status")
 
         self.update_state({

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -270,11 +270,11 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
         # type: (str, FetchStateMachine, TagList, int) -> str
         if remote_info["state"] == "succeeded":
             if remote_info["tags"]:
-                seen = {tag.sha: tag.tag for tag in local_tags.all}
+                seen = {(tag.sha, tag.tag) for tag in local_tags.all}
                 tags_list = [
                     tag
                     for tag in remote_info["tags"]
-                    if tag.tag[-3:] != "^{}" and tag.sha not in seen
+                    if tag.tag[-3:] != "^{}" and (tag.sha, tag.tag) not in seen
                 ]
                 msg = "\n".join(
                     "    {} {}".format(self.get_short_hash(tag.sha), tag.tag)

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -341,11 +341,11 @@ class gs_tags_toggle_remotes(TagsInterfaceCommand):
 
     def run(self, edit, show=None):
         interface = self.interface
-        interface.state["remote_tags"] = {}
-        if show is None:
-            interface.state["show_remotes"] = not interface.state["show_remotes"]
-        else:
-            interface.state["show_remotes"] = show
+        current_state = interface.state["show_remotes"]
+        next_state = not current_state if show is None else show
+        interface.state["show_remotes"] = next_state
+        if next_state:
+            interface.state["remote_tags"] = {}
         interface.render()
 
 

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -486,18 +486,19 @@ class gs_tags_show_commit(TagsInterfaceCommand):
 
 class gs_tags_show_graph(TagsInterfaceCommand):
     def run(self, edit) -> None:
-        # NOTE: We take the commit sha's here (instead of the tag names)
-        #       because in the graph a tag ref takes the form e.g.
-        #       `tag: 2.14.5`.  T.i we avoid prepending "tag: " here.
-        commits = self.selected_local_commits()
-        if not commits:
+        # NOTE: We take the tag name because the sha can be point to
+        #       a real commit or a tag in case it's an annotated tag.
+        #       Because in the graph a tag ref takes the form e.g.
+        #       `tag: 2.14.5` we need to format it like that here.
+        tags = self.selected_local_tags()
+        if not tags:
             return
-        if len(commits) > 1:
+        if len(tags) > 1:
             flash(self.view, "Can only follow one tag. Taking the first one")
 
         self.window.run_command('gs_graph', {
             'all': True,
-            'follow': commits[0]
+            'follow': "tag: {}".format(tags[0])
         })
 
 

--- a/syntax/tags.sublime-syntax
+++ b/syntax/tags.sublime-syntax
@@ -29,9 +29,11 @@ contexts:
   section:
     - match: ^$
       pop: true
-    - match: '^    ([0-9a-f]{7,40}) (.+?)(?: +(.+))?\n$'
+    - match: '^   (?:(\*)|(!)| )([0-9a-f]{7,40}) (.+?)(?: +(.+))?\n$'
       scope: meta.git-savvy.tags.tag
       captures:
-        1: constant.other.git-savvy.tags.sha1
-        2: meta.git-savvy.tag.name gitsavvy.gotosymbol
-        3: comment.git-savvy.tag.age
+        1: punctuation.tag-tag.new-tag.git-savvy
+        2: punctuation.tag-tag.changed-tag.git-savvy
+        3: constant.other.git-savvy.tags.sha1
+        4: meta.git-savvy.tag.name gitsavvy.gotosymbol
+        5: comment.git-savvy.tag.age


### PR DESCRIPTION
- Fix: `[g]` to annotated tags did not work
- Fix: multiple tags on the same sha on a remote were not visible under some circumstances
- Feat: Add special markers for new (unpushed) tags and changed tag (which are on a different sha than on the remote)
- Further tune the fetch/render order