### PR TITLE
Tune gs_diff_open_file_at_hunk

### DIFF
--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -942,6 +942,7 @@ def real_linecol_in_hunk(hunk, row_offset, col):
     # type: (Hunk, int, ColNo) -> LineCol
     """Translate relative to absolute line, col pair"""
     hunk_lines = list(recount_lines_for_jump_to_file(hunk))
+    row_offset = min(row_offset, len(hunk_lines))
 
     # If the user is on the header line ('@@ ..') pretend to be on the
     # first visible line with some content instead.

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -881,6 +881,8 @@ class gs_diff_open_file_at_hunk(TextCommand, GitCommand):
                 "position": Position(line - 1, col - 1, None),
             })
         else:
+            if self.view.settings().get("git_savvy.diff_view.in_cached_mode"):
+                line = self.find_matching_lineno("HEAD", None, line=line, file_path=full_path)
             window.open_file(
                 "{file}:{line}:{col}".format(file=full_path, line=line, col=col),
                 sublime.ENCODED_POSITION

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -836,9 +836,16 @@ class gs_diff_open_file_at_hunk(TextCommand, GitCommand):
                     seen.add(item.filename)
                     yield item
 
-        diff = SplittedDiff.from_view(self.view)
+        diff_regions = self.view.find_by_selector("git-savvy.commit, git-savvy.diff")
+        if not diff_regions:
+            flash(self.view, "Could not extract a diff.")
+            return
+
         jump_positions = list(first_per_file(filter_(
             jump_position_to_file(self.view, diff, s.begin())
+            for region in diff_regions
+            if (content := self.view.substr(region))
+            if (diff := SplittedDiff.from_string(content, region.a))
             for s in self.view.sel()
         )))
         if not jump_positions:

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -829,7 +829,7 @@ class gs_diff_open_file_at_hunk(TextCommand, GitCommand):
         # type: (sublime.Edit) -> None
 
         def first_per_file(items):
-            # type: (Iterator[JumpTo]) -> Iterator[JumpTo]
+            # type: (Iterable[JumpTo]) -> Iterator[JumpTo]
             seen = set()  # type: Set[str]
             for item in items:
                 if item.filename not in seen:

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -837,15 +837,18 @@ class gs_diff_open_file_at_hunk(TextCommand, GitCommand):
                     yield item
 
         diff_regions = self.view.find_by_selector("git-savvy.commit, git-savvy.diff")
-        if not diff_regions:
+        diffs = [
+            SplittedDiff.from_string(content, region.a)
+            for region in diff_regions
+            if (content := self.view.substr(region))
+        ]
+        if not diffs:
             flash(self.view, "Could not extract a diff.")
             return
 
         jump_positions = list(first_per_file(filter_(
             jump_position_to_file(self.view, diff, s.begin())
-            for region in diff_regions
-            if (content := self.view.substr(region))
-            if (diff := SplittedDiff.from_string(content, region.a))
+            for diff in diffs
             for s in self.view.sel()
         )))
         if not jump_positions:

--- a/core/parse_diff.py
+++ b/core/parse_diff.py
@@ -67,6 +67,14 @@ class SplittedDiff(NamedTuple):
         else:
             return None
 
+    def first_hunk_after_pt(self, pt):
+        # type: (int) -> Optional[Hunk]
+        for hunk in self.hunks:
+            if hunk.a > pt:
+                return hunk
+        else:
+            return None
+
     def head_for_pt(self, pt):
         # type: (int) -> Optional[FileHeader]
         for header in reversed(self.headers):

--- a/tests/test_diff_view.py
+++ b/tests/test_diff_view.py
@@ -186,6 +186,7 @@ diff --git a/foxx b/boxx
 """
         view = self.window.new_file()
         self.addCleanup(view.close)
+        view.set_syntax_file("Packages/GitSavvy/syntax/diff_view.sublime-syntax")
         view.run_command('append', {'characters': VIEW_CONTENT})
         view.set_scratch(True)
 
@@ -218,8 +219,9 @@ diff --git a/fooz b/barz
 """.format(b_line=B_LINE)
         CURSOR = 79
         view = self.window.new_file()
-        view.settings().set("translate_tabs_to_spaces", False)
         self.addCleanup(view.close)
+        view.settings().set("translate_tabs_to_spaces", False)
+        view.set_syntax_file("Packages/GitSavvy/syntax/diff_view.sublime-syntax")
         view.run_command('append', {'characters': VIEW_CONTENT})
         view.set_scratch(True)
 


### PR DESCRIPTION
* Make `gs_diff_open_file_at_hunk` safe when used in the commit/patch views
* Use the first hunk if the cursor is not in a hunk but e.g. in the header section
* Implement line matching when `in_cached_mode`