### PR TITLE
Small code readability nit

### DIFF
--- a/core/commands/next_hunk.py
+++ b/core/commands/next_hunk.py
@@ -93,13 +93,13 @@ def modifications_per_hunk(view, forwards=True):
         )
     except StopIteration:
         return
-    else:
-        yield from (
-            b for a, b in takewhile(
-                lambda a_b: line_distance(view, *a_b) < LINE_DISTANCE_BETWEEN_EDITS,
-                jump_positions
-            )
+
+    yield from (
+        b for a, b in takewhile(
+            lambda a_b: line_distance(view, *a_b) < LINE_DISTANCE_BETWEEN_EDITS,
+            jump_positions
         )
+    )
 
 
 def all_modifications(view, forwards=True):


### PR DESCRIPTION
Avoid the `else` clause as we're not using a variable coming from the `try` clause.