### PR TITLE
Flash navigation position in the diff views

### DIFF
--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -1003,6 +1003,7 @@ class gs_diff_navigate(GsNavigate):
     """
 
     offset = 0
+    log_position = True
     wrap_with_force = True
 
     def get_available_regions(self):

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -1004,7 +1004,6 @@ class gs_diff_navigate(GsNavigate):
 
     offset = 0
     log_position = True
-    wrap_with_force = True
 
     def get_available_regions(self):
         return [

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -1096,6 +1096,7 @@ class gs_inline_diff_navigate_hunk(GsNavigate):
     position.
     """
     offset = 0
+    log_position = True
     first_region_may_expand_to_bof = False
 
     def get_available_regions(self):

--- a/core/commands/navigate.py
+++ b/core/commands/navigate.py
@@ -19,6 +19,7 @@ class GsNavigate(TextCommand, GitCommand):
     show_at_center = False
     wrap = True
     wrap_with_force = False
+    log_position = False
     # For the first entry, try to show the beginning of the buffer.
     # (Usually we have some info/help text there.)
     first_region_may_expand_to_bof = True
@@ -46,6 +47,12 @@ class GsNavigate(TextCommand, GitCommand):
                     window.status_message("press again to wrap around ...")
             self._just_jumped -= 1
             return
+
+        if self.log_position:
+            window = self.view.window()
+            if window:
+                idx = available_regions.index(wanted_section)
+                window.status_message(f"[{idx + 1}/{len(available_regions)}]")
 
         self._just_jumped = 2
         sel.clear()

--- a/core/commands/navigate.py
+++ b/core/commands/navigate.py
@@ -30,7 +30,7 @@ class GsNavigate(TextCommand, GitCommand):
     def run(self, edit, forward=True):
         self.forward = forward
         sel = self.view.sel()
-        current_position = sel[0].a
+        current_position = sel[0].b
 
         available_regions = self.get_available_regions()
         if not available_regions:

--- a/core/commands/navigate.py
+++ b/core/commands/navigate.py
@@ -2,6 +2,7 @@ import sublime
 from sublime_plugin import TextCommand
 
 from ..git_command import GitCommand
+from ..utils import flash
 from GitSavvy.core.view import show_region
 
 
@@ -42,17 +43,13 @@ class GsNavigate(TextCommand, GitCommand):
         )
         if wanted_section is None:
             if self._just_jumped == 1:
-                window = self.view.window()
-                if window:
-                    window.status_message("press again to wrap around ...")
+                flash(self.view, "press again to wrap around ...")
             self._just_jumped -= 1
             return
 
         if self.log_position:
-            window = self.view.window()
-            if window:
-                idx = available_regions.index(wanted_section)
-                window.status_message(f"[{idx + 1}/{len(available_regions)}]")
+            idx = available_regions.index(wanted_section)
+            flash(self.view, f"[{idx + 1}/{len(available_regions)}]")
 
         self._just_jumped = 2
         sel.clear()


### PR DESCRIPTION
Log current position after navigating in typical `n/m` form.  Turn off "wrap_with_force"  for the diff view as that seems unnecessary
to improve orientation then.