### PR TITLE
Fix line range computation from a diff for deleted lines

### DIFF
--- a/core/commands/line_history.py
+++ b/core/commands/line_history.py
@@ -172,9 +172,13 @@ class gs_line_history(TextCommand, GitCommand):
                 hunk_with_linenos[rel_end][1].a
             )]
         else:
+            end_line = hunk_with_linenos[rel_end]
             ranges = [(
                 hunk_with_linenos[rel_begin][1].b,
-                hunk_with_linenos[rel_end][1].b
+                (
+                    end_line[1].b
+                    + (1 if end_line[0].is_from_line() else 0)
+                )
             )]
 
         window.run_command("gs_open_line_history", {


### PR DESCRIPTION
When the user selects deleted lines (`is_from_line`) taking the lineno from the "to" side (`b`) is off by 1 as the b numbers don't increment on these lines.  Adjust that by adding 1.