### PR TITLE
Let `gs_merge` list only unmerged branches

### DIFF
--- a/core/base_commands.py
+++ b/core/base_commands.py
@@ -10,7 +10,7 @@ from GitSavvy.core.git_command import GitCommand
 from GitSavvy.core.ui_mixins.quick_panel import show_branch_panel
 from GitSavvy.core import store
 
-from typing import Callable, Dict, Iterator, List, Literal, Protocol, TypeVar, Union
+from typing import Any, Callable, Dict, Iterator, List, Literal, Protocol, TypeVar, Union
 
 
 class Kont(Protocol):
@@ -174,7 +174,7 @@ KnownKeys = Literal["last_branch_used_to_pull_from", "last_branch_used_to_rebase
 
 
 def ask_for_branch(memorize_key=None, **kw):
-    # type: (KnownKeys, object) -> ArgProvider
+    # type: (KnownKeys, Any) -> ArgProvider
     def handler(self, args, done):
         # type: (GsCommand, Args, Kont) -> None
         def on_done(branch):

--- a/core/commands/merge.py
+++ b/core/commands/merge.py
@@ -19,7 +19,7 @@ class gs_merge(GsWindowCommand):
     """
 
     defaults = {
-        "branch": ask_for_branch(ignore_current_branch=True),
+        "branch": ask_for_branch(ignore_current_branch=True, merged=False),
     }
 
     @on_worker

--- a/core/git_mixins/branches.py
+++ b/core/git_mixins/branches.py
@@ -87,16 +87,17 @@ class BranchesMixin(mixin_base):
         """
         stdout = self.git(
             "for-each-ref",
-            (
-                "--format="
-                "%(HEAD)%00"
-                "%(refname)%00"
-                "%(upstream)%00"
-                "%(upstream:remotename)%00"
-                "%(upstream:track,nobracket)%00"
-                "%(committerdate:unix)%00"
-                "%(objectname)%00"
-                "%(contents:subject)"
+            "--format={}".format(
+                "%00".join((
+                    "%(HEAD)",
+                    "%(refname)",
+                    "%(upstream)",
+                    "%(upstream:remotename)",
+                    "%(upstream:track,nobracket)",
+                    "%(committerdate:unix)",
+                    "%(objectname)",
+                    "%(contents:subject)",
+                ))
             ),
             *refs
         )  # type: str

--- a/core/ui_mixins/quick_panel.py
+++ b/core/ui_mixins/quick_panel.py
@@ -236,6 +236,7 @@ def show_branch_panel(
         ignore_current_branch: bool = False,
         ask_remote_first: bool = False,
         selected_branch: Optional[str] = None,
+        merged: Optional[bool] = None,
 ):
     """
     Show a quick panel with branches. The callback `on_done(branch)` will
@@ -255,7 +256,8 @@ def show_branch_panel(
         remote_branches_only,
         ignore_current_branch,
         ask_remote_first,
-        selected_branch
+        selected_branch,
+        merged,
     )
     bp.show()
     return bp
@@ -272,6 +274,7 @@ class BranchPanel(GitCommand):
             ignore_current_branch: bool = False,
             ask_remote_first: bool = False,
             selected_branch: Optional[str] = None,
+            merged: Optional[bool] = None,
     ):
         self.window = sublime.active_window()
         self.on_done = on_done
@@ -281,6 +284,7 @@ class BranchPanel(GitCommand):
         self.ignore_current_branch = ignore_current_branch
         self.ask_remote_first = ask_remote_first
         self.selected_branch = selected_branch
+        self.merged = merged
 
     def show(self):
         if self.ask_remote_first:
@@ -289,7 +293,7 @@ class BranchPanel(GitCommand):
             self.select_branch(remote=None)
 
     def select_branch(self, remote=None):
-        branches = self.get_branches()
+        branches = self.get_branches(merged=self.merged)
         if self.local_branches_only:
             self.all_branches = [b.canonical_name for b in branches if b.is_local]
         elif self.remote_branches_only:

--- a/core/ui_mixins/quick_panel.py
+++ b/core/ui_mixins/quick_panel.py
@@ -228,14 +228,14 @@ class RemotePanel(GitCommand):
 
 
 def show_branch_panel(
-        on_done,
+        on_done: Callable[[str], None],
         *,
-        on_cancel=lambda: None,
-        local_branches_only=False,
-        remote_branches_only=False,
-        ignore_current_branch=False,
-        ask_remote_first=False,
-        selected_branch=None
+        on_cancel: Callable[[], None] = lambda: None,
+        local_branches_only: bool = False,
+        remote_branches_only: bool = False,
+        ignore_current_branch: bool = False,
+        ask_remote_first: bool = False,
+        selected_branch: Optional[str] = None,
 ):
     """
     Show a quick panel with branches. The callback `on_done(branch)` will
@@ -265,13 +265,13 @@ class BranchPanel(GitCommand):
 
     def __init__(
             self,
-            on_done,
-            on_cancel,
-            local_branches_only=False,
-            remote_branches_only=False,
-            ignore_current_branch=False,
-            ask_remote_first=False,
-            selected_branch=None
+            on_done: Callable[[str], None],
+            on_cancel: Callable[[], None] = lambda: None,
+            local_branches_only: bool = False,
+            remote_branches_only: bool = False,
+            ignore_current_branch: bool = False,
+            ask_remote_first: bool = False,
+            selected_branch: Optional[str] = None,
     ):
         self.window = sublime.active_window()
         self.on_done = on_done

--- a/tests/test_git_mixins.py
+++ b/tests/test_git_mixins.py
@@ -65,7 +65,8 @@ class TestGetBranchesParsing(TestGitMixinsUsage):
         repo = GitCommand()
         git_output = join0(
             [" ", "refs/heads/master", "refs/remotes/origin/master", "origin", ""]
-            + date_sha_and_subject)
+            + date_sha_and_subject
+            + ["0 0"])
         when(repo).git("for-each-ref", ...).thenReturn(git_output)
         when(repo).get_repo_path().thenReturn("yeah/sure")
         actual = repo.get_branches()
@@ -81,7 +82,8 @@ class TestGetBranchesParsing(TestGitMixinsUsage):
                 0,
                 git_mixins.branches.Upstream(
                     "origin", "master", "origin/master", ""
-                )
+                ),
+                git_mixins.branches.AheadBehind(ahead=0, behind=0)
             )
         ])
 
