### PR TITLE
Pass starting point as initial prompt text when creating new branches

### DIFF
--- a/core/commands/checkout.py
+++ b/core/commands/checkout.py
@@ -75,7 +75,9 @@ class gs_checkout_new_branch(GsWindowCommand):
     Prompt the user for a new branch name, create it, and check it out.
     """
     defaults = {
-        "branch_name": ask_for_name(),
+        "branch_name": ask_for_name(
+            initial_text=lambda start_point: start_point or "",
+        ),
     }
 
     def run(self, branch_name, start_point=None, force=False, merge=False):


### PR DESCRIPTION
Unlike with remote branches, local branches that were the target of the `[b]` shortcut, were failing to pass the branch name as the initial text of the prompt for the new branch.

This commit was already in #1797 which got reverted in #1800 because it threw.  Since then we taught `base_commands.WithInputHandlers` to include arguments with their default values if the command was not called with them, essentially fixing the underlying issue.

Still, Pavel's patch needed an `or = ""` because the default `start_point` is `None` which is not an allowed initial text for an input handler.  Added that.