### PR TITLE
Deep import `package_control.events`

### DIFF
--- a/git_savvy.py
+++ b/git_savvy.py
@@ -14,7 +14,7 @@ from .gitlab.commands import *
 def plugin_loaded():
 
     try:
-        import package_control
+        import package_control.events
     except ImportError:
         pass
     else:


### PR DESCRIPTION
For the new to come Package Control v4, we need to import the `events` module deeply.

Fixes #1576