### PR TITLE
Clarify when we need a full render

### DIFF
--- a/common/ui.py
+++ b/common/ui.py
@@ -438,6 +438,11 @@ def indent_by_2(text):
     return "\n".join(line[2:] for line in text.split("\n"))
 
 
+def should_do_a_full_render(current, previous):
+    # type: (AbstractSet[str], AbstractSet[str]) -> bool
+    return bool(current - previous) or not previous
+
+
 class gs_new_content_and_regions(TextCommand):
     current_region_names = set()  # type: AbstractSet[str]
 
@@ -454,11 +459,7 @@ class gs_new_content_and_regions(TextCommand):
             else:
                 return content[a:b]
 
-        if (
-            not regions
-            or not self.current_region_names
-            or regions.keys() - self.current_region_names
-        ):
+        if should_do_a_full_render(regions.keys(), self.current_region_names):
             replace_view_content(self.view, content)
 
         else:

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,0 +1,21 @@
+from GitSavvy.common import ui
+
+from unittesting import DeferrableTestCase
+from GitSavvy.tests.parameterized import parameterized as p
+
+
+class TestWhenWeNeedAFullRender(DeferrableTestCase):
+    @p.expand([
+        (set([]), set([]), True),
+        (set([1, 2]), set([]), True),
+        (set([1, 2]), set([1]), True),
+        (set([1, 2]), set([2, 3]), True),
+        (set([1, 2]), set([3, 4]), True),
+
+        (set([]), set([1, 2]), False),
+        (set([1]), set([1, 2]), False),
+        (set([1, 2]), set([1, 2]), False),
+
+    ])
+    def test_do_a_full_render(self, current, previous, RESULT):
+        self.assertEqual(ui.should_do_a_full_render(current, previous), RESULT)


### PR DESCRIPTION
After the hotfix 3266859a (Fix `blame` not rendering anything) we do a
fresh render whenever `regions` becomes empty which is not necessary
(and a bit confusing).  Rewrite that passage for clarity:

We need a full render whenever we have sections not currently drawn;
and also when we haven't drawn any sections at all in the previous
round.  The latter implies `not regions`.

In other words: Instead of `not regions` *or* `not current_region_names`
*and* would have been correct.

Add tests because I did this wrong 3 times now.
