### PR TITLE
Revert "fix(branch): pass name as initial prompt text"

### DIFF
--- a/core/commands/checkout.py
+++ b/core/commands/checkout.py
@@ -75,9 +75,7 @@ class gs_checkout_new_branch(GsWindowCommand):
     Prompt the user for a new branch name, create it, and check it out.
     """
     defaults = {
-        "branch_name": ask_for_name(
-            initial_text=lambda start_point: start_point,
-        ),
+        "branch_name": ask_for_name(),
     }
 
     def run(self, branch_name, start_point=None, force=False, merge=False):


### PR DESCRIPTION
This reverts commit fdabd46e4dc93ecfbb2f9c9377d12069532d6a8f.

The change introduced in #1797 throws for the command "checkout new branch":

```
Traceback (most recent call last):
  File "C:\Users\c-flo\AppData\Roaming\Sublime Text\Packages\GitSavvy\core\base_commands.py", line 75, in run_
    self.defaults[name](self, args, done)
  File "C:\Users\c-flo\AppData\Roaming\Sublime Text\Packages\GitSavvy\core\commands\branch.py", line 71, in handler
    initial_text_ or call_with_wanted_args(initial_text, args),
  File "C:\Users\c-flo\AppData\Roaming\Sublime Text\Packages\GitSavvy\core\commands\branch.py", line 48, in call_with_wanted_args
    return fn(**{k: args[k] for k in fs.parameters.keys() if k in args})
TypeError: <lambda>() missing 1 required positional argument: 'start_point'
```

Revert as a hotfix.

