### PR TITLE
Switch unit tests runner to "fail-fast"

### DIFF
--- a/unittesting.json
+++ b/unittesting.json
@@ -1,5 +1,6 @@
 {
     "deferred": true,
     "capture_console": true,
-    "legacy_runner": false
+    "legacy_runner": false,
+    "failfast": true
 }


### PR DESCRIPTION
Failing tests are often super-slow because we often wait for a view change, that will never happen so we actually await the timeout.

Set "failfast" for the better initial experience.