### PR TITLE
Add `[a]/[b]` to toggle sides in the inline diff

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -151,6 +151,24 @@
         ]
     },
     {
+        "keys": ["a"],
+        "command": "gs_inline_diff_toggle_side",
+        "args": {"side": "a"},
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.inline_diff_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["b"],
+        "command": "gs_inline_diff_toggle_side",
+        "args": {"side": "b"},
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.inline_diff_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
         "keys": ["tab"],
         "command": "gs_inline_diff_toggle_cached_mode",
         "context": [

--- a/core/commands/_help_popups.py
+++ b/core/commands/_help_popups.py
@@ -112,6 +112,7 @@ class gs_inline_diff_help_tooltip(GsAbstractHelpPopup):
     key_bindings = dedent("""\
     ### Actions ###
     [tab]          switch between staged/unstaged area
+    [a]/[b]        show/hide the a and b (red or green) sides of the diff
     [l]            stage line, unstage in cached mode
     [h]            stage hunk, unstage in cached mode
     [L]            reset line


### PR DESCRIPTION
Typically diffs show two sides, a and b, in red and green.  For the inline diff add shortcuts to hide and show one of the sides.  This comes in handy for complicated diffs to quickly switch between the previous and the next state.


https://github.com/timbrel/GitSavvy/assets/8558/a13c7254-8e8d-44a2-b632-6182014771c0

