### PR TITLE
`"log_follow_rename": true` setting works properly for `show_file_at_commit`, `checkout_file_at_commit`

### DIFF
--- a/core/commands/blame.py
+++ b/core/commands/blame.py
@@ -457,11 +457,10 @@ class gs_blame_action(BlameMixin, PanelActionMixin):
                 settings.get("git_savvy.commit_hash"), commit_hash, lineno)
 
         assert self.file_path
-        file_path = self.filename_at_commit(self.file_path, commit_hash)
 
         self.window.run_command("gs_show_file_at_commit", {
             "commit_hash": commit_hash,
-            "filepath": file_path,
+            "filepath": self.file_path,
             "position": Position(lineno - 1, 0, None),
             "lang": settings.get('git_savvy.original_syntax', None)
         })

--- a/core/commands/blame.py
+++ b/core/commands/blame.py
@@ -162,8 +162,9 @@ class gs_blame_current_file(LogMixin, BlameMixin):
         return self._commit_hash and commit_hash.startswith(self._commit_hash)
 
     def log(self, **kwargs):  # type: ignore[override]
-        follow = self.savvy_settings.get("blame_follow_rename")
-        kwargs["follow"] = follow
+        # `--follow` requires a pathspec; only request it when a file_path
+        # has been threaded through.
+        kwargs["follow"] = bool(kwargs.get("file_path") and self.savvy_settings.get("blame_follow_rename"))
         return super().log(**kwargs)
 
 

--- a/core/commands/log.py
+++ b/core/commands/log.py
@@ -99,7 +99,7 @@ class LogMixin(GitCommand):
         if window:
             window.run_command("gs_show_commit_info", {
                 "commit_hash": commit,
-                "file_path": file_path
+                "file_path": self.file_path_at(file_path, commit)
             })
 
     def do_action(self, commit_hash, **kwargs):
@@ -289,5 +289,5 @@ class gs_log_action(PanelActionMixin, WindowCommand):
         })
 
     def checkout_file_at_commit(self):
-        self.checkout_ref(self._commit_hash, fpath=self._file_path)
+        self.checkout_ref(self._commit_hash, fpath=self.file_path_at(self._file_path, self._commit_hash))
         util.view.refresh_gitsavvy_interfaces(self.window, refresh_sidebar=True)

--- a/core/commands/log_graph_main_actions.py
+++ b/core/commands/log_graph_main_actions.py
@@ -650,5 +650,5 @@ class gs_log_graph_action(WindowCommand, GitCommand):
         })
 
     def checkout_file_at_commit(self, commit_hash, file_path):
-        self.checkout_ref(commit_hash, fpath=file_path)
+        self.checkout_ref(commit_hash, fpath=self.file_path_at(file_path, commit_hash))
         util.view.refresh_gitsavvy_interfaces(self.window)

--- a/core/commands/show_file_at_commit.py
+++ b/core/commands/show_file_at_commit.py
@@ -146,9 +146,16 @@ class _gs_show_file_at_commit_refresh_mixin(GsTextCommand):
         views_with_reference_document.add(self.view)
 
     def previous_file_version(self, current_commit: str, file_path: str) -> str:
-        previous_commit = self.previous_commit(current_commit, file_path)
-        if previous_commit:
-            return self.get_file_content_at_commit(file_path, previous_commit)
+        # `file_path` is the canonical HEAD-side name. With `log_follow_rename`
+        # on, we must walk renames using the file's name *at* `current_commit`
+        # (because `--follow` needs an existing pathspec at the range tip), and
+        # then read the previous version using the name at the previous commit.
+        follow = bool(self.savvy_settings.get("log_follow_rename"))
+        name_at_current = self.file_path_at(file_path, current_commit)
+        previous_commit = self.previous_commit(current_commit, name_at_current, follow=follow)
+        if previous_commit and previous_commit != current_commit:
+            name_at_previous = self.file_path_at(file_path, previous_commit)
+            return self.get_file_content_at_commit(name_at_previous, previous_commit)
         else:
             # For initial revisions of a file, everything is new/added, and we
             # just compare with the empty "".
@@ -171,13 +178,14 @@ class gs_show_file_at_commit_refresh(_gs_show_file_at_commit_refresh_mixin):
         settings = view.settings()
         file_path = settings.get("git_savvy.file_path")
         commit_hash = settings.get("git_savvy.show_file_at_commit_view.commit")
+        name_at_commit = self.file_path_at(file_path, commit_hash)
 
         def program():
-            text = self.get_file_content_at_commit(file_path, commit_hash)
+            text = self.get_file_content_at_commit(name_at_commit, commit_hash)
             render(view, text, position)
             view.reset_reference_document()
             commit_details = self.commit_subject_and_date(commit_hash)
