### PR TITLE
Support progress information in the output panel

### DIFF
--- a/common/util/log.py
+++ b/common/util/log.py
@@ -2,9 +2,7 @@ import re
 import sublime
 
 
-MYPY = False
-if MYPY:
-    from typing import Optional
+from typing import Optional
 
 
 PANEL_NAME = "GitSavvy"

--- a/core/commands/init.py
+++ b/core/commands/init.py
@@ -206,6 +206,7 @@ class gs_clone(WindowCommand, GitCommand):
         window.status_message("Start cloning {}".format(self.git_url))
         self.git(
             "clone",
+            "--progress",
             "--recursive" if self.recursive else None,
             self.git_url,
             self.target_dir,

--- a/core/fns.py
+++ b/core/fns.py
@@ -1,3 +1,4 @@
+from collections import deque
 from functools import partial
 from itertools import accumulate as accumulate_, chain, islice, tee
 
@@ -8,6 +9,10 @@ U = TypeVar('U')
 
 filter_ = partial(filter, None)  # type: Callable[[Iterable[Optional[T]]], Iterator[T]]  # type: ignore[assignment]
 flatten = chain.from_iterable
+
+
+def consume(it: Iterable) -> None:
+    deque(it, 0)
 
 
 def maybe(fn):

--- a/core/fns.py
+++ b/core/fns.py
@@ -1,11 +1,9 @@
 from functools import partial
 from itertools import accumulate as accumulate_, chain, islice, tee
 
-MYPY = False
-if MYPY:
-    from typing import Callable, Iterable, Iterator, List, Optional, Set, Tuple, TypeVar
-    T = TypeVar('T')
-    U = TypeVar('U')
+from typing import Callable, Iterable, Iterator, List, Optional, Set, Tuple, TypeVar
+T = TypeVar('T')
+U = TypeVar('U')
 
 
 filter_ = partial(filter, None)  # type: Callable[[Iterable[Optional[T]]], Iterator[T]]  # type: ignore[assignment]

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -23,14 +23,13 @@ import sublime
 
 from ..common import util
 from .settings import SettingsMixin
-from GitSavvy.core.fns import filter_
+from GitSavvy.core.fns import filter_, pairwise
 from GitSavvy.core.runtime import auto_timeout, enqueue_on_worker, run_as_future
 from GitSavvy.core.utils import kill_proc, paths_upwards, resolve_path
 
 
+from typing import Callable, Deque, Dict, IO, Iterator, List, Optional, Sequence, Tuple, Union
 MYPY = False
-if MYPY:
-    from typing import Callable, Deque, Dict, IO, Iterator, List, Optional, Sequence, Tuple, Union
 
 
 #: A mapping from a git binary to its version
@@ -54,6 +53,36 @@ MIN_GIT_VERSION = (2, 18, 0)
 GIT_TOO_OLD_MSG = "Your Git version is too old. GitSavvy requires {:d}.{:d}.{:d} or above."
 
 NOT_SET = "<NOT_SET>"
+
+
+class TimeoutManager:
+    def __init__(self, timeout: float) -> None:
+        self._start_time = time.perf_counter()
+        self._timeout = timeout
+
+    def ping(self) -> None:
+        self._start_time = time.perf_counter()
+
+    def has_timed_out(self) -> bool:
+        return time.perf_counter() - self._start_time > self._timeout
+
+
+class _NullTimeoutManager(TimeoutManager):
+    def __init__(self) -> None:
+        pass
+
+    def ping(self) -> None:
+        pass
+
+    def has_timed_out(self):
+        return False
+
+
+NeverTimeout = _NullTimeoutManager()
+
+
+def timer(timeout: Optional[float]) -> TimeoutManager:
+    return TimeoutManager(timeout) if timeout else NeverTimeout
 
 
 def communicate_and_log(proc, stdin, log, timeout=None):
@@ -86,23 +115,47 @@ class Out(bytes): pass  # noqa: E701
 class Err(bytes): pass  # noqa: E701
 
 
-def read_linewise(fh, kont):
-    # type: (IO[bytes], Callable[[bytes], None]) -> None
-    for line in iter(fh.readline, b''):
+def read_linewise(fh, kont, ping):
+    # type: (IO[bytes], Callable[[bytes], None], Callable[[], None]) -> None
+    for line in _group_bytes_to_lines(_read_bytewise(fh, ping)):
         kont(line)
+
+
+def _read_bytewise(fh: IO[bytes], ping: Callable[[], None]) -> Iterator[bytes]:
+    while True:
+        byte = fh.read(1)
+        if not byte:
+            break
+        ping()
+        yield byte
+
+
+def _group_bytes_to_lines(bytewise: Iterator[bytes]) -> Iterator[bytes]:
+    line = b""
+    for left, right in pairwise(chain(bytewise, [None])):
+        if left == b"\r" and right == b"\n":
+            # skip to convert "\r\n" to "\n"
+            continue
+
+        assert left is not None  # mypy is confused because of the `[None]`
+        line += left
+        if left == b"\n" or left == b"\r":
+            yield line
+            line = b""
+
+    if line:
+        yield line
 
 
 def stream_stdout_and_err(proc, timeout):
     # type: (subprocess.Popen[bytes], Optional[float]) -> Iterator[bytes]
-    if timeout:
-        start_time = time.perf_counter()
-
+    timeout_manager = timer(timeout)
     container = deque()  # type: Deque[bytes]
     append = container.append
     assert proc.stdout
     assert proc.stderr
-    out_f = run_as_future(read_linewise, proc.stdout, lambda line: append(Out(line)))
-    err_f = run_as_future(read_linewise, proc.stderr, lambda line: append(Err(line)))
+    out_f = run_as_future(read_linewise, proc.stdout, lambda line: append(Out(line)), timeout_manager.ping)
+    err_f = run_as_future(read_linewise, proc.stderr, lambda line: append(Err(line)), timeout_manager.ping)
     delay = chain([1, 2, 4, 8, 15, 30], repeat(50))
 
     with proc:
@@ -111,7 +164,7 @@ def stream_stdout_and_err(proc, timeout):
                 yield container.popleft()
             except IndexError:
                 time.sleep(next(delay) / 1000)
-                if timeout and time.perf_counter() - start_time > timeout:
+                if timeout_manager.has_timed_out():
                     kill_proc(proc)
                     raise TimeoutError("timed out after {} seconds".format(timeout))
 

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -143,16 +143,16 @@ def stream_stdout_and_err(proc, timeout):
 
 def read_linewise(fh, kont, ping):
     # type: (IO[bytes], Callable[[bytes], None], Callable[[], None]) -> None
-    for line in _group_bytes_to_lines(_read_bytewise(fh, ping)):
+    for line in _group_bytes_to_lines(_read_bytewise(fh)):
+        ping()
         kont(line)
 
 
-def _read_bytewise(fh: IO[bytes], ping: Callable[[], None]) -> Iterator[bytes]:
+def _read_bytewise(fh: IO[bytes]) -> Iterator[bytes]:
     while True:
         byte = fh.read(1)
         if not byte:
             break
-        ping()
         yield byte
 
 

--- a/syntax/output_panel.sublime-syntax
+++ b/syntax/output_panel.sublime-syntax
@@ -19,6 +19,12 @@ contexts:
       comment: SHA
       scope: constant.numeric.graph.commit-hash.git-savvy
 
+    - match: \((\d+)/(\d+)\)
+      comment: progress counter
+      captures:
+        1: constant.numeric.progress.git-savvy
+        2: constant.numeric.progress.git-savvy
+
     - match: -> ([^ ]*)
       captures:
         1: storage

--- a/syntax/test/syntax_test_output_panel.txt
+++ b/syntax/test/syntax_test_output_panel.txt
@@ -36,6 +36,9 @@ $ git rebase --interactive --autostash --no-autosquash 87e57b9d^
 #                 ^^^^^^^^ constant.numeric.graph.commit-hash.git-savvy
 Rebasing (2/3)
 Rebasing (3/3)
+#         ^ constant.numeric.progress.git-savvy
+#          ^ - constant.numeric.progress.git-savvy
+#           ^ constant.numeric.progress.git-savvy
 
 Successfully rebased and updated refs/heads/open-issue-at-hand.
 Successfully rebased and updated refs/heads/open-issue-at-hand


### PR DESCRIPTION
E.g.

![image](https://github.com/timbrel/GitSavvy/assets/8558/8460639e-d56a-4914-bbcd-8f2a56faac4f)

Of course these numbers above move, that's the point of a progress bar/info.

Note that this changes how we measure timeouts as we now "ping" on each byte we receive, thus we only timeout stalled
processes.  (This is what we want probably as before that we actually could have timed out if we fetch big enough repos.  E.g. just clone "git" and it is likely the command would have timed out unless you live in a rich region of the world.)

The interpretation for the timeout has only changed for our implementation though, t.i. when we log to the open panel, as we otherwise just use `proc.communicate` which has its own semantics.  

The progress is only turned on for "clone" and "rebase".  A future PR will enable this for other commands.  Typically "push", "pull", "fetch".  