### PR TITLE
Fix initial cursor position of "File History" views

### DIFF
--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -908,7 +908,9 @@ class gs_log_graph_refresh(TextCommand, GitCommand):
                 # gone, or happens to be after the fold of fresh
                 # content.
                 if not follow or not try_navigate_to_symbol():
-                    if visible_selection:
+                    if navigate_after_draw:
+                        view.run_command("gs_log_graph_navigate")
+                    elif visible_selection:
                         view.show(view.sel(), True)
             reset_overwrite_status(view)
             reset_caret_style(view)


### PR DESCRIPTION
Since d19c3f81 we follow "HEAD" if nothing else can be specified when opening a new graph.  In case "HEAD" is not within the graph we want to show (which is only typical for file histories or other searches), the cursor remained in BOF position.

Do a `gs_log_graph_navigate` after the initial, first draw in that case.