### PR TITLE
Fix the incorrect name `from_filename` -> `to_filename`

### DIFF
--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -372,7 +372,7 @@ def _draw(view, title, prelude, diff_text, match_position):
 def find_header_for_filename(headers, filename):
     # type: (Iterable[FileHeader], str) -> Optional[FileHeader]
     for header in headers:
-        if header.from_filename() == filename:
+        if header.to_filename() == filename:
             return header
     else:
         return None
@@ -618,7 +618,7 @@ class gs_diff_stage_or_reset_hunk(TextCommand, GitCommand):
 
         if diff.is_combined_diff():
             headers = list(unique(filter_(map(diff.head_for_pt, cursor_pts))))
-            files = list(filter_(head.from_filename() for head in headers))
+            files = list(filter_(head.to_filename() for head in headers))
             if not files:
                 flash(self.view, "Not within a hunk")
                 return
@@ -865,7 +865,7 @@ def jump_position_to_file(view, diff, pt):
     header, hunk = head_and_hunk
 
     line, col = real_linecol_in_hunk(hunk, *row_offset_and_col_in_hunk(view, hunk, pt))
-    filename = header.from_filename()
+    filename = header.to_filename()
     if not filename:
         return None
 

--- a/core/commands/line_history.py
+++ b/core/commands/line_history.py
@@ -133,7 +133,7 @@ class gs_line_history(TextCommand, GitCommand):
             flash(view, "Not on a hunk.")
             return
         header = d.head_for_hunk(hunk)
-        file_path = header.from_filename()
+        file_path = header.to_filename()
         if not file_path:
             flash(view, "Can't extract a file path.")
             return

--- a/core/parse_diff.py
+++ b/core/parse_diff.py
@@ -182,7 +182,7 @@ class CommitHeader(TextRange):
 
 
 class FileHeader(TextRange):
-    def from_filename(self):
+    def to_filename(self):
         # type: () -> Optional[str]
         match = HEADER_TO_FILE_RE.search(self.text)
         if not match:


### PR DESCRIPTION
The function actually returns the "b"-part.  The used regex `HEADER_TO_FILE_RE` already indicates that.