### PR TITLE
Improve "Compare with..." command

### DIFF
--- a/core/commands/commit_compare.py
+++ b/core/commands/commit_compare.py
@@ -89,8 +89,8 @@ class gs_compare_against_branch(WindowCommand, GitCommand):
 
 class gs_compare_against(PanelActionMixin, WindowCommand):
     default_actions = [
-        ["compare_against_branch", "Branch"],
-        ["compare_against_reference", "Reference"],
+        ["compare_against_branch", "Select branch..."],
+        ["compare_against_reference", "Enter reference..."],
     ]
 
     def run(self, base_commit=None, target_commit=None, file_path=None, current_file=False, target_hints=None):

--- a/core/commands/log.py
+++ b/core/commands/log.py
@@ -203,7 +203,8 @@ class GsLogActionCommand(PanelActionMixin, WindowCommand):
     def compare_against(self):
         self.window.run_command("gs_compare_against", {
             "base_commit": self._commit_hash,
-            "file_path": self._file_path
+            "file_path": self._file_path,
+            "target_hints": ["HEAD"],
         })
 
     def copy_sha(self):

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -2480,7 +2480,7 @@ class gs_log_graph_action(WindowCommand, GitCommand):
                     "Compare {}'{}' and '{}'".format(
                         "file between " if file_path else "", base_commit, target_commit
                     ),
-                    partial(self.compare_against, base_commit, target_commit, file_path)
+                    partial(self.compare_commits, base_commit, target_commit, file_path)
                 ),
                 (
                     "Show file history from {}..{}".format(base_commit, target_commit)
@@ -2681,15 +2681,41 @@ class gs_log_graph_action(WindowCommand, GitCommand):
 
         actions += [
             ("Revert commit", partial(self.revert_commit, commit_hash)),
-            (
-                "Compare {}against ...".format("file " if file_path else ""),
-                partial(
-                    self.compare_against,
-                    info["HEAD"] if on_checked_out_branch else commit_hash,
-                    file_path=file_path
-                )
-            ),
         ]
+        if not head_info or cursor_is_not_on_head:
+            good_head_name = (
+                "'{}'".format(head_info["HEAD"])  # type: ignore[index]
+                if head_is_on_a_branch
+                else "HEAD"
+            )
+            get = partial(get_list, info)  # type: Callable[[ListItems], List[str]]  # type: ignore[no-redef]
+            good_target_name = next(
+                chain(get("local_branches"), get("branches")),
+                good_commit_name
+            )
+            actions += [
+                (
+                    "Compare '{}' with {}".format(good_target_name, good_head_name),
+                    partial(
+                        self.compare_commits,
+                        head_info["HEAD"] if head_is_on_a_branch else commit_hash,  # type: ignore[index]
+                        good_target_name,
+                        file_path=file_path,
+                    )
+                )
+            ]
+        else:
+            actions += [
+                (
+                    "Compare {}against ...".format("file " if file_path else ""),
+                    partial(
+                        self.compare_against,
+                        info["HEAD"] if on_checked_out_branch else commit_hash,
+                        file_path=file_path,
+                    )
+                ),
+            ]
+
         if file_path:
             actions += [
                 (
@@ -2772,12 +2798,17 @@ class gs_log_graph_action(WindowCommand, GitCommand):
         finally:
             util.view.refresh_gitsavvy_interfaces(self.window, refresh_sidebar=True)
 
-    def compare_against(self, base_commit, target_commit=None, file_path=None):
-        self.window.run_command("gs_compare_against", {
+    def compare_commits(self, base_commit, target_commit, file_path=None):
+        self.window.run_command("gs_compare_commit", {
             "base_commit": base_commit,
             "target_commit": target_commit,
+            "file_path": file_path
+        })
+
+    def compare_against(self, base_commit, file_path=None):
+        self.window.run_command("gs_compare_against", {
+            "base_commit": base_commit,
             "file_path": file_path,
-            "target_hints": ["HEAD"],
         })
 
     def copy_sha(self, commit_hash):

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -2776,7 +2776,8 @@ class gs_log_graph_action(WindowCommand, GitCommand):
         self.window.run_command("gs_compare_against", {
             "base_commit": base_commit,
             "target_commit": target_commit,
-            "file_path": file_path
+            "file_path": file_path,
+            "target_hints": ["HEAD"],
         })
 
     def copy_sha(self, commit_hash):

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -2705,6 +2705,8 @@ class gs_log_graph_action(WindowCommand, GitCommand):
                 )
             ]
         else:
+            interesting_candidates = branches.keys() & ["main", "master", "dev"]
+            target_hints = sorted(interesting_candidates, key=lambda branch: -branches[branch].committerdate)
             actions += [
                 (
                     "Compare {}against ...".format("file " if file_path else ""),
@@ -2712,6 +2714,7 @@ class gs_log_graph_action(WindowCommand, GitCommand):
                         self.compare_against,
                         info["HEAD"] if on_checked_out_branch else commit_hash,
                         file_path=file_path,
+                        target_hints=target_hints
                     )
                 ),
             ]
@@ -2805,10 +2808,16 @@ class gs_log_graph_action(WindowCommand, GitCommand):
             "file_path": file_path
         })
 
-    def compare_against(self, base_commit, file_path=None):
+    def compare_against(self, base_commit, file_path=None, target_hints=None):
+        nearest_tag = self.git("describe", "--abbrev=0").strip()
+        if nearest_tag:
+            if target_hints is None:
+                target_hints = []
+            target_hints += [nearest_tag]
         self.window.run_command("gs_compare_against", {
             "base_commit": base_commit,
             "file_path": file_path,
+            "target_hints": target_hints
         })
 
     def copy_sha(self, commit_hash):


### PR DESCRIPTION
Fixes #1778

If the cursor is *not* on the HEAD, just offer to compare the
commit under cursor with HEAD.  (T.i. we don't show the wizard anymore.)

If the cursor *is* on the HEAD commit, show the wizard to let the user
choose a target.  Make sure the wizard does not offer "HEAD" as a target
as that would mean compare "HEAD vs HEAD" which is nonsense.  Add
some typical targets, "main" or "master" and e.g. the nearest tag, to choose 
from quickly. 

