### PR TITLE
Avoid active reloading after upgrade

### DIFF
--- a/git_savvy.py
+++ b/git_savvy.py
@@ -1,3 +1,12 @@
+import sys
+
+prefix = __package__ + '.'  # don't clear the base package
+for module_name in [
+        module_name for module_name in sys.modules
+        if module_name.startswith(prefix) and module_name != __name__]:
+    del sys.modules[module_name]
+prefix = None
+
 import sublime
 
 from .common.commands import *
@@ -12,30 +21,7 @@ from .gitlab.commands import *
 
 
 def plugin_loaded():
-
-    try:
-        import package_control.events
-    except ImportError:
-        pass
-    else:
-        if (
-            package_control.events.install('GitSavvy') or
-            package_control.events.post_upgrade('GitSavvy')
-        ):
-            # The "event" (flag) is set for 5 seconds. To not get into a
-            # reloader excess we wait for that time, so that the next time
-            # this exact `plugin_loaded` handler runs, the flag is already
-            # unset.
-            sublime.set_timeout_async(reload_plugin, 5000)
-            return
-
     prepare_gitsavvy()
-
-
-def reload_plugin():
-    from .common import util
-    print("GitSavvy: Reloading plugin after install.")
-    util.reload.reload_plugin(verbose=False, then=prepare_gitsavvy)
 
 
 def prepare_gitsavvy():

--- a/git_savvy.py
+++ b/git_savvy.py
@@ -1,23 +1,23 @@
 import sys
-
 prefix = __package__ + '.'  # don't clear the base package
 for module_name in [
         module_name for module_name in sys.modules
         if module_name.startswith(prefix) and module_name != __name__]:
     del sys.modules[module_name]
-prefix = None
+del prefix
 
-import sublime
 
-from .common.commands import *
-from .common.ui import *
-from .common.global_events import *
-from .core.commands import *
-from .core.settings import *
-from .core.interfaces import *
-from .core.runtime import *
-from .github.commands import *
-from .gitlab.commands import *
+import sublime  # noqa: E402
+
+from .common.commands import *  # noqa: E402
+from .common.ui import *  # noqa: E402
+from .common.global_events import *  # noqa: E402
+from .core.commands import *  # noqa: E402
+from .core.settings import *  # noqa: E402
+from .core.interfaces import *  # noqa: E402
+from .core.runtime import *  # noqa: E402
+from .github.commands import *  # noqa: E402
+from .gitlab.commands import *  # noqa: E402
 
 
 def plugin_loaded():


### PR DESCRIPTION
Actively unloading and reloading GitSavvy after it has just been installed/updated may fail with strange exceptions if multiple packages are being updated at that time.

Replacing default builtin importer may also cause other plugins to fail loading.

Everything needed to ensure all sub-modules being reloaded in correct order is to remove them from `sys.modules` before any local import appears.

As a result saving `git_savvy.py` is everything needed for every sub- module to be re-imported during normal plugin reloading.

The `common.utils.reload` module becomes somewhat obsolete then.

It may still be used for development/debugging purposes, but well ... .

Note: The choosen mechanism has been used by A File Icon, GitGutter, PackageDev and probably more packages for quite a while without issues. The only crucial part is that there must be a single plugin in a package's root directory only, which imports modules from a sub directory.