### PR TITLE
Move cursor to the next hunk after staging (et.al.)

### DIFF
--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -571,14 +571,20 @@ class gs_diff_stage_or_reset_hunk(TextCommand, GitCommand):
         move_fn = None
         if whole_file or all(s.empty() for s in frozen_sel):
             if whole_file:
-                headers = unique(filter_(map(diff.head_for_pt, cursor_pts)))
+                headers = (
+                    list(unique(filter_(map(diff.head_for_pt, cursor_pts))))
+                    or [diff.headers[0]]
+                )
                 patches = list(flatten(
                     chain([head], diff.hunks_for_head(head))
                     for head in headers
                 ))
 
             else:
-                patches = list(unique(flatten(filter_(diff.head_and_hunk_for_pt(pt) for pt in cursor_pts))))
+                patches = (
+                    list(unique(flatten(filter_(diff.head_and_hunk_for_pt(pt) for pt in cursor_pts))))
+                    or [diff.headers[0], diff.hunks[0]]
+                )
 
             last_selected_hunk = patches[-1]
             try:

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -537,7 +537,7 @@ class gs_diff_stage_or_reset_hunk(TextCommand, GitCommand):
         cursor_pts = [s.a for s in frozen_sel]
         diff = SplittedDiff.from_view(self.view)
         if diff.is_combined_diff():
-            headers = unique(filter_(map(diff.head_for_pt, cursor_pts)))
+            headers = list(unique(filter_(map(diff.head_for_pt, cursor_pts))))
             files = list(filter_(head.from_filename() for head in headers))
             if not files:
                 flash(self.view, "Not within a hunk")

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -536,6 +536,15 @@ class gs_diff_stage_or_reset_hunk(TextCommand, GitCommand):
         frozen_sel = [s for s in self.view.sel()]
         cursor_pts = [s.a for s in frozen_sel]
         diff = SplittedDiff.from_view(self.view)
+        if not diff.headers:
+            flash(
+                self.view,
+                "The {} is clean.".format(
+                    "file" if self.view.settings().get("git_savvy.file_path") else "repo"
+                )
+            )
+            return
+
         if diff.is_combined_diff():
             headers = list(unique(filter_(map(diff.head_for_pt, cursor_pts))))
             files = list(filter_(head.from_filename() for head in headers))

--- a/syntax/output_panel.sublime-syntax
+++ b/syntax/output_panel.sublime-syntax
@@ -26,3 +26,9 @@ contexts:
     - match: \s(https?:\S+)
       captures:
         1: markup.underline.link
+
+    - match: ^hint:.*
+      scope: string.other.hint.git-savvy
+
+    - match: ^fatal:.*
+      scope: markup.deleted.fatal.git-savvy

--- a/syntax/test/syntax_test_output_panel.txt
+++ b/syntax/test/syntax_test_output_panel.txt
@@ -61,3 +61,11 @@ From https://github.com/SublimeLinter/SublimeLinter
 
 Traceback (most recent call last):
 # ^^^^^^ - constant.numeric.graph.commit-hash.git-savvy
+
+hint: You have divergent branches
+# <- string.other.hint.git-savvy
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.other.hint.git-savvy
+
+fatal: Need to specify
+# <- markup.deleted.fatal.git-savvy
+#^^^^^^^^^^^^^^^^^^^^^ markup.deleted.fatal.git-savvy

--- a/tests/test_diff_view.py
+++ b/tests/test_diff_view.py
@@ -445,25 +445,10 @@ diff --git a/fooz b/barz
         expected = ['apply', None, '--cached', '--unidiff-zero', '-']
         self.assertEqual(actual, expected)
 
-    def test_status_message_if_not_in_hunk(self):
+    def test_status_message_if_clean(self):
         VIEW_CONTENT = """\
 prelude
 --
-diff --git a/fooz b/barz
---- a/fooz
-+++ b/barz
-@@ -16,1 +16,1 @@ Hi
- one
- two
-@@ -20,1 +20,1 @@ Ho
- three
- four
-diff --git a/foxx b/boxx
---- a/foox
-+++ b/boox
-@@ -16,1 +16,1 @@ Hello
- one
- two
 """
         view = self.window.new_file()
         self.addCleanup(view.close)
@@ -481,7 +466,7 @@ diff --git a/foxx b/boxx
         cmd = module.gs_diff_stage_or_reset_hunk(view)
         cmd.run('_unused_edit')
 
-        verify(window, times=1).status_message('Not within a hunk')
+        verify(window, times=1).status_message('The repo is clean.')
 
 
 class TestZooming(DeferrableTestCase):


### PR DESCRIPTION
Implements precise cursor movement after staging/unstaging etc. in the diff. (Surprisingly, we did not had any code here but relied more or less on luck.)