### PR TITLE
Let the fixup log helper not pre-select fixup commits

### DIFF
--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -15,7 +15,7 @@ from sublime_plugin import WindowCommand, TextCommand, EventListener
 from . import intra_line_colorizer
 from . import stage_hunk
 from .navigate import GsNavigate
-from ..fns import filter_, flatten, pairwise, unique
+from ..fns import head, filter_, flatten, pairwise, unique
 from ..parse_diff import SplittedDiff
 from ..git_command import GitCommand
 from ..runtime import ensure_on_ui, enqueue_on_worker
@@ -794,7 +794,20 @@ class gs_initiate_fixup_commit(TextCommand, LogHelperMixin):
                 "initial_text": "fixup! {}".format(commit_message)
             })
 
-        self.show_log_panel(action)
+        def preselected_commit(items):
+            # type: (List[LogEntry]) -> int
+            return next(chain(
+                head(
+                    idx for idx, item in enumerate(items)
+                    if (
+                        not item.summary.startswith("fixup! ")
+                        and not item.summary.startswith("squash! ")
+                    )
+                ),
+                [-1]
+            ))
+
+        self.show_log_panel(action, preselected_commit=preselected_commit)
 
 
 MYPY = False

--- a/core/fns.py
+++ b/core/fns.py
@@ -61,6 +61,11 @@ def drop(n, iterable):
     return islice(iterable, n, None)
 
 
+def head(iterable):
+    # type: (Iterable[T]) -> List[T]
+    return take(1, iterable)
+
+
 def tail(iterable):
     # type: (Iterable[T]) -> Iterator[T]
     return drop(1, iterable)

--- a/core/ui_mixins/quick_panel.py
+++ b/core/ui_mixins/quick_panel.py
@@ -593,8 +593,8 @@ class LogPanel(PaginatedPanel):
 
 
 class LogHelperMixin(GitCommand):
-    def show_log_panel(self, action, preselected_commit_message=None):
-        # type: (Callable[[LogEntry], None], str) -> None
+    def show_log_panel(self, action, preselected_commit=lambda items: -1):
+        # type: (Callable[[LogEntry], None], Callable[[List[LogEntry]], int]) -> None
         window = self._current_window()
         if not window:
             return
@@ -622,11 +622,7 @@ class LogHelperMixin(GitCommand):
                 entry.summary
             )))
 
-        preselected_idx = next(
-            (idx for idx, item in enumerate(items) if item.summary == preselected_commit_message),
-            -1
-        ) if preselected_commit_message else -1
-
+        preselected_idx = preselected_commit(items)
         show_panel(
             window,
             map(format_item, items),


### PR DESCRIPTION
As user you don't want to fixup fixup commits but the original ones. Therefore do not preselect possible fixup/squash commits at the start of the shown list but the first typical commit.