### PR TITLE
fix(branch): pass name as initial prompt text

### DIFF
--- a/core/commands/checkout.py
+++ b/core/commands/checkout.py
@@ -75,7 +75,9 @@ class gs_checkout_new_branch(GsWindowCommand):
     Prompt the user for a new branch name, create it, and check it out.
     """
     defaults = {
-        "branch_name": ask_for_name(),
+        "branch_name": ask_for_name(
+            initial_text=lambda start_point: start_point,
+        ),
     }
 
     def run(self, branch_name, start_point=None, force=False, merge=False):


### PR DESCRIPTION
Unlike with remote branches, local branches that were the target of the [b] shortcut, were failing to pass the branch name as the initial text of the prompt for the new branch.

For context, this is a problem for me as I use this flow:
1. when I have a big change planned
2. I create a copy of the local branch by hitting [b]
3. I usually add a suffix in the end of the branch to indicate it's a copy

Tested on a local copy