### PR TITLE
Let `[a]` act like a toggle when branches are set

### DIFF
--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -1074,7 +1074,7 @@ class gs_log_graph_refresh(TextCommand, GitCommand):
         ):
             args += ['--simplify-by-decoration', '--sparse']
 
-        if branches:
+        if branches and not all_branches:
             args += branches
 
         if filters and apply_filters:


### PR DESCRIPTION
Fixes #1775

We had a mismatch between the git command we executed and the prelude we show.

The prelude suggested that `[a]` is a toggle, i.e. it did *hide* the set `branches` when `all_branches` was also set.  But the actual git command did not follow.

I think the prelude is right here so we fix the git command.