@@ -89,7 +91,8 @@ class TestGetBranchesParsing(TestGitMixinsUsage):
         repo = GitCommand()
         git_output = join0(
             ["*", "refs/heads/master", "refs/remotes/origin/master", "origin", ""]
-            + date_sha_and_subject)
+            + date_sha_and_subject
+            + ["2 4"])
         when(repo).git("for-each-ref", ...).thenReturn(git_output)
         when(repo).get_repo_path().thenReturn("yeah/sure")
         actual = repo.get_branches()
@@ -105,7 +108,8 @@ class TestGetBranchesParsing(TestGitMixinsUsage):
                 0,
                 git_mixins.branches.Upstream(
                     "origin", "master", "origin/master", ""
-                )
+                ),
+                git_mixins.branches.AheadBehind(ahead=2, behind=4)
             )
         ])
 
@@ -113,7 +117,8 @@ class TestGetBranchesParsing(TestGitMixinsUsage):
         repo = GitCommand()
         git_output = join0(
             [" ", "refs/remotes/origin/dev", "", "", ""]
-            + date_sha_and_subject)
+            + date_sha_and_subject
+            + ["0 0"])
         when(repo).git("for-each-ref", ...).thenReturn(git_output)
         when(repo).get_repo_path().thenReturn("yeah/sure")
         actual = repo.get_branches()
