### PR TITLE
Do not reset cursor if assume_complete_redraw

### DIFF
--- a/core/commands/log_graph_smart_copy.py
+++ b/core/commands/log_graph_smart_copy.py
@@ -90,7 +90,7 @@ def read_commit_hash(view, line_span):
 
 def read_commit_decoration(view, line_span):
     # type: (sublime.View, sublime.Region) -> Iterator[TextRange]
-    for r in find_by_selector(view, "constant.other.git.branch.git-savvy"):
+    for r in find_by_selector(view, "constant.other.git.branch, entity.name.tag.branch-name"):
         if r.a > line_span.b:
             break
         if line_span.contains(r):


### PR DESCRIPTION
Teach the smart copy helper to copy special branches and tags

The selector for the branches ("constant.other.git.branch.git-savvy")
was too restrictive and did not catch special branch names like "main",
"dev", and so on.  This is a regression from b01ccb0b (Mark some special
branches in the graph view), released with 2.41.0 (Jun 2023).

Add the selector for tag names. It is not clear why that was missing,
so this looks like a bug as well.
