### PR TITLE
When rebase asks for a branch also include remotes

### DIFF
--- a/core/base_commands.py
+++ b/core/base_commands.py
@@ -170,7 +170,7 @@ GsCommand = Union[GsTextCommand, GsWindowCommand]
 
 # COMMON INPUT HANDLERS
 
-KnownKeys = Literal["last_local_branch_for_rebase", "last_branch_used_to_pull_from"]
+KnownKeys = Literal["last_branch_used_to_pull_from", "last_branch_used_to_rebase_from"]
 
 
 def ask_for_branch(memorize_key=None, **kw):

--- a/core/commands/log_graph_rebase_actions.py
+++ b/core/commands/log_graph_rebase_actions.py
@@ -784,10 +784,10 @@ class gs_rebase_skip(sublime_plugin.WindowCommand, RebaseCommand):
         self.rebase('--skip')
 
 
-ask_for_local_branch = ask_for_branch(
-    local_branches_only=True,
+ask_for_branch_ = ask_for_branch(
+    ask_remote_first=False,
     ignore_current_branch=True,
-    memorize_key="last_local_branch_for_rebase"
+    memorize_key="last_branch_used_to_rebase_from"
 )
 
 
@@ -847,7 +847,7 @@ class gs_rebase_interactive(GsTextCommand, RebaseCommand):
 class gs_rebase_interactive_onto_branch(GsTextCommand, RebaseCommand):
     defaults = {
         "commitish": extract_parent_symbol_from_graph,
-        "onto": ask_for_local_branch,
+        "onto": ask_for_branch_,
         "rebase_merges": provide_rebase_merges,
         "update_refs": provide_update_refs,
     }
@@ -875,7 +875,7 @@ class gs_rebase_interactive_onto_branch(GsTextCommand, RebaseCommand):
 
 class gs_rebase_on_branch(GsTextCommand, RebaseCommand):
     defaults = {
-        "on": ask_for_local_branch,
+        "on": ask_for_branch_,
         "rebase_merges": provide_rebase_merges,
         "update_refs": provide_update_refs,
     }

--- a/core/store.py
+++ b/core/store.py
@@ -30,7 +30,7 @@ if MYPY:
             "local_tags": TagList,
             "last_branches": Deque[Optional[str]],
             "last_branch_used_to_pull_from": Optional[str],
-            "last_local_branch_for_rebase": Optional[str],
+            "last_branch_used_to_rebase_from": Optional[str],
             "last_remote_used": Optional[str],
             "last_remote_used_for_push": Optional[str],
             "last_remote_used_with_option_all": Optional[str],


### PR DESCRIPTION
A user might not want to update the local branches all the time. Offer remote branches to rebase from to support that mode.