### PR TITLE
Fine tune syntax recognition of commit hashes in commit messages

### DIFF
--- a/syntax/make_commit.sublime-syntax
+++ b/syntax/make_commit.sublime-syntax
@@ -23,7 +23,11 @@ contexts:
       comment: issue
       scope: constant.other.issue-ref.git-savvy.make-commit meta.git-savvy.issue-reference
 
-    - match: (?:\W|\w\@)(\h{7,})\b
+    - match: '(?:[\s\[\(@])(\h{7,})\b'
+      comment: sha reference
+      captures:
+        1: constant.other.commit-sha.git-savvy.make-commit
+    - match: '(?:")(\h{7,})(?!\B|\")'
       comment: sha reference
       captures:
         1: constant.other.commit-sha.git-savvy.make-commit

--- a/syntax/test/syntax_test_make_commit.txt
+++ b/syntax/test/syntax_test_make_commit.txt
@@ -32,9 +32,25 @@ This is a ref to a commit (89d6780).
 #                          ^^^^^^^ constant.other.commit-sha.git-savvy.make-commit
 #                         ^ - constant.other.commit-sha.git-savvy.make-commit
 #                                 ^ - constant.other.commit-sha.git-savvy.make-commit
+This is a ref to a commit [89d6780].
+#                          ^^^^^^^ constant.other.commit-sha.git-savvy.make-commit
+#                         ^ - constant.other.commit-sha.git-savvy.make-commit
+#                                 ^ - constant.other.commit-sha.git-savvy.make-commit
+This is a ref to a commit "89d6780 The message".
+#                          ^^^^^^^ constant.other.commit-sha.git-savvy.make-commit
+#                         ^ - constant.other.commit-sha.git-savvy.make-commit
+#                                 ^ - constant.other.commit-sha.git-savvy.make-commit
+This is a ref to a commit "89d6780".
+#                          ^^^^^^^ - constant.other.commit-sha.git-savvy.make-commit
+#                         ^ - constant.other.commit-sha.git-savvy.make-commit
+#                                 ^ - constant.other.commit-sha.git-savvy.make-commit
 This is a ref to a commit fue@89d6780
 #                             ^^^^^^^ constant.other.commit-sha.git-savvy.make-commit
 #                         ^^^^ - constant.other.commit-sha.git-savvy.make-commit
+This is not a ref to a commit /89d6780/
+#                             ^^^^^^^^^ - constant.other.commit-sha.git-savvy.make-commit
+This is not a ref to a commit xu89d6780
+#                             ^^^^^^^^^ - constant.other.commit-sha.git-savvy.make-commit
 
 
 ## To make a commit, type your commit message and press SUPER-ENTER. To cancel


### PR DESCRIPTION
There is no good solution.  For now *restrict* what we consider to be a commit hash.

Our starting point was the simple `\b<hash>\b`. Maybe I lean towards less colors when in doubt instead of more colors; here we highlighted a part of an url which I disliked.