### PR TITLE
Fix `[g]` not switching from the commit panel to the graph

### DIFF
--- a/core/commands/show_commit.py
+++ b/core/commands/show_commit.py
@@ -377,8 +377,13 @@ class gs_show_commit_open_graph_context(TextCommand, GitCommand):
             return
 
         settings = self.view.settings()
-        commit_hash = settings.get("git_savvy.show_commit_view.commit")
+        if settings.get("git_savvy.show_commit_view.belongs_to_a_graph"):
+            av = window.active_view()
+            if av:
+                window.focus_view(av)
+            return
 
+        commit_hash = settings.get("git_savvy.show_commit_view.commit")
         window.run_command("gs_graph", {
             "all": True,
             "follow": self.get_short_hash(commit_hash)


### PR DESCRIPTION
We have bound `[g]` to the tag `setting.git_savvy.show_commit_view` which is true for both stand-alone views and the detail panel below the graph or a log entry quick panel.  We then just call `gs_graph` to do the actual work.

Typically `gs_graph` focuses the graph view but not here because it has been taught to not steal the focus from its own details panel. (This is rather complicated state, refer `PANEL_JUST_LOST_FOCUS` and the `had_focus` setting.)

The fix is to check if the view the command is bound to actually `belongs_to_a_graph`, and if so to just focus the main graph view.