-            self.update_title(commit_details, file_path)
+            self.update_title(commit_details, name_at_commit)
             self.update_status_bar(commit_details)
             enqueue_on_worker(self.update_reference_document, commit_hash, file_path)
 
@@ -307,7 +315,8 @@ def get_next_commit(
     if next_commit := recall_next_commit_for(view, commit_hash):
         return next_commit
 
-    next_commits = cmd.next_commits(commit_hash, file_path)
+    follow = bool(cmd.savvy_settings.get("log_follow_rename"))
+    next_commits = cmd.next_commits(commit_hash, file_path, follow=follow)
     remember_next_commit_for(view, next_commits)
     return next_commits.get(commit_hash)
 
@@ -322,7 +331,11 @@ def get_previous_commit(
     if previous := recall_previous_commit_for(view, commit_hash):
         return previous
 
-    if previous := cmd.previous_commit(commit_hash, file_path):
+    follow = bool(cmd.savvy_settings.get("log_follow_rename"))
+    # `--follow` needs the file's name *at* `commit_hash` (the range tip);
+    # the HEAD-side name may not exist there yet.
+    name_at_commit = cmd.file_path_at(file_path, commit_hash)
+    if previous := cmd.previous_commit(commit_hash, name_at_commit, follow=follow):
         remember_next_commit_for(view, {previous: commit_hash})
     return previous
 

--- a/core/commands/show_file_at_commit.py
+++ b/core/commands/show_file_at_commit.py
@@ -150,12 +150,12 @@ class _gs_show_file_at_commit_refresh_mixin(GsTextCommand):
         # on, we must walk renames using the file's name *at* `current_commit`
         # (because `--follow` needs an existing pathspec at the range tip), and
         # then read the previous version using the name at the previous commit.
-        follow = bool(self.savvy_settings.get("log_follow_rename"))
+        follow = bool(file_path and self.savvy_settings.get("log_follow_rename"))
         name_at_current = self.file_path_at(file_path, current_commit)
         previous_commit = self.previous_commit(current_commit, name_at_current, follow=follow)
         if previous_commit and previous_commit != current_commit:
             name_at_previous = self.file_path_at(file_path, previous_commit)
-            return self.get_file_content_at_commit(name_at_previous, previous_commit)
+            return self.get_file_content_at_commit(name_at_previous or file_path, previous_commit)
         else:
             # For initial revisions of a file, everything is new/added, and we
             # just compare with the empty "".
@@ -181,11 +181,11 @@ class gs_show_file_at_commit_refresh(_gs_show_file_at_commit_refresh_mixin):
         name_at_commit = self.file_path_at(file_path, commit_hash)
 
         def program():
-            text = self.get_file_content_at_commit(name_at_commit, commit_hash)
+            text = self.get_file_content_at_commit(name_at_commit or file_path, commit_hash)
             render(view, text, position)
             view.reset_reference_document()
             commit_details = self.commit_subject_and_date(commit_hash)
-            self.update_title(commit_details, name_at_commit)
+            self.update_title(commit_details, name_at_commit or file_path)
             self.update_status_bar(commit_details)
             enqueue_on_worker(self.update_reference_document, commit_hash, file_path)
 
@@ -315,7 +315,9 @@ def get_next_commit(
     if next_commit := recall_next_commit_for(view, commit_hash):
         return next_commit
 
-    follow = bool(cmd.savvy_settings.get("log_follow_rename"))
+    # `--follow` requires a pathspec; in views without a file (e.g. show-commit)
+    # `file_path` is None, so don't request follow there.
+    follow = bool(file_path and cmd.savvy_settings.get("log_follow_rename"))
     next_commits = cmd.next_commits(commit_hash, file_path, follow=follow)
     remember_next_commit_for(view, next_commits)
     return next_commits.get(commit_hash)
@@ -331,13 +333,18 @@ def get_previous_commit(
     if previous := recall_previous_commit_for(view, commit_hash):
         return previous
 
-    follow = bool(cmd.savvy_settings.get("log_follow_rename"))
+    follow = bool(file_path and cmd.savvy_settings.get("log_follow_rename"))
     # `--follow` needs the file's name *at* `commit_hash` (the range tip);
     # the HEAD-side name may not exist there yet.
     name_at_commit = cmd.file_path_at(file_path, commit_hash)
-    if previous := cmd.previous_commit(commit_hash, name_at_commit, follow=follow):
+    previous = cmd.previous_commit(commit_hash, name_at_commit, follow=follow)
+    # `previous_commit` returns `commit_hash` itself when there's no actual
+    # older commit (e.g., at the file's initial revision). Don't cache that
+    # self-referential entry, because it would later make `n` a NOOP.
+    if previous and previous != commit_hash:
         remember_next_commit_for(view, {previous: commit_hash})
-    return previous
+        return previous
+    return None
 
 
 def remember_next_commit_for(view: sublime.View, mapping: Dict[str, str]) -> None:

--- a/core/git_mixins/history.py
+++ b/core/git_mixins/history.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
+
 import email.utils
 from itertools import chain, takewhile
+from typing import Iterator, List, NamedTuple, Optional
 
-from ..exceptions import GitSavvyError
-from ...common import util
 from GitSavvy.core.fns import last, pairwise
 from GitSavvy.core.git_command import mixin_base
 from GitSavvy.core.utils import cached
 
-
-from typing import Iterator, List, NamedTuple, Optional
+from ...common import util
+from ..exceptions import GitSavvyError
 
 
 class LogEntry(NamedTuple):
@@ -194,17 +194,56 @@ class HistoryMixin(mixin_base):
     def resolve_commitish(self, ref: str) -> str:
         return self.git("rev-parse", "--short", ref).strip()
 
+    @cached(not_if={"file_path": lambda p: not p})
+    def file_rename_history(self, file_path):
+        # type: (str) -> List[Tuple[str, str]]
+        # Returns [(commit_hash, name_at_that_commit)] for the file's full
+        # history (newest first), traced via `--follow`.  `file_path` must
+        # be the HEAD-side name, since `--follow` matches the pathspec at
+        # the tip of the range. Cached: lets callers do many cheap lookups
+        # against a single subprocess walk.
+        output = self.git(
+            "log",
+            "--follow",
+            "--name-status",
+            "--format=COMMIT %H",
+            "--", file_path
+        )
+        history = []  # type: List[Tuple[str, str]]
+        current_commit = None  # type: Optional[str]
+        for line in output.splitlines():
+            if line.startswith("COMMIT "):
+                current_commit = line[7:].strip()
+            elif current_commit and line.strip():
+                cols = line.split("\t")
+                if len(cols) >= 2:
+                    history.append((current_commit, cols[-1]))
+                    current_commit = None
+        return history
+
     def filename_at_commit(self, filename, commit_hash):
+        # type: (str, str) -> str
+        for h, name in self.file_rename_history(filename):
+            if h.startswith(commit_hash):
+                return name
+        # Cache miss. Most likely a merge commit (default
+        # `--diff-merges=off` emits no name-status line and our parser
+        # drops it), or a commit reachable only via the branch_hint that
+        # `next_commits` walks but HEAD doesn't. Fall back to a targeted
+        # query so `get_file_content_at_commit` doesn't blow up.
+        return self._filename_at_commit_uncached(filename, commit_hash)
+
+    @cached(not_if={"commit_hash": is_dynamic_ref})
+    def _filename_at_commit_uncached(self, filename, commit_hash):
         # type: (str, str) -> str
         lines = self.git(
             "log",
-            "--format=",  # we don't need any commit info beside the name status
+            "--format=",
             "--follow",
             "--name-status",
             "{}..".format(commit_hash),
             "--", filename
         ).strip().splitlines()
-
         try:
             return lines[-1].split("\t")[1]
         except IndexError:

--- a/core/git_mixins/history.py
+++ b/core/git_mixins/history.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import email.utils
 from itertools import chain, takewhile
-from typing import Iterator, List, NamedTuple, Optional
+from typing import Iterator, List, NamedTuple, Optional, Tuple
 
 from GitSavvy.core.fns import last, pairwise
 from GitSavvy.core.git_command import mixin_base

--- a/core/git_mixins/history.py
+++ b/core/git_mixins/history.py
@@ -210,6 +210,14 @@ class HistoryMixin(mixin_base):
         except IndexError:
             return filename
 
+    def file_path_at(self, file_path, commit_hash):
+        # type: (Optional[str], Optional[str]) -> Optional[str]
+        # `file_path` must be the HEAD-side name; `filename_at_commit`
+        # only detects renames walking backward from HEAD.
+        if commit_hash and file_path and self.savvy_settings.get("log_follow_rename"):
+            return self.filename_at_commit(file_path, commit_hash)
+        return file_path
+
     @cached(not_if={"base_commit": is_dynamic_ref, "target_commit": is_dynamic_ref})
     def list_touched_filenames(self, base_commit, target_commit, cached=None):
         # type: (Optional[str], Optional[str], Optional[bool]) -> List[str]


### PR DESCRIPTION
- `"log_follow_rename": true` setting works properly for `show_file_at_commit`, `checkout_file_at_commit`
- This uses existing `filename_at_commit` function, [in the same way it's used here](https://github.com/kylebebak/GitSavvy/blob/3266859a62c12bf16da02332106e5da5ef0bfc52/core/commands/blame.py#L220-L224) in `blame_file_atcommit`
- I've tested this locally to verify both `show_file_at_commit` and `checkout_file_at_commit` work as expected, for files that have been renamed and files that haven't been renamed