### PR TITLE
Ensure new views can act as a result buffer after creation

### DIFF
--- a/common/util/view.py
+++ b/common/util/view.py
@@ -77,6 +77,10 @@ def create_scratch_view(window, typ, options={}):
         "read_only": True
     }
     update_view(view, ChainMap(options, defaults))  # type: ignore[arg-type]  # mypy expects a MutableMapping here
+    # Call `focus_view` so that `result_file_regex` et.al. settings get applied.
+    # This does *not* in turn sends `on_activated` as the view gets activated
+    # directly after its creation.
+    window.focus_view(view)
     return view
 
 

--- a/common/util/view.py
+++ b/common/util/view.py
@@ -8,7 +8,7 @@ from ...core.view import place_view
 
 MYPY = False
 if MYPY:
-    from typing import Mapping, Optional
+    from typing import Callable, Mapping, Optional
 
 
 ##############
@@ -91,12 +91,11 @@ def update_view(view, options):
         "title": view.set_name,
         "scratch": view.set_scratch,
         "read_only": view.set_read_only,
-    }
-
+    }  # type: Mapping[str, Callable]
     settings = view.settings()
     for k, v in options.items():
         if k in special_setters:
-            special_setters[k](v)  # type: ignore[operator]
+            special_setters[k](v)
         else:
             settings.set(k, v)
 


### PR DESCRIPTION
Ref: sublimehq/sublime_text#5596
Ref: sublimehq/sublime_text#1358

Directly after creation, t.i. after the views *first* activation,
result regexes (e.g. `result_file_regex`) are not in effect.  The
work-around is to call `focus_view` *after* assigning the regexes.

For now, call this unconditionally to get better insights into this
side-effect.