@@ -127,7 +132,8 @@ class TestGetBranchesParsing(TestGitMixinsUsage):
                 False,
                 True,
                 0,
-                None
+                None,
+                git_mixins.branches.AheadBehind(ahead=0, behind=0)
             )
         ])
 
@@ -135,7 +141,8 @@ class TestGetBranchesParsing(TestGitMixinsUsage):
         repo = GitCommand()
         git_output = join0(
             [" ", "refs/heads/master", "refs/remotes/orig/in/master", "orig/in", ""]
-            + date_sha_and_subject)
+            + date_sha_and_subject
+            + ["0 0"])
         when(repo).git("for-each-ref", ...).thenReturn(git_output)
         when(repo).get_repo_path().thenReturn("yeah/sure")
         actual = repo.get_branches()
@@ -151,7 +158,8 @@ class TestGetBranchesParsing(TestGitMixinsUsage):
                 0,
                 git_mixins.branches.Upstream(
                     "orig/in", "master", "orig/in/master", ""
-                )
+                ),
+                git_mixins.branches.AheadBehind(ahead=0, behind=0)
             )
         ])
 
@@ -159,7 +167,8 @@ class TestGetBranchesParsing(TestGitMixinsUsage):
         repo = GitCommand()
         git_output = join0(
             [" ", "refs/heads/master", "refs/remotes/origin/master", "origin", "gone"]
-            + date_sha_and_subject)
+            + date_sha_and_subject
+            + ["0 0"])
         when(repo).git("for-each-ref", ...).thenReturn(git_output)
         when(repo).get_repo_path().thenReturn("yeah/sure")
         actual = repo.get_branches()
@@ -175,7 +184,8 @@ class TestGetBranchesParsing(TestGitMixinsUsage):
                 0,
                 git_mixins.branches.Upstream(
                     "origin", "master", "origin/master", "gone"
-                )
+                ),
+                git_mixins.branches.AheadBehind(ahead=0, behind=0)
             )
         ])
 
@@ -183,7 +193,8 @@ class TestGetBranchesParsing(TestGitMixinsUsage):
         repo = GitCommand()
         git_output = join0(
             [" ", "refs/heads/test", "refs/heads/update-branch-from-upstream", ".", ""]
-            + date_sha_and_subject)
+            + date_sha_and_subject
+            + ["0 0"])
         when(repo).git("for-each-ref", ...).thenReturn(git_output)
         when(repo).get_repo_path().thenReturn("yeah/sure")
         actual = repo.get_branches()
@@ -199,7 +210,8 @@ class TestGetBranchesParsing(TestGitMixinsUsage):
                 0,
                 git_mixins.branches.Upstream(
                     ".", "update-branch-from-upstream", "update-branch-from-upstream", ""
-                )
+                ),
+                git_mixins.branches.AheadBehind(ahead=0, behind=0)
             )
         ])
 
@@ -271,7 +283,8 @@ class TestBranchParsing(EndToEndTestCase):
                 True,
                 False,
                 1671490333,
-                None
+                None,
+                git_mixins.branches.AheadBehind(ahead=0, behind=0)
             )
         ])
 
@@ -293,6 +306,7 @@ class TestBranchParsing(EndToEndTestCase):
                 1671490333,
                 git_mixins.branches.Upstream(
                     ".", "master", "master", ""
-                )
+                ),
+                git_mixins.branches.AheadBehind(ahead=0, behind=0)
             )
         ])

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -506,7 +506,8 @@ class TestRecentCommitsFormat(DeferrableTestCase):
                 0,
                 git_mixins.branches.Upstream(
                     "origin", "master", "origin/master", ""
-                )
+                ),
+                git_mixins.branches.AheadBehind(ahead=0, behind=0)
             )
         ]
         actual = list(active_branch.format_and_limit(lines, 5, "origin/master", branches))


### PR DESCRIPTION
To make the list of branches shorter and sane filter fully merged branches.  T.i. only present branches that would have an effect when merging them.