### PR TITLE
Fix deleting tags in the tags dashboard

### DIFF
--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -404,11 +404,11 @@ class gs_tags_delete(TagsInterfaceCommand):
     @on_worker
     def run(self, edit):
         interface = self.interface
-        self.delete_local(interface)
+        self.delete_local()
         self.delete_remote(interface)
         util.view.refresh_gitsavvy(self.view)
 
-    def delete_local(self, interface):
+    def delete_local(self):
         tags_to_delete = self.selected_local_tags()
         if not tags_to_delete:
             return

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -421,7 +421,6 @@ class gs_tags_delete(TagsInterfaceCommand):
                 uprint(DELETE_UNDO_MESSAGE.format(tag, commit))
 
         flash(self.view, TAG_DELETE_MESSAGE)
-        util.view.refresh_gitsavvy(self.view)
 
     def delete_remote(self, interface):
         if not interface.remotes:
@@ -440,7 +439,6 @@ class gs_tags_delete(TagsInterfaceCommand):
 
         flash(self.view, TAG_DELETE_MESSAGE)
         interface.remotes = None
-        util.view.refresh_gitsavvy(self.view)
 
 
 class gs_tags_push(TagsInterfaceCommand):

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -217,7 +217,7 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
 
         remote_tags, remote_tag_names = set(), set()
         # wait until all settled to prohibit intermediate state to be drawn
-        # what we draw explcitily relies on *all* known remote tags
+        # what we draw explicitly relies on *all* known remote tags
         if all(info["state"] != "loading" for info in self.state["remote_tags"].values()):
             for info in self.state["remote_tags"].values():
                 if info["state"] == "succeeded":

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -3,6 +3,7 @@ from functools import partial
 import os
 import re
 
+import sublime
 from sublime_plugin import WindowCommand
 
 from ..commands import GsNavigate
@@ -403,6 +404,7 @@ class gs_tags_delete(TagsInterfaceCommand):
 
     @on_worker
     def run(self, edit):
+        # type: (sublime.Edit) -> None
         local_tags = self.delete_local()
         remote_tags = self.delete_remote()
         if local_tags or remote_tags:

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -403,9 +403,8 @@ class gs_tags_delete(TagsInterfaceCommand):
 
     @on_worker
     def run(self, edit):
-        interface = self.interface
         self.delete_local()
-        self.delete_remote(interface)
+        self.delete_remote()
         util.view.refresh_gitsavvy(self.view)
 
     def delete_local(self):
@@ -422,13 +421,9 @@ class gs_tags_delete(TagsInterfaceCommand):
 
         flash(self.view, TAG_DELETE_MESSAGE)
 
-    def delete_remote(self, interface):
-        if not interface.remotes:
-            return
-
-        for remote_name, remote in interface.remotes.items():
+    def delete_remote(self):
+        for remote_name in self.interface.state["remotes"]:
             tags_to_delete = self.selected_remote_tags(remote_name)
-
             if tags_to_delete:
                 self.git(
                     "push",
@@ -438,7 +433,7 @@ class gs_tags_delete(TagsInterfaceCommand):
                 )
 
         flash(self.view, TAG_DELETE_MESSAGE)
-        interface.remotes = None
+        self.interface.state["remote_tags"] = {}
 
 
 class gs_tags_push(TagsInterfaceCommand):


### PR DESCRIPTION
Esp. deleting remote tags was just not possible.  Deleting local tags worked but still raised as `self.delete_remote` did run unconditionally. 

Unfortunately mypy did not catch fire here as this is a simple left-over from moving to the reactive base class.  