### PR TITLE
Set `overview: False` when reusing a graph

### DIFF
--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -164,6 +164,7 @@ class gs_graph(WindowCommand, GitCommand):
             )
             if other_id in [this_id] + standard_graph_views:
                 settings = view.settings()
+                settings.set("git_savvy.log_graph_view.overview", False)
                 settings.set("git_savvy.log_graph_view.all_branches", all)
                 settings.set("git_savvy.log_graph_view.show_tags", show_tags)
                 settings.set("git_savvy.log_graph_view.branches", branches)


### PR DESCRIPTION
We have two options here, (1) to *not* use graph views which are in overview or (2) to switch them out of overview mode.

I choose the latter as the overview mode is from the intent an intermediate state.