### PR TITLE
Factor `run_new_daemon_thread`

### DIFF
--- a/core/commands/custom.py
+++ b/core/commands/custom.py
@@ -6,7 +6,7 @@ from ..runtime import enqueue_on_worker
 from ..ui_mixins.input_panel import show_single_line_input_panel
 from ..view import replace_view_content
 from ...common import util
-from GitSavvy.core.runtime import run_on_new_thread
+from GitSavvy.core.runtime import run_new_daemon_thread
 
 
 __all__ = (
@@ -75,6 +75,6 @@ class gs_custom(WindowCommand, GitCommand):
             util.view.refresh_gitsavvy_interfaces(self.window)
 
         if run_in_thread:
-            run_on_new_thread(program, __daemon=True)
+            run_new_daemon_thread(program)
         else:
             enqueue_on_worker(program)

--- a/core/runtime.py
+++ b/core/runtime.py
@@ -121,9 +121,14 @@ def _enqueue_on_worker(fn):
     sublime.set_timeout_async(fn_)
 
 
-def run_on_new_thread(fn, *args, __daemon=None, **kwargs):
-    # type: (Callable[P, T], P.args, Optional[bool], P.kwargs) -> None
-    threading.Thread(target=_set_timout(fn), args=args, kwargs=kwargs, daemon=__daemon).start()
+def run_on_new_thread(fn, *args, **kwargs):
+    # type: (Callable[P, T], P.args, P.kwargs) -> None
+    threading.Thread(target=_set_timout(fn), args=args, kwargs=kwargs).start()
+
+
+def run_new_daemon_thread(fn, *args, **kwargs):
+    # type: (Callable[P, T], P.args, P.kwargs) -> None
+    threading.Thread(target=_set_timout(fn), args=args, kwargs=kwargs, daemon=True).start()
 
 
 def _set_timout(fn):


### PR DESCRIPTION
The special `__daemon` argument of `run_on_new_thread` broke its type, or mypy's understanding of it.

Fix that by providing two functions.  This simplifies the type and actually also looks nicer as the special, hidden keyword argument.