### PR TITLE
Scroll to nearest hunk when switching from file to diff

### DIFF
--- a/core/commands/blame.py
+++ b/core/commands/blame.py
@@ -6,7 +6,7 @@ import unicodedata
 import sublime
 
 from .navigate import GsNavigate
-from ..view import Position
+from ..view import scroll_to_pt, y_offset, Position
 from ...common import util
 from .log import LogMixin
 from ..ui_mixins.quick_panel import PanelActionMixin
@@ -197,9 +197,7 @@ class gs_blame_refresh(BlameMixin):
         was_empty = self.view.size() == 0
         # store viewport for later restoration
         if len(self.view.sel()) > 0:
-            old_viewport = self.view.viewport_position()
-            cursor_layout = self.view.text_to_layout(self.view.sel()[0].begin())
-            yoffset = cursor_layout[1] - old_viewport[1]
+            yoffset = y_offset(self.view, self.view.sel()[0].begin())
         else:
             yoffset = 0
 
@@ -214,8 +212,7 @@ class gs_blame_refresh(BlameMixin):
                 # if it was opened as a new file
                 self.view.show_at_center(self.view.line(self.view.sel()[0].begin()).begin())
             else:
-                cursor_layout = self.view.text_to_layout(self.view.sel()[0].begin())
-                self.view.set_viewport_position((0, cursor_layout[1] - yoffset), animate=False)
+                scroll_to_pt(self.view, self.view.sel()[0].begin(), yoffset)
 
     def get_content(self, file_path, ignore_whitespace=False, detect_options=None, commit_hash=None):
         if commit_hash and self.savvy_settings.get("blame_follow_rename"):

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -109,6 +109,11 @@ def compute_identifier_for_view(view):
     ) if settings.get('git_savvy.diff_view') else None
 
 
