### PR TITLE
Expose where the dot is when parsing a commit line

### DIFF
--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -84,7 +84,7 @@ COMMIT_NODE_CHAR = "●"
 COMMIT_NODE_CHAR_OPTIONS = "●*"
 GRAPH_CHAR_OPTIONS = r" /_\|\-\\."
 COMMIT_LINE = re.compile(
-    r"^[{graph_chars}]*[{node_chars}][{graph_chars}]* "
+    r"^[{graph_chars}]*(?P<dot>[{node_chars}])[{graph_chars}]* "
     r"(?P<commit_hash>[a-f0-9]{{5,40}}) +"
     r"(\((?P<decoration>.+?)\))?"
     .format(graph_chars=GRAPH_CHAR_OPTIONS, node_chars=COMMIT_NODE_CHAR_OPTIONS)


### PR DESCRIPTION
Add exposing the "dot"-position.  This is required for a later add-on to support "PowerCursors".