### PR TITLE
feature: inline diff select commit/branch to diff

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -743,6 +743,15 @@
             { "key": "selector", "operand": "git-savvy.make-commit meta.dropped.git.commit" }
         ]
     },
+    {
+        "keys": ["s"],
+        "command": "gs_commit_view_open_transient_view",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.commit_view", "operator": "equal", "operand": true },
+            { "key": "selector", "operand": "git-savvy.make-commit meta.dropped.git.commit" }
+        ]
+    },
 
 
     ///////////////

--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -24,6 +24,7 @@ __all__ = (
     "gs_commit_view_do_commit",
     "gs_commit_view_sign",
     "gs_commit_view_close",
+    "gs_commit_view_open_transient_view",
     "gs_commit_log_helper",
     "GsPrepareCommitFocusEventListener",
     "GsPedanticEnforceEventListener",
@@ -615,6 +616,23 @@ class gs_commit_view_close(TextCommand, GitCommand):
 
         else:
             self.view.close()
+
+
+class gs_commit_view_open_transient_view(WindowCommand):
+    def run(self):
+        window = sublime.active_window()
+        view = window.active_view()
+        text = view.substr(sublime.Region(0, view.size()))
+        text = text.replace(COMMIT_HELP_TEXT, "## To make a commit,\n")
+        text = text.replace(HELP_WHEN_PATCH_IS_VISIBLE, "")
+        text = text.replace(HELP_WHEN_UNSTAGING_IS_POSSIBLE, "")
+        text = text.replace(HELP_WHEN_DISCARDING_IS_POSSIBLE, "")
+        text = text.replace('diff --git', '\ndiff --git')
+
+        window.run_command('set_layout', { "cols": [0.0, 0.5, 1.0], "rows": [0.0, 1.0], "cells": [[0, 0, 1, 1], [1, 0, 2, 1]] })
+        window.run_command('focus_group', { "group": 1 })
+        view_transient = window.new_file(sublime.NewFileFlags.TRANSIENT, "Packages/GitSavvy/syntax/make_commit.sublime-syntax")
+        view_transient.run_command("append", {"characters": text})
 
 
 class gs_commit_log_helper(TextCommand, LogHelperMixin):

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -1217,7 +1217,7 @@ class gs_inline_diff_undo(TextCommand, GitCommand):
             "sync": True
         })
 
-class SelectInlineDiffCommitCommand(WindowCommand):
+class SelectInlineDiffCommitCommand(WindowCommand, GitCommand):
     def _on_commits(self):
         commit_text_list = self.git('log', '--format="%h %s"', '-n', str(self._last_n_commits)).strip().splitlines()
         if not commit_text_list:
@@ -1237,7 +1237,7 @@ class SelectInlineDiffCommitCommand(WindowCommand):
         self._on_done(commit_id)
 
     def _on_branches(self):
-        branches_text_list = self.git("branches").strip().splitlines()
+        branches_text_list = self.git("branch").strip().splitlines()
         if not branches_text_list:
             return self._on_cancel()
         self._branch_list = []
@@ -1258,8 +1258,9 @@ class SelectInlineDiffCommitCommand(WindowCommand):
     def _on_done(self, commit_id):
         if not commit_id:
             return self._on_cancel()
-        settings = self.view.settings()
-        base_commit = settings.get("git_savvy.inline_diff_view.base_commit")
+        view = self.window.active_view()
+        settings = view.settings()
+        base_commit = self.git("rev-parse", "--short", "HEAD").strip().splitlines()[0]
         self.window.run_command("gs_inline_diff", {
             "cached": self._cached,
             "base_commit": base_commit,


### PR DESCRIPTION
Inline diff currently compares the file's current state vs the last commit, then you can cycle through previous states using n/p.
My usecase is usually current state vs last commit or completely different branch/commit so I've come up with a workaround.

![image](https://github.com/timbrel/GitSavvy/assets/28522820/90172e85-1835-43de-8542-0b2a5234404c)

Manual commit id entry
![image](https://github.com/timbrel/GitSavvy/assets/28522820/a58c0302-69c4-4d79-8c9e-d6ef6e35db02)

Branches
fetches the branch list then it will compare against the lastest commit in that branch
![image](https://github.com/timbrel/GitSavvy/assets/28522820/2ac6e400-e025-47af-8921-fba2f9eecb47)

Commits
fetches the last N commits (default is 20) along with the commit message
![image](https://github.com/timbrel/GitSavvy/assets/28522820/1d81628b-e081-46c8-9ef1-649d7ce0729c)



Theres probably a better way of integrating the idea with the graph view, but this was good enough for me to whip up quickly. Thought id share incase it can be adapted and be a useful idea/addition