### PR TITLE
Implement [E] and [W] rebase shortcuts when viewing patches

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1023,6 +1023,22 @@
         ]
     },
     {
+        "keys": ["W"],
+        "command": "gs_show_commit_reword_commit",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.show_commit_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["E"],
+        "command": "gs_show_commit_edit_commit",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.show_commit_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
         "keys": ["g"],
         "command": "gs_show_commit_open_graph_context",
         "context": [
@@ -1946,6 +1962,22 @@
     {
         "keys": ["f"],
         "command": "gs_show_commit_initiate_fixup_commit",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.line_history_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["W"],
+        "command": "gs_show_commit_reword_commit",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.line_history_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["E"],
+        "command": "gs_show_commit_edit_commit",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.line_history_view", "operator": "equal", "operand": true }

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1969,7 +1969,7 @@
     },
     {
         "keys": ["W"],
-        "command": "gs_show_commit_reword_commit",
+        "command": "gs_line_history_reword_commit",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.line_history_view", "operator": "equal", "operand": true }

--- a/core/commands/_help_popups.py
+++ b/core/commands/_help_popups.py
@@ -168,6 +168,8 @@ class gs_show_commit_help_tooltip(GsAbstractHelpPopup):
     [n]/[p]        show next/previous commit
     [h]            open commit on GitHub (if available)
     [f]            initiate fixup commit
+    [W]            reWord commit message
+    [E]            Edit commit
     [g]            show in graph
     [,]/[.]        go to next/previous hunk (also: [j]/[k] in vintageous mode)
 
@@ -232,6 +234,8 @@ class gs_line_history_help_tooltip(GsAbstractHelpPopup):
     [O]            open file revision at hunk
     [g]            show in graph
     [f]            make fixup commit
+    [W]            reWord commit message
+    [E]            Edit commit
     [,]/[.]        go to next/previous hunk (also: [j]/[k] in vintageous mode)
 
     ### Other ###


### PR DESCRIPTION
We have `[E]` and `[W]` implemented in the graph view to quickly
initiate a rebase.  Do this also for the "show commit" and "line
history" views.  Especially "show commit" has since then learned `[n]`
and `[p]` to walk the commit history.  To e.g. reword a commit message
seems a natural fit when reviewing the commits then.
