### PR TITLE
Set `project_data` after cloning has finished

### DIFF
--- a/core/commands/init.py
+++ b/core/commands/init.py
@@ -200,9 +200,6 @@ class gs_clone(WindowCommand, GitCommand):
             # HACK: `git()` uses `self.window`, we can't pass anything down
             self.window = window
 
-        window.set_project_data({
-            "folders": [dict(follow_symlinks=True, path=self.target_dir)]
-        })
         window.status_message("Start cloning {}".format(self.git_url))
         self.git(
             "clone",
@@ -213,6 +210,10 @@ class gs_clone(WindowCommand, GitCommand):
             working_dir='.',
             show_panel=True
         )
+        # Set this late to ensure `target_dir` actually exists
+        window.set_project_data({
+            "folders": [dict(follow_symlinks=True, path=self.target_dir)]
+        })
         window.status_message("Cloned repo successfully.")
         if not window.is_sidebar_visible():
             self.window.run_command("toggle_side_bar")


### PR DESCRIPTION
We set this directly after creating the window.  But with a window Sublime also creates a first view and this in turn triggers e.g. `on_activated` et.al. ... and so on ... at the end SublimeLinter may kick in and tell you that `target_dir` does not exists and can't be used as a working dir...

Just do it later to avoid these cascades.