### PR TITLE
Normalize branch dashboard syntax

### DIFF
--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -637,7 +637,7 @@ class gs_branches_navigate_branch(GsNavigate):
     offset = 0
 
     def get_available_regions(self):
-        return self.view.find_by_selector("meta.git-savvy.branches.branch.sha1")
+        return self.view.find_by_selector("constant.other.git-savvy.branches.branch.sha1")
 
 
 class gs_branches_navigate_to_active_branch(GsNavigate):
@@ -649,7 +649,7 @@ class gs_branches_navigate_to_active_branch(GsNavigate):
 
     def get_available_regions(self):
         return self.view.find_by_selector(
-            "meta.git-savvy.branches.branch.active-branch meta.git-savvy.branches.branch.sha1")
+            "meta.git-savvy.branches.branch.active-branch constant.other.git-savvy.branches.branch.sha1")
 
 
 class gs_branches_log(LogMixin, BranchInterfaceCommand):

--- a/syntax/branch.sublime-syntax
+++ b/syntax/branch.sublime-syntax
@@ -28,17 +28,24 @@ contexts:
     - match: ^$
       pop: true
 
-    - match: '^    ([0-9a-f]{7,40}) (\S+)\s?(.*)$'
+    - match: (?=^\s+▸)
+      push:
+        - meta_scope: meta.git-savvy.branches.branch.active-branch
+        - include: row
+        - match: $
+          pop: true
+
+    - match: ^
+      push:
+        - include: row
+        - match: $
+          pop: true
+
+  row:
+    - match: '^  (▸)?\s+([0-9a-f]{7,40}) (\S+)\s?(.*)$'
       captures:
         0: meta.git-savvy.branches.branch
-        1: meta.git-savvy.branches.branch.sha1
-        2: meta.git-savvy.branches.branch.name gitsavvy.gotosymbol
-        3: comment.git-savvy.branches.branch.extra-info
-
-    - match: '^  (▸) ([0-9a-f]{7,40}) (\S+)\s?(.*)$'
-      captures:
-        0: meta.git-savvy.branches.branch.active-branch
-        1: string.other.git-savvy.branches.branch.symbol
-        2: meta.git-savvy.branches.branch.sha1 string.other.git-savvy.branches.branch.sha1
-        3: meta.git-savvy.branches.branch.name gitsavvy.gotosymbol string.other.git-savvy.branches.branch.name
+        1: punctuation.symbol.active-branch.git-savvy
+        2: constant.other.git-savvy.branches.branch.sha1
+        3: meta.git-savvy.branches.branch.name gitsavvy.gotosymbol
         4: comment.git-savvy.branches.branch.extra-info

--- a/syntax/test/syntax_test_branch.txt
+++ b/syntax/test/syntax_test_branch.txt
@@ -4,19 +4,14 @@
 #  <- meta.git-savvy.status -meta.git-savvy.status-summary
 #  ^ keyword.other
   ▸ aaf90ba develop
-# ^ string.other
-#    ^ string.other
-#           ^ string.other
+# ^ punctuation.symbol.active-branch.git-savvy
+#   ^^^^^^^ constant.other.git-savvy.branches.branch.sha1
+#           ^^^^^^^ meta.git-savvy.branches.branch.name
+#           ^^^^^^^ gitsavvy.gotosymbol
   ▸ aaf90ba develop (origin/develop)
-# ^ string.other
-#    ^ string.other
-#           ^ string.other
-#                   ^ comment -string
-    2b17192 master
-#    ^ -string.other
-#           ^ -string.other
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.git-savvy.branches.branch.active-branch
+# <- meta.git-savvy.branches.branch.active-branch
     f21e6a8 old (origin/develop, ahead 13, behind 40)
-#    ^ -string.other -comment
-#           ^ -string.other -comment
-#                  ^ comment -string
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.git-savvy.branches.branch.active-branch
+#               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.git-savvy.branches.branch.extra-info
 


### PR DESCRIPTION
- Mark the sha's as `constant.other...` just like in the other dashboards.

- Mark the active branch indicator as `punctuation...`.

- Mark the whole line of the active branch using a `meta...active-branch` scope.

- Do not use `string.other...` at all.  Esp. do not mark the active branch's name as such.  User can target that name with e.g.

  ``` meta.git-savvy.branches.branch.active-branch meta.git-savvy.branches.branch.name ```