### PR TITLE
Add "Rebase on" to the standard graph menu

### DIFF
--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -2662,6 +2662,7 @@ class gs_log_graph_action(WindowCommand, GitCommand):
                 ]
             actions += [
                 ("Push", partial(self.push, current_branch)),
+                ("Rebase on...", partial(self.rebase_on)),
                 SEPARATOR,
             ]
 
@@ -2862,6 +2863,9 @@ class gs_log_graph_action(WindowCommand, GitCommand):
     def fetch(self, current_branch):
         remote = self.get_remote_for_branch(current_branch)
         self.window.run_command("gs_fetch", {"remote": remote} if remote else None)
+
+    def rebase_on(self):
+        self.window.run_command("gs_rebase_on_branch")
 
     def update_from_tracking(self, remote, remote_name, local_name):
         # type: (str, str, str) -> None


### PR DESCRIPTION
Standard rebasing is just too common to place it in the rebase menu only.  Place it in the standard menu, where we also fetch, push, and pull.

![image](https://github.com/timbrel/GitSavvy/assets/8558/69c652d0-8e8b-4f72-8498-b0605d8c5e2c)

