### PR TITLE
Do not scroll to the cursor if it is on the first "page"

### DIFF
--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -357,9 +357,11 @@ def _draw(view, title, prelude, diff_text, match_position):
                     # yields all lines in the hunk.
                     if not line.is_from_line() and b == lineno:
                         pt = line.a + col + line.mode_len
-                        visible_region = view.visible_region()
-                        # Do not scroll if the diff fits on one screen
-                        should_scroll = view.size() > len(visible_region)
+                        # Do not scroll if the cursor fits on the first "page",
+                        # always show the prelude if possible.
+                        _, cy = view.text_to_layout(pt)
+                        _, vh = view.viewport_extent()
+                        should_scroll = cy >= vh
                         place_cursor_and_show(
                             view, pt, row_offset if should_scroll else None, no_overscroll=True)
                         navigated = True


### PR DESCRIPTION
We introduced scrolling the viewport when switching from a file to its diff.  We omitted this already for diffs that fit on one page.

Omit this generally if the cursor fits on the *first* page of the diff view.  T.i. essentially: try to always show the prelude.