### PR TITLE
Omit fetch and pull when no upstream is set

### DIFF
--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -2589,10 +2589,15 @@ class gs_log_graph_action(WindowCommand, GitCommand):
         actions = []  # type: List[Tuple[str, Callable[[], None]]]
         on_checked_out_branch = "HEAD" in info and info["HEAD"] in info.get("local_branches", [])
         if on_checked_out_branch:
+            current_branch = info["HEAD"]
+            b = branches[current_branch]
+            if b.upstream:
+                actions += [
+                    ("Fetch", partial(self.fetch, current_branch)),
+                    ("Pull", self.pull),
+                ]
             actions += [
-                ("Fetch", partial(self.fetch, info["HEAD"])),
-                ("Pull", self.pull),
-                ("Push", partial(self.push, info["HEAD"])),
+                ("Push", partial(self.push, current_branch)),
                 SEPARATOR,
             ]
 


### PR DESCRIPTION
Fixes #1796

The "plain" fetch and pull commands are confusing to use when no upstream is set.  Both ask for a remote or a remote branch in case of pull.  This might be useful but inconsistent to when the upstream is set.  Hence, omit these menu items.