+def is_diff_view(view):
+    # type: (sublime.View) -> bool
+    return view.settings().get('git_savvy.diff_view')
+
+
 class gs_diff(WindowCommand, GitCommand):
 
     """
@@ -142,6 +147,13 @@ class gs_diff(WindowCommand, GitCommand):
         active_view = self.window.active_view()
         assert active_view
 
+        if is_diff_view(active_view) and (
+            in_cached_mode is None
+            or active_view.settings().get('git_savvy.diff_view.in_cached_mode') == in_cached_mode
+        ):
+            active_view.close()
+            return
+
         this_id = (
             repo_path,
             file_path,
@@ -151,13 +163,6 @@ class gs_diff(WindowCommand, GitCommand):
         for view in self.window.views():
             if compute_identifier_for_view(view) == this_id:
                 settings = view.settings()
-                if view == active_view and (
-                    in_cached_mode is None
-                    or settings.get("git_savvy.diff_view.in_cached_mode") == in_cached_mode
-                ):
-                    view.close()
-                    return
-
                 if in_cached_mode is not None:
                     settings.set("git_savvy.diff_view.in_cached_mode", in_cached_mode)
                 focus_view(view)

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -162,9 +162,9 @@ class gs_diff(WindowCommand, GitCommand):
         )
         for view in self.window.views():
             if compute_identifier_for_view(view) == this_id:
-                settings = view.settings()
                 if in_cached_mode is not None:
-                    settings.set("git_savvy.diff_view.in_cached_mode", in_cached_mode)
+                    view.settings().set("git_savvy.diff_view.in_cached_mode", in_cached_mode)
+
                 focus_view(view)
                 place_view(self.window, view, after=active_view)
                 break

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -21,7 +21,7 @@ from ..git_command import GitCommand
 from ..runtime import ensure_on_ui, enqueue_on_worker
 from ..ui_mixins.quick_panel import LogHelperMixin
 from ..utils import flash, focus_view, line_indentation
-from ..view import replace_view_content, place_view, y_offset, Position
+from ..view import replace_view_content, scroll_to_pt, place_view, y_offset, Position
 from ...common import util
 
 
@@ -470,10 +470,7 @@ class gs_diff_zoom(TextCommand):
         self.view.sel().add_all(list(cursors))
 
         cursor, offset = min(scroll_offsets, key=lambda cursor_offset: abs(cursor_offset[1]))
-        _, cy = self.view.text_to_layout(cursor)
-        vy = cy - offset
-        vx, _ = self.view.viewport_position()
-        self.view.set_viewport_position((vx, vy), animate=False)
+        scroll_to_pt(self.view, cursor, offset)
 
 
 if MYPY:

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -21,7 +21,9 @@ from ..git_command import GitCommand
 from ..runtime import ensure_on_ui, enqueue_on_worker
 from ..ui_mixins.quick_panel import LogHelperMixin
 from ..utils import flash, focus_view, line_indentation
-from ..view import replace_view_content, scroll_to_pt, place_view, y_offset, Position
+from ..view import (
+    capture_cur_position, replace_view_content, scroll_to_pt,
+    place_view, place_cursor_and_show, y_offset, Position)
 from ...common import util
 
 
@@ -54,6 +56,7 @@ if MYPY:
     Point = int
     LineCol = Tuple[LineNo, ColNo]
     HunkLineWithB = NamedTuple('HunkLineWithB', [('line', 'HunkLine'), ('b', LineNo)])
+    _Position = Tuple[Position, str]
 else:
     HunkLineWithB = namedtuple('HunkLineWithB', 'line b')
 
@@ -165,6 +168,18 @@ class gs_diff(WindowCommand, GitCommand):
             active_view.close()
             return
 
+        av_fname = active_view.file_name()
+        cur_pos = None
+        if av_fname:
+            if _cur_pos := capture_cur_position(active_view):
+                rel_file_path = self.get_rel_path(av_fname)
+                if in_cached_mode:
+                    row, col, offset = _cur_pos
+                    new_row = self.find_matching_lineno(None, None, row + 1, file_path) - 1
+                    cur_pos = Position(new_row, col, offset), rel_file_path
+                else:
+                    cur_pos = _cur_pos, rel_file_path
+
         this_id = (
             repo_path,
             file_path,
@@ -210,19 +225,22 @@ class gs_diff(WindowCommand, GitCommand):
 
         # Assume diffing a single file is very fast and do it
         # sync because it looks better.
-        diff_view.run_command("gs_diff_refresh", {"sync": bool(file_path)})
+        diff_view.run_command("gs_diff_refresh", {
+            "sync": bool(file_path),
+            "match_position": cur_pos
+        })
 
 
 class gs_diff_refresh(TextCommand, GitCommand):
     """Refresh the diff view with the latest repo state."""
 
-    def run(self, edit, sync=True):
+    def run(self, edit, sync=True, match_position=None):
         if sync:
-            self.run_impl(sync)
+            self.run_impl(sync, match_position)
         else:
-            enqueue_on_worker(self.run_impl, sync)
+            enqueue_on_worker(self.run_impl, sync, match_position)
 
-    def run_impl(self, runs_on_ui_thread):
+    def run_impl(self, runs_on_ui_thread, match_position):
         view = self.view
         if not runs_on_ui_thread and not view.is_valid():
             return
@@ -312,20 +330,59 @@ class gs_diff_refresh(TextCommand, GitCommand):
                     view.close()
                 return
 
-        ensure_on_ui(_draw, view, ' '.join(title), prelude, diff)
+        ensure_on_ui(_draw, view, ' '.join(title), prelude, diff, match_position)
 
 
-def _draw(view, title, prelude, diff_text):
-    # type: (sublime.View, str, str, str) -> None
+def _draw(view, title, prelude, diff_text, match_position):
+    # type: (sublime.View, str, str, str, Optional[_Position]) -> None
     was_empty = not view.find_by_selector("git-savvy.diff_view git-savvy.diff")
+    navigated = False
     text = prelude + diff_text
 
     view.set_name(title)
     replace_view_content(view, text)
-    if was_empty:
+
+    if match_position:
+        cur_pos, wanted_filename = match_position
+        diff = SplittedDiff.from_view(view)
+        if header := find_header_for_filename(diff.headers, wanted_filename):
+            row, col, row_offset = cur_pos
+            lineno = row + 1
+            if hunk := find_hunk_for_line(diff.hunks_for_head(header), lineno):
+                for line, b in recount_lines_for_jump_to_file(hunk):
+                    # We're switching from a real file to the diff.  `lineno`
+                    # comes from the `b` ("to") side.  We must filter using
+                    # `not is_from_line()` as `recount_lines_for_jump_to_file`
+                    # yields all lines in the hunk.
+                    if not line.is_from_line() and b == lineno:
+                        pt = line.a + col + line.mode_len
+                        place_cursor_and_show(view, pt, row_offset)
+                        navigated = True
+                        break
+
+    if was_empty and not navigated:
         view.run_command("gs_diff_navigate")
 
     intra_line_colorizer.annotate_intra_line_differences(view, diff_text, len(prelude))
+
+
+def find_header_for_filename(headers, filename):
+    # type: (Iterable[FileHeader], str) -> Optional[FileHeader]
+    for header in headers:
+        if header.from_filename() == filename:
+            return header
+    else:
+        return None
+
+
+def find_hunk_for_line(hunks, row):
+    # type: (Iterable[Hunk], int) -> Optional[Hunk]
+    for hunk in hunks:
+        start, length = hunk.header().safely_parse_metadata()[-1]
+        if start <= row <= start + length:
+            return hunk
+    else:
+        return None
 
 
 class gs_diff_toggle_setting(TextCommand):

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -18,7 +18,7 @@ from .navigate import GsNavigate
 from ..fns import filter_, flatten, pairwise, unique
 from ..parse_diff import SplittedDiff
 from ..git_command import GitCommand
-from ..runtime import enqueue_on_ui, enqueue_on_worker
+from ..runtime import ensure_on_ui, enqueue_on_worker
 from ..ui_mixins.quick_panel import LogHelperMixin
 from ..utils import flash, focus_view, line_indentation
 from ..view import replace_view_content, place_view, y_offset, Position
@@ -313,17 +313,7 @@ class gs_diff_refresh(TextCommand, GitCommand):
                 return
 
         has_content = view.find_by_selector("git-savvy.diff_view git-savvy.diff")
-        draw = lambda: _draw(
-            view,
-            ' '.join(title),
-            prelude,
-            diff,
-            navigate=not has_content
-        )
-        if runs_on_ui_thread:
-            draw()
-        else:
-            enqueue_on_ui(draw)
+        ensure_on_ui(_draw, view, ' '.join(title), prelude, diff, navigate=not has_content)
 
 
 def _draw(view, title, prelude, diff_text, navigate):

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -312,16 +312,17 @@ class gs_diff_refresh(TextCommand, GitCommand):
                     view.close()
                 return
 
-        has_content = view.find_by_selector("git-savvy.diff_view git-savvy.diff")
-        ensure_on_ui(_draw, view, ' '.join(title), prelude, diff, navigate=not has_content)
+        ensure_on_ui(_draw, view, ' '.join(title), prelude, diff)
 
 
-def _draw(view, title, prelude, diff_text, navigate):
-    # type: (sublime.View, str, str, str, bool) -> None
-    view.set_name(title)
+def _draw(view, title, prelude, diff_text):
+    # type: (sublime.View, str, str, str) -> None
+    was_empty = not view.find_by_selector("git-savvy.diff_view git-savvy.diff")
     text = prelude + diff_text
+
+    view.set_name(title)
     replace_view_content(view, text)
-    if navigate:
+    if was_empty:
         view.run_command("gs_diff_navigate")
 
     intra_line_colorizer.annotate_intra_line_differences(view, diff_text, len(prelude))

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -140,6 +140,8 @@ class gs_diff(WindowCommand, GitCommand):
             file_path = self.file_path or file_path
 
         active_view = self.window.active_view()
+        assert active_view
+
         this_id = (
             repo_path,
             file_path,
@@ -159,8 +161,7 @@ class gs_diff(WindowCommand, GitCommand):
                 if in_cached_mode is not None:
                     settings.set("git_savvy.diff_view.in_cached_mode", in_cached_mode)
                 focus_view(view)
-                if active_view:
-                    place_view(self.window, view, after=active_view)
+                place_view(self.window, view, after=active_view)
                 break
 
         else:

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -13,7 +13,7 @@ from ..git_command import GitCommand
 from ..parse_diff import SplittedDiff, UnsupportedCombinedDiff
 from ..runtime import enqueue_on_ui, enqueue_on_worker
 from ..utils import flash, focus_view
-from ..view import capture_cur_position, place_view, replace_view_content, y_offset, Position
+from ..view import capture_cur_position, place_view, replace_view_content, scroll_to_pt, y_offset, Position
 from ...common import util
 
 
@@ -79,10 +79,7 @@ def place_cursor_and_show(view, row, col, row_offset):
     pt = view.text_point(row, col)
     view.sel().add(sublime.Region(pt, pt))
 
-    _, cy = view.text_to_layout(pt)
-    vy = cy - row_offset
-    vx, _ = view.viewport_position()
-    view.set_viewport_position((vx, vy), animate=False)
+    scroll_to_pt(view, pt, row_offset)
 
 
 def translate_row_to_inline_diff(diff_view, row):

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -13,7 +13,7 @@ from ..git_command import GitCommand
 from ..parse_diff import SplittedDiff, UnsupportedCombinedDiff
 from ..runtime import enqueue_on_ui, enqueue_on_worker
 from ..utils import flash, focus_view
-from ..view import capture_cur_position, place_view, replace_view_content, scroll_to_pt, y_offset, Position
+from ..view import apply_position, capture_cur_position, place_view, replace_view_content, y_offset, Position
 from ...common import util
 
 
@@ -38,7 +38,7 @@ __all__ = (
 MYPY = False
 if MYPY:
     from typing import Dict, Iterable, List, NamedTuple, Optional, Tuple
-    from ..types import LineNo, ColNo, Row, Col
+    from ..types import LineNo, ColNo, Row
     from GitSavvy.common.util.parse_diff import Hunk as InlineDiff_Hunk
 
     HunkReference = NamedTuple("HunkReference", [
@@ -71,15 +71,6 @@ DIFF_HEADER = """diff --git a/{path} b/{path}
 
 diff_view_hunks = {}  # type: Dict[sublime.ViewId, List[HunkReference]]
 active_on_activated = True
