### PR TITLE
For addition only hunks assume the hunk is selected

### DIFF
--- a/core/commands/line_history.py
+++ b/core/commands/line_history.py
@@ -144,10 +144,16 @@ class gs_line_history(TextCommand, GitCommand):
         )
 
         if first_sel.empty():
-            # Assume the changed lines are selected which gives slightly
-            # better results than selecting the whole hunk.
             changed_lines = [line for line in hunk.content().lines() if not line.is_context()]
-            first_sel = sublime.Region(changed_lines[0].a, changed_lines[-1].b)
+            if all(line.is_to_line() for line in changed_lines):
+                # For addition only hunks, select the whole hunk as the added
+                # lines don't have any history in the repo by definition.
+                first_sel = hunk.content().region()
+
+            else:
+                # Assume the changed lines are selected which gives slightly
+                # better results than selecting the whole hunk.
+                first_sel = sublime.Region(changed_lines[0].a, changed_lines[-1].b)
 
         hunk_with_linenos = list(diff.recount_lines(hunk))
         rel_begin, _ = diff.row_offset_and_col_in_hunk(view, hunk, first_sel.begin())

--- a/core/commands/line_history.py
+++ b/core/commands/line_history.py
@@ -129,6 +129,10 @@ class gs_line_history(TextCommand, GitCommand):
         if not hunk:
             flash(view, "Not on a hunk.")
             return
+        if d.hunk_for_pt(first_sel.end()) != hunk:
+            flash(view, "Not across multiple hunks.")
+            return
+
         header = d.head_for_hunk(hunk)
         file_path = header.to_filename()
         if not file_path:
@@ -144,10 +148,6 @@ class gs_line_history(TextCommand, GitCommand):
             # better results than selecting the whole hunk.
             changed_lines = [line for line in hunk.content().lines() if not line.is_context()]
             first_sel = sublime.Region(changed_lines[0].a, changed_lines[-1].b)
-
-        if d.hunk_for_pt(first_sel.end()) != hunk:
-            flash(view, "Not across multiple hunks.")
-            return
 
         hunk_with_linenos = list(diff.recount_lines(hunk))
         rel_begin, _ = diff.row_offset_and_col_in_hunk(view, hunk, first_sel.begin())


### PR DESCRIPTION

When the user did not select anything in a diff, we construct a virtual
selection by ourself.  Typically it looks slightly better if we only
select the changed lines, t.i. we do not include the leading and
trailing context lines as the history gets too broad quickly.

In case of "addition only hunks" this is counterproductive though as by
definition the added lines don't have any history in the repo.

Therefore select the whole hunk with the context lines in that case.