### PR TITLE
Only ask for a tag message if the tag looks like a version

### DIFF
--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -129,6 +129,14 @@
     "default_tag_message": "Tag {tag_name}",
 
     /*
+        Ask for a tag message to annotate the tag only if the tag looks like
+        a version, e.g. "v2.31.2" or "2022.11.23".  All other tags are considered
+        private and don't need to get annotated as we never push them.
+        Set to `false` if you always want to get asked for a tag message.
+     */
+    "only_ask_to_annotate_versions": true,
+
+    /*
         The filename for extra customized info to be displayed after the default
         COMMIT_HELP_TEXT, such as commit message rules/tips/conventions.
         Place this file at the root of the repo, and it should be commited to the

--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -139,7 +139,7 @@
     /*
         The filename for extra customized info to be displayed after the default
         COMMIT_HELP_TEXT, such as commit message rules/tips/conventions.
-        Place this file at the root of the repo, and it should be commited to the
+        Place this file at the root of the repo, and it should be committed to the
         repo as well.
         The file name defaults to `.commit_help`.
         If this file is not presented, the functionality is totally ignored.

--- a/core/commands/tag.py
+++ b/core/commands/tag.py
@@ -27,6 +27,7 @@ if MYPY:
 
 
 RELEASE_REGEXP = re.compile(r"^([0-9A-Za-z-]*[A-Za-z-])?([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-\.]*?)?([0-9]+))?$")
+MAYBE_SEMVER = re.compile(r"\d+\.\d+(\.\d+)?")
 
 TAG_CREATE_PROMPT = "Enter tag:"
 TAG_CREATE_MESSAGE = "Tag \"{}\" created."
@@ -112,13 +113,17 @@ class gs_tag_create(GsTextCommand):
             return None
 
         self.tag_name = stdout.strip()[10:]
-        show_single_line_input_panel(
-            TAG_CREATE_MESSAGE_PROMPT,
-            self.savvy_settings.get("default_tag_message").format(tag_name=tag_name),
-            self.on_entered_message
-        )
 
-    def on_entered_message(self, message):
+        if MAYBE_SEMVER.search(tag_name) and self.savvy_settings.get("only_ask_to_annotate_versions"):
+            show_single_line_input_panel(
+                TAG_CREATE_MESSAGE_PROMPT,
+                self.savvy_settings.get("default_tag_message").format(tag_name=tag_name),
+                self.on_entered_message
+            )
+        else:
+            self.on_entered_message()
+
+    def on_entered_message(self, message=None):
         # type: (str) -> None
         """
         Create a tag with the specified tag name and message.


### PR DESCRIPTION
Fixes #1737

This is pluggable via the `only_ask_to_annotate_versions` setting.