-
-
-def place_cursor_and_show(view, row, col, row_offset):
-    # type: (sublime.View, Row, Col, float) -> None
-    view.sel().clear()
-    pt = view.text_point(row, col)
-    view.sel().add(sublime.Region(pt, pt))
-
-    scroll_to_pt(view, pt, row_offset)
 
 
 def translate_row_to_inline_diff(diff_view, row):
@@ -486,7 +477,7 @@ class gs_inline_diff_refresh(TextCommand, GitCommand):
         if match_position:
             row, col, row_offset = match_position
             new_row = translate_row_to_inline_diff(view, row)
-            place_cursor_and_show(view, new_row, col, row_offset)
+            apply_position(view, new_row, col, row_offset)
         elif navigate_to_first_hunk:
             view.run_command("gs_inline_diff_navigate_hunk")
 

--- a/core/commands/show_file_at_commit.py
+++ b/core/commands/show_file_at_commit.py
@@ -7,7 +7,7 @@ from sublime_plugin import TextCommand, WindowCommand
 from ..git_command import GitCommand
 from ..runtime import enqueue_on_worker, run_as_text_command, text_command
 from ..utils import flash, focus_view
-from ..view import capture_cur_position, replace_view_content, scroll_to_pt, Position
+from ..view import apply_position, capture_cur_position, replace_view_content, Position
 from ...common import util
 
 from .log import LogMixin
