### PR TITLE
Ensure user did not set `rebase.abbreviateCommands`

### DIFF
--- a/core/commands/log_graph_rebase_actions.py
+++ b/core/commands/log_graph_rebase_actions.py
@@ -41,6 +41,7 @@ MYPY = False
 if MYPY:
     from typing import (
         Callable,
+        Dict,
         List,
         Iterator,
         NamedTuple,
@@ -600,9 +601,24 @@ class gs_rebase_quick_action(GsTextCommand, RebaseCommand):
                         None
                     ),
                     start_commit,
+                    custom_environ=make_git_config_env({
+                        "rebase.abbreviateCommands": "false"
+                    })
                 )
 
         run_on_new_thread(program)
+
+
+def make_git_config_env(config):
+    # type: (Dict[str, str]) -> Dict[str, str]
+    rv = {
+        "GIT_CONFIG_COUNT": str(len(config))
+    }
+    for n, (key, value) in enumerate(config.items()):
+        rv[f"GIT_CONFIG_KEY_{n}"] = key
+        rv[f"GIT_CONFIG_VALUE_{n}"] = value
+
+    return rv
 
 
 def change_first_action(new_action, base_commit, buffer_content):


### PR DESCRIPTION
For our automatic interactive rebase commands, e.g. "Reword this commit", we rewrite the todo list.  We expect long commands, e.g. "pick", in the todo list but a user *could* change that in their configuration.  Explicitly set `rebase.abbreviateCommands` to make our code more robust.

We could use `-c rebase.abbreviateCommands` but this would show up in the logging which is a bit ugly.  We also had to code this in as yet another argument for `self.git`.

Instead use environment keys to achieve the same thing.  These environment settings are read since v2.31.0 but naturally do not fail on older versions.