### PR TITLE
Add action to apply available fixes to a given commit

### DIFF
--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -2207,7 +2207,7 @@ def __find_matching_dots(vid, dot):
         original_message = strip_fixup_or_squash_prefix(commit_message)
         return take(1, find_matching_commit(dot, original_message))
     else:
-        return list(find_fixups_upwards(dot, commit_message))
+        return list(dot for dot, _ in find_fixups_upwards(dot, commit_message))
 
 
 def extract_message_regions(view):
@@ -2264,7 +2264,7 @@ def find_matching_commit(dot, message, forward=True):
 
 
 def find_fixups_upwards(dot, message):
-    # type: (colorizer.Char, str) -> Iterator[colorizer.Char]
+    # type: (colorizer.Char, str) -> Iterator[Tuple[colorizer.Char, str]]
     messages = add_fixup_or_squash_prefixes(message.rstrip(".").strip())
 
     previous_dots = follow_dots(dot, forward=False)
@@ -2274,7 +2274,7 @@ def find_fixups_upwards(dot, message):
             for message in messages:
                 shorter, longer = sorted((message, this_message), key=len)
                 if longer.startswith(shorter):
-                    yield dot
+                    yield dot, this_message
 
 
 def _with_message(dots):

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -2207,7 +2207,7 @@ def __find_matching_dots(vid, dot):
         original_message = strip_fixup_or_squash_prefix(commit_message)
         return take(1, find_matching_commit(dot, original_message))
     else:
-        return list(_find_fixups_upwards(dot, commit_message))
+        return list(find_fixups_upwards(dot, commit_message))
 
 
 def extract_message_regions(view):
@@ -2263,7 +2263,7 @@ def find_matching_commit(dot, message, forward=True):
             yield dot
 
 
-def _find_fixups_upwards(dot, message):
+def find_fixups_upwards(dot, message):
     # type: (colorizer.Char, str) -> Iterator[colorizer.Char]
     messages = add_fixup_or_squash_prefixes(message.rstrip(".").strip())
 

--- a/core/commands/log_graph_rebase_actions.py
+++ b/core/commands/log_graph_rebase_actions.py
@@ -181,10 +181,7 @@ class gs_rebase_action(GsWindowCommand):
                     base_commit = commit_hash
                     dots = log_graph.find_fixups_upwards(base_dot, commit_message)
                     fixups = [
-                        Commit(
-                            log_graph.extract_commit_hash(log_graph.line_from_pt(view, dot.pt).text),
-                            message
-                        )
+                        Commit(commit_hash_from_dot(view, dot), message)
                         for dot, message in dots
                     ]
                     if fixups:
@@ -437,6 +434,12 @@ def commit_message_from_line(view, line):
             return line.text[(r.a - line_span.a):(r.b - line_span.a)]
     else:
         return None
+
+
+def commit_hash_from_dot(view, dot):
+    # type: (sublime.View, log_graph.colorizer.Char) -> str
+    line = log_graph.line_from_pt(view, dot.pt)
+    return log_graph.extract_commit_hash(line.text)
 
 
 def find_base_commit_for_fixup(view, commit_line, commit_message):

--- a/core/commands/log_graph_rebase_actions.py
+++ b/core/commands/log_graph_rebase_actions.py
@@ -185,7 +185,7 @@ class gs_rebase_action(GsWindowCommand):
                             log_graph.extract_commit_hash(log_graph.line_from_pt(view, dot.pt).text),
                             message
                         )
-                        for dot, message in log_graph._with_message(dots)
+                        for dot, message in dots
                     ]
                     if fixups:
                         formatted_commit_hashes = log_graph.format_revision_list(


### PR DESCRIPTION
In the rebase menu we already offer "Apply fix to <commit>" when the
cursor is on a fixup or squash commit.  Do this also when the cursor is
on the "base" commit searching upwards for fixups.