@@ -55,7 +55,7 @@ class gs_show_file_at_commit(WindowCommand, GitCommand):
             if compute_identifier_for_view(view) == this_id:
                 focus_view(view)
                 if position:
-                    run_as_text_command(move_cursor_to_line_col, view, position)
+                    run_as_text_command(apply_position, view, *position)
                 break
         else:
             self.create_view(commit_hash, filepath, position, lang)
@@ -174,20 +174,7 @@ def render(view, text, position):
     # type: (sublime.View, str, Optional[Position]) -> None
     replace_view_content(view, text)
     if position:
-        move_cursor_to_line_col(view, position)
-
-
-def move_cursor_to_line_col(view, position):
-    # type: (sublime.View, Position) -> None
-    row, col, row_offset = position
-    pt = view.text_point(row, col)
-    view.sel().clear()
-    view.sel().add(sublime.Region(pt))
-
-    if row_offset is None:
-        view.show(pt)
-    else:
-        scroll_to_pt(view, pt, row_offset)
+        apply_position(view, *position)
 
 
 class gs_show_file_at_commit_open_previous_commit(TextCommand, GitCommand):

--- a/core/commands/show_file_at_commit.py
+++ b/core/commands/show_file_at_commit.py
@@ -7,7 +7,7 @@ from sublime_plugin import TextCommand, WindowCommand
 from ..git_command import GitCommand
 from ..runtime import enqueue_on_worker, run_as_text_command, text_command
 from ..utils import flash, focus_view
