### PR TITLE
Set `default_branch_only` when forking a GitHub repo

### DIFF
--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -46,6 +46,22 @@
     },
 
     /*
+        Only supported on GitHub.
+        When creating a fork, do only copy the main branch.  Especially do
+        *not* copy the tags from the original repo to your repo.
+        Instead of changing the default, you can also add a command, for
+        example to your `User.sublime-commands` file, e.g.:
+            {
+                "caption": "git: create fork (non-sparse)",
+                "command": "gs_github_create_fork",
+                "args": { "default_branch_only": false}
+            },
+
+        See: https://github.blog/changelog/2022-07-27-you-can-now-fork-a-repo-and-copy-only-the-default-branch/
+    */
+    "sparse_fork": true,
+
+    /*
     maximum number of items per page when requesting from github
     */
     "github_per_page_max" : 100,

--- a/common/interwebs.py
+++ b/common/interwebs.py
@@ -40,6 +40,9 @@ def request(verb, host, port, path, payload=None, https=False, headers=None, aut
         username_password = "{}:{}".format(*auth).encode("ascii")
         headers["Authorization"] = "Basic {}".format(b64encode(username_password).decode("ascii"))
 
+    if payload and not isinstance(payload, str):
+        payload = json.dumps(payload)
+
     with measure_runtime() as ms:
         connection = (http.client.HTTPSConnection(host, port)
                       if https

--- a/github/commands/create_fork.py
+++ b/github/commands/create_fork.py
@@ -16,14 +16,16 @@ __all__ = ['gs_github_create_fork']
 class gs_github_create_fork(GsWindowCommand, git_mixins.GithubRemotesMixin):
 
     @on_worker
-    def run(self):
+    def run(self, default_branch_only=None):
         remotes = self.get_remotes()
         base_remote_name = self.get_integrated_remote_name(remotes)
         base_remote_url = remotes[base_remote_name]
         base_remote = github.parse_remote(base_remote_url)
 
+        if default_branch_only is None:
+            default_branch_only = self.savvy_settings.get("sparse_fork", True)
         self.window.status_message(START_CREATE_MESSAGE.format(repo=base_remote.url))
-        result = github.create_fork(base_remote)
+        result = github.create_fork(base_remote, default_branch_only=default_branch_only)
         util.debug.add_to_log({"github: fork result": result})
 
         url = (

--- a/github/commands/create_fork.py
+++ b/github/commands/create_fork.py
@@ -1,10 +1,9 @@
 import sublime
-from sublime_plugin import WindowCommand
 
 from ...common import util
-from ...core.git_command import GitCommand
 from .. import github, git_mixins
-from GitSavvy.core.runtime import enqueue_on_worker
+from GitSavvy.core.base_commands import GsWindowCommand
+from GitSavvy.core.runtime import on_worker
 
 
 START_CREATE_MESSAGE = "Forking {repo} ..."
@@ -14,16 +13,10 @@ END_CREATE_MESSAGE = "Fork created successfully."
 __all__ = ['gs_github_create_fork']
 
 
-class gs_github_create_fork(
-    WindowCommand,
-    git_mixins.GithubRemotesMixin,
-    GitCommand,
-):
+class gs_github_create_fork(GsWindowCommand, git_mixins.GithubRemotesMixin):
 
+    @on_worker
     def run(self):
-        enqueue_on_worker(self.run_async)
-
-    def run_async(self):
         remotes = self.get_remotes()
         base_remote_name = self.get_integrated_remote_name(remotes)
         base_remote_url = remotes[base_remote_name]

--- a/github/github.py
+++ b/github/github.py
@@ -209,7 +209,7 @@ get_forks = partial(iteratively_query_github, "/repos/{owner}/{repo}/forks")
 get_pull_requests = partial(iteratively_query_github, "/repos/{owner}/{repo}/pulls")
 
 
-def post_to_github(api_url_template, github_repo):
+def post_to_github(api_url_template, github_repo, payload=None):
     """
     Takes a URL template that takes `owner` and `repo` template variables
     and as a GitHub repo object.  Do a POST for the provided URL and return
@@ -218,7 +218,7 @@ def post_to_github(api_url_template, github_repo):
     fqdn, path = github_api_url(api_url_template, github_repo)
     auth = (github_repo.token, "x-oauth-basic") if github_repo.token else None
 
-    response = interwebs.post(fqdn, 443, path, https=True, auth=auth)
+    response = interwebs.post(fqdn, 443, path, https=True, auth=auth, payload=payload)
     validate_response(response, method="POST")
 
     return response.payload

--- a/github/github.py
+++ b/github/github.py
@@ -224,4 +224,9 @@ def post_to_github(api_url_template, github_repo, payload=None):
     return response.payload
 
 
-create_fork = partial(post_to_github, "/repos/{owner}/{repo}/forks")
+def create_fork(github_repo: GitHubRepo, default_branch_only: bool = False):
+    return post_to_github(
+        "/repos/{owner}/{repo}/forks",
+        github_repo,
+        {"default_branch_only": default_branch_only}
+    )


### PR DESCRIPTION


Closes #1772

Setting `default_branch_only` is like a sparse fork.  See:
https://github.blog/changelog/2022-07-27-you-can-now-fork-a-repo-and-copy-only-the-default-branch/

We make the default "sparse" and introduce an argument to the command
so users can add a "create full fork" to the Command Palette or where
they wish to at their own.

Additionally, a new setting `sparse_fork` is added whose value is used
as a default when `default_branch_only` is `None`.