### PR TITLE
Fix: diff file from graph menu did not select a file

### DIFF
--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -2904,7 +2904,7 @@ class gs_log_graph_action(WindowCommand, GitCommand):
             actions += [
                 (
                     "Diff file against workdir",
-                    partial(self.diff_commit, commit_hash)
+                    partial(self.diff_commit, commit_hash, file_path=file_path)
                 ),
             ]
         elif "HEAD" in info:


### PR DESCRIPTION
The "File History" offers to diff different versions (commits) of files. However, we did not pass the `file_path` down to the diff, so it always showed the complete diff between the revisions.  Fix that!