### PR TITLE
Use `--topo-order` to find the next or previous commit

### DIFF
--- a/core/git_mixins/history.py
+++ b/core/git_mixins/history.py
@@ -328,6 +328,7 @@ class HistoryMixin(mixin_base):
             return self.git(
                 "log",
                 "--format=%H",
+                "--topo-order",
                 "--follow" if follow else None,
                 "-2",
                 current_commit,
@@ -343,6 +344,7 @@ class HistoryMixin(mixin_base):
             return self.git(
                 "log",
                 "--format=%H",
+                "--topo-order",
                 "--follow" if follow else None,
                 "{}..".format(current_commit),
                 "--",


### PR DESCRIPTION
`--topo-order` is what we should show in the graph views and should give in general more "natural" results.  (In the history views we usually use `--simplify-by-decoration` but I don't think that is relevant here and maybe it is just more costly performance-wise. But actually idk and we will see.)