-from ..view import capture_cur_position, replace_view_content, Position
+from ..view import capture_cur_position, replace_view_content, scroll_to_pt, Position
 from ...common import util
 
 from .log import LogMixin
@@ -187,10 +187,7 @@ def move_cursor_to_line_col(view, position):
     if row_offset is None:
         view.show(pt)
     else:
-        _, cy = view.text_to_layout(pt)
-        vy = cy - row_offset
-        vx, _ = view.viewport_position()
-        view.set_viewport_position((vx, vy), animate=False)
+        scroll_to_pt(view, pt, row_offset)
 
 
 class gs_show_file_at_commit_open_previous_commit(TextCommand, GitCommand):

--- a/core/view.py
+++ b/core/view.py
@@ -130,6 +130,14 @@ def y_offset(view, cursor):
     return cy - vy
 
 
+def scroll_to_pt(view, pt, offset):
+    # type: (sublime.View, int, float) -> None
+    _, cy = view.text_to_layout(pt)
+    vy = cy - offset
+    vx, _ = view.viewport_position()
+    view.set_viewport_position((vx, vy), animate=False)
+
+
 def place_view(window, view, after):
     # type: (sublime.Window, sublime.View, sublime.View) -> None
     view_group, current_index = window.get_view_index(view)

--- a/core/view.py
+++ b/core/view.py
@@ -138,6 +138,22 @@ def scroll_to_pt(view, pt, offset):
     view.set_viewport_position((vx, vy), animate=False)
 
 
+def place_cursor_and_show(view, pt, row_offset):
+    # type: (sublime.View, int, Optional[float]) -> None
+    view.sel().clear()
+    view.sel().add(pt)
+    if row_offset is None:
+        view.show(pt)
+    else:
+        scroll_to_pt(view, pt, row_offset)
+
+
+def apply_position(view, row, col, row_offset):
+    # type: (sublime.View, Row, Col, Optional[float]) -> None
+    pt = view.text_point(row, col)
+    place_cursor_and_show(view, pt, row_offset)
+
+
 def place_view(window, view, after):
     # type: (sublime.Window, sublime.View, sublime.View) -> None
     view_group, current_index = window.get_view_index(view)


### PR DESCRIPTION
Fixes #1040

We do this for inline diff for ages now:  when opening (or switching to) a diff view from the source file, try to jump to /or show) the position we're currently at.  

E.g. total seamless:

https://github.com/timbrel/GitSavvy/assets/8558/de9c07ab-087f-4dd5-a589-e0d58868f774

Without this patch the diff would land on the first hunk of the edited file.  
