### PR TITLE
When navigating the commit history remember and restore the view state

### DIFF
--- a/core/commands/show_commit.py
+++ b/core/commands/show_commit.py
@@ -9,6 +9,7 @@ from sublime_plugin import WindowCommand, TextCommand
 from . import diff
 from . import intra_line_colorizer
 from . import log_graph_rebase_actions
+from . import show_commit_info
 from . import show_file_at_commit
 from ..fns import filter_, flatten, unique
 from ..git_command import GitCommand
@@ -113,6 +114,7 @@ class gs_show_commit_refresh(TextCommand, GithubRemotesMixin, GitCommand):
         )
         view.set_name(title)
         replace_view_content(view, content)
+        show_commit_info.restore_view_state(view, commit_hash)
         intra_line_colorizer.annotate_intra_line_differences(view)
         if SUBLIME_SUPPORTS_REGION_ANNOTATIONS:
             url = url_cache.get(commit_hash)
@@ -315,6 +317,7 @@ class gs_show_commit_open_previous_commit(TextCommand, GitCommand):
             return
 
         show_file_at_commit.remember_next_commit_for(view, {previous_commit: commit_hash})
+        show_commit_info.remember_view_state(view)
         settings.set("git_savvy.show_commit_view.commit", previous_commit)
 
         view.run_command("gs_show_commit_refresh")
@@ -345,6 +348,7 @@ class gs_show_commit_open_next_commit(TextCommand, GitCommand):
             flash(view, "No newer commit found.")
             return
 
+        show_commit_info.remember_view_state(view)
         settings.set("git_savvy.show_commit_view.commit", next_commit)
 
         view.run_command("gs_show_commit_refresh")

--- a/core/commands/show_commit_info.py
+++ b/core/commands/show_commit_info.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from contextlib import contextmanager
 
 import sublime
@@ -16,12 +17,12 @@ __all__ = (
 
 MYPY = False
 if MYPY:
-    from typing import Dict, Iterator, List, Tuple
+    from typing import DefaultDict, Dict, Iterator, List, Tuple
     ViewportPosition = Tuple[float, float]
     Selection = List[sublime.Region]
 
 
-storage = {}  # type: Dict[str, Tuple[ViewportPosition, Selection]]
+storage = defaultdict(dict)  # type: DefaultDict[sublime.View, Dict[str, Tuple[ViewportPosition, Selection]]]
 PANEL_NAME = "show_commit_info"
 
 
@@ -115,14 +116,22 @@ def _draw(window, view, text, commit, from_log_graph):
 @contextmanager
 def restore_viewport_position(view, next_commit):
     # type: (sublime.View, str) -> Iterator
+    remember_view_state(view)
+    view.settings().set("git_savvy.show_commit_view.commit", next_commit)
+    yield
+    restore_view_state(view, next_commit)
+
+
+def remember_view_state(view):
+    # type: (sublime.View) -> None
     prev_commit = view.settings().get("git_savvy.show_commit_view.commit")
     if prev_commit:
-        storage[prev_commit] = (view.viewport_position(), [r for r in view.sel()])
+        storage[view][prev_commit] = (view.viewport_position(), [r for r in view.sel()])
 
-    yield
 
-    view.settings().set("git_savvy.show_commit_view.commit", next_commit)
-    prev_position, prev_sel = storage.get(next_commit, ((0, 0), [sublime.Region(0)]))
+def restore_view_state(view, next_commit):
+    # type: (sublime.View, str) -> None
+    prev_position, prev_sel = storage[view].get(next_commit, ((0, 0), [sublime.Region(0)]))
     view.set_viewport_position(prev_position, animate=False)
     view.sel().clear()
     view.sel().add_all(prev_sel)


### PR DESCRIPTION
When we show patches in the commit info panel, we generally remember the viewport-/scrolling-position and the selection per each commit.

Add this also to the show commit view, which is more or less just the maximized version of the panel and which offers navigation using `[n]` and `[p]`.