### PR TITLE
Rework prelude generation

### DIFF
--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -1114,7 +1114,7 @@ def prelude(view):
     elif repo_path:
         prelude += "  REPO: {}\n".format(repo_path)
 
-    all_ = settings.get("git_savvy.log_graph_view.all_branches") or False
+    all_branches = settings.get("git_savvy.log_graph_view.all_branches") or False
     branches = [] if overview else settings.get("git_savvy.log_graph_view.branches") or []
     filters = apply_filters and settings.get("git_savvy.log_graph_view.filters") or ""
     prelude += (
@@ -1123,9 +1123,9 @@ def prelude(view):
             (
                 'OVERVIEW'
                 if overview
-                else '[a]ll: true' if all_ else '[a]ll: false'
+                else '[a]ll: true' if all_branches else '[a]ll: false'
             ),
-            " ".join(branches) if not all_ else None,
+            " ".join(branches) if not all_branches else None,
             filters
         )))
     )

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -1105,18 +1105,18 @@ def prelude(view):
     repo_path = settings.get("git_savvy.repo_path")
     overview = settings.get("git_savvy.log_graph_view.overview")
 
-    paths = [] if overview else settings.get("git_savvy.log_graph_view.paths")
+    paths = settings.get("git_savvy.log_graph_view.paths") or []
     apply_filters = settings.get("git_savvy.log_graph_view.apply_filters")
 
     prelude = "\n"
-    if apply_filters and paths:
+    if paths and apply_filters and not overview:
         prelude += "  FILE: {}\n".format(" ".join(paths))
     elif repo_path:
         prelude += "  REPO: {}\n".format(repo_path)
 
     all_branches = settings.get("git_savvy.log_graph_view.all_branches") or False
-    branches = [] if overview else settings.get("git_savvy.log_graph_view.branches") or []
-    filters = apply_filters and settings.get("git_savvy.log_graph_view.filters") or ""
+    branches = settings.get("git_savvy.log_graph_view.branches") or []
+    filters = settings.get("git_savvy.log_graph_view.filters") or ""
     prelude += (
         "  "
         + "  ".join(filter_((
@@ -1125,8 +1125,8 @@ def prelude(view):
                 if overview
                 else '[a]ll: true' if all_branches else '[a]ll: false'
             ),
-            " ".join(branches) if not all_branches else None,
-            filters
+            " ".join(branches) if not all_branches and not overview else None,
+            filters if apply_filters else None
         )))
     )
     return prelude + "\n\n"

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -1102,11 +1102,13 @@ def lax_decoder(encodings):
 def prelude(view):
     # type: (sublime.View) -> str
     settings = view.settings()
-    repo_path = settings.get("git_savvy.repo_path")
-    overview = settings.get("git_savvy.log_graph_view.overview")
-
-    paths = settings.get("git_savvy.log_graph_view.paths") or []
+    all_branches = settings.get("git_savvy.log_graph_view.all_branches") or False
     apply_filters = settings.get("git_savvy.log_graph_view.apply_filters")
+    branches = settings.get("git_savvy.log_graph_view.branches") or []
+    filters = settings.get("git_savvy.log_graph_view.filters") or ""
+    overview = settings.get("git_savvy.log_graph_view.overview")
+    paths = settings.get("git_savvy.log_graph_view.paths") or []
+    repo_path = settings.get("git_savvy.repo_path")
 
     prelude = "\n"
     if paths and apply_filters and not overview:
@@ -1114,9 +1116,6 @@ def prelude(view):
     elif repo_path:
         prelude += "  REPO: {}\n".format(repo_path)
 
-    all_branches = settings.get("git_savvy.log_graph_view.all_branches") or False
-    branches = settings.get("git_savvy.log_graph_view.branches") or []
-    filters = settings.get("git_savvy.log_graph_view.filters") or ""
     prelude += (
         "  "
         + "  ".join(filter_((

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -1107,9 +1107,6 @@ def prelude(view):
 
     paths = [] if overview else settings.get("git_savvy.log_graph_view.paths")
     apply_filters = settings.get("git_savvy.log_graph_view.apply_filters")
-    all_ = settings.get("git_savvy.log_graph_view.all_branches") or False
-    branches = settings.get("git_savvy.log_graph_view.branches") or []
-    filters = apply_filters and settings.get("git_savvy.log_graph_view.filters") or ""
 
     prelude = "\n"
     if apply_filters and paths:


### PR DESCRIPTION
In 98eed7b (Bind `[s]` to switch to an "branches overview" mode) we
introduced reading some settings twice.  Fix that and then just write 
the function more concise.  