### PR TITLE
Render root nodes differently

### DIFF
--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -83,13 +83,12 @@ T = TypeVar('T')
 
 QUICK_PANEL_SUPPORTS_WANT_EVENT = int(sublime.version()) >= 4096
 COMMIT_NODE_CHAR = "●"
-COMMIT_NODE_CHAR_OPTIONS = "●*"
 GRAPH_CHAR_OPTIONS = r" /_\|\-\\."
 COMMIT_LINE = re.compile(
     r"^[{graph_chars}]*(?P<dot>[{node_chars}])[{graph_chars}]* "
     r"(?P<commit_hash>[a-f0-9]{{5,40}}) +"
     r"(\((?P<decoration>.+?)\))?"
-    .format(graph_chars=GRAPH_CHAR_OPTIONS, node_chars=COMMIT_NODE_CHAR_OPTIONS)
+    .format(graph_chars=GRAPH_CHAR_OPTIONS, node_chars=colorizer.COMMIT_NODE_CHARS)
 )
 
 DOT_SCOPE = 'git_savvy.graph.dot'
@@ -1525,7 +1524,7 @@ def dots_after_dot(dot, forward=True):
     # type: (colorizer.Char, bool) -> Iterator[colorizer.Char]
     """Return exact next dots (commits) after `dot`."""
     fn = colorizer.follow_path_down if forward else colorizer.follow_path_up
-    return filter(lambda ch: ch.char() in COMMIT_NODE_CHAR_OPTIONS, fn(dot))
+    return filter(lambda ch: ch.char() in colorizer.COMMIT_NODE_CHARS, fn(dot))
 
 
 class gs_log_graph_navigate_to_head(TextCommand):
@@ -2143,7 +2142,7 @@ def extract_comit_hash_span(view, line_span):
 
 
 FIND_COMMIT_HASH = "^[{graph_chars}]*[{node_chars}][{graph_chars}]* ".format(
-    graph_chars=GRAPH_CHAR_OPTIONS, node_chars=COMMIT_NODE_CHAR_OPTIONS
+    graph_chars=GRAPH_CHAR_OPTIONS, node_chars=colorizer.COMMIT_NODE_CHARS
 )
 
 
@@ -2233,7 +2232,7 @@ def line_from_pt(view, pt):
 
 def dot_from_line(view, line):
     # type: (sublime.View, TextRange) -> Optional[colorizer.Char]
-    for ch in COMMIT_NODE_CHAR_OPTIONS:
+    for ch in colorizer.COMMIT_NODE_CHARS:
         idx = line.text.find(ch)
         if idx > -1:
             return colorizer.Char(view, line.region().begin() + idx)
@@ -2312,7 +2311,7 @@ def __paint(view, paths_down, paths_up):
         lambda path: len(path) > 1,  # type: ignore[arg-type]  # https://github.com/python/mypy/issues/9176
         paths_up
     ))
-    path_up, dot_up = partition(lambda ch: ch.char() in COMMIT_NODE_CHAR_OPTIONS, chars_up)
+    path_up, dot_up = partition(lambda ch: ch.char() in colorizer.COMMIT_NODE_CHARS, chars_up)
     view.add_regions('gs_log_graph.path_below', list(map(to_region, path_down)), scope=PATH_SCOPE)
     view.add_regions('gs_log_graph.path_above', list(map(to_region, path_up)), scope=PATH_ABOVE_SCOPE)
     view.add_regions('gs_log_graph.dot.above', list(map(to_region, dot_up)), scope=DOT_ABOVE_SCOPE)

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -1525,7 +1525,7 @@ def dots_after_dot(dot, forward=True):
     # type: (colorizer.Char, bool) -> Iterator[colorizer.Char]
     """Return exact next dots (commits) after `dot`."""
     fn = colorizer.follow_path_down if forward else colorizer.follow_path_up
-    return filter(lambda ch: ch == COMMIT_NODE_CHAR, fn(dot))
+    return filter(lambda ch: ch.char() in COMMIT_NODE_CHAR_OPTIONS, fn(dot))
 
 
 class gs_log_graph_navigate_to_head(TextCommand):
@@ -2233,9 +2233,10 @@ def line_from_pt(view, pt):
 
 def dot_from_line(view, line):
     # type: (sublime.View, TextRange) -> Optional[colorizer.Char]
-    idx = line.text.find(COMMIT_NODE_CHAR)
-    if idx > -1:
-        return colorizer.Char(view, line.region().begin() + idx)
+    for ch in COMMIT_NODE_CHAR_OPTIONS:
+        idx = line.text.find(ch)
+        if idx > -1:
+            return colorizer.Char(view, line.region().begin() + idx)
     return None
 
 
@@ -2311,7 +2312,7 @@ def __paint(view, paths_down, paths_up):
         lambda path: len(path) > 1,  # type: ignore[arg-type]  # https://github.com/python/mypy/issues/9176
         paths_up
     ))
-    path_up, dot_up = partition(lambda ch: ch == COMMIT_NODE_CHAR, chars_up)
+    path_up, dot_up = partition(lambda ch: ch.char() in COMMIT_NODE_CHAR_OPTIONS, chars_up)
     view.add_regions('gs_log_graph.path_below', list(map(to_region, path_down)), scope=PATH_SCOPE)
     view.add_regions('gs_log_graph.path_above', list(map(to_region, path_up)), scope=PATH_ABOVE_SCOPE)
     view.add_regions('gs_log_graph.dot.above', list(map(to_region, dot_up)), scope=DOT_ABOVE_SCOPE)

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -765,7 +765,7 @@ class gs_log_graph_refresh(GsTextCommand):
         def split_up_line(line):
             # type: (str) -> Union[str, GraphLine]
             try:
-                return GraphLine(*line.split("%00"))
+                return GraphLine(*line.rstrip().split("%00"))
             except TypeError:
                 return line
 
@@ -957,7 +957,7 @@ class gs_log_graph_refresh(GsTextCommand):
                 left = f"{hash} ({decoration})"
             else:
                 left = f"{hash}"
-            return f"{left} {trunc(subject, max(2, LEFT_COLUMN_WIDTH - len(left)))} \u200b {info}"
+            return f"{left} {trunc(subject, max(2, LEFT_COLUMN_WIDTH - len(left)))} \u200b {info}\n"
 
         def filter_consecutive_continuation_lines(lines):
             # type: (Iterator[str]) -> Iterator[str]

--- a/core/commands/log_graph_colorizer.py
+++ b/core/commands/log_graph_colorizer.py
@@ -25,7 +25,7 @@ NextFn = Callable[['Char'], Iterator['Char']]
 Direction = Literal["down", "up"]
 
 
-COMMIT_NODE_CHAR = '●'
+COMMIT_NODE_CHARS = '●'
 
 
 class Char:
@@ -214,7 +214,7 @@ def __follow_path(dot, direction):
     while stack:
         c = stack.popleft()
         yield c
-        if c.char() not in COMMIT_NODE_CHAR:
+        if c.char() not in COMMIT_NODE_CHARS:
             stack.extendleft(reversed(list(follow_char(c, direction))))
 
 
@@ -231,20 +231,20 @@ def contains(next_char, test):
         yield next_char
 
 
-@follow(COMMIT_NODE_CHAR, "down")
+@follow(COMMIT_NODE_CHARS, "down")
 def after_dot(char):
     # type: (Char) -> Iterator[Char]
     yield from contains(char.sw, '/')
-    yield from contains(char.s, '|' + COMMIT_NODE_CHAR)
+    yield from contains(char.s, '|' + COMMIT_NODE_CHARS)
     yield from contains(char.se, '\\')
     yield from contains(char.e, '-')
 
 
-@follow(COMMIT_NODE_CHAR, "up")
+@follow(COMMIT_NODE_CHARS, "up")
 def before_dot(char):
     # type: (Char) -> Iterator[Char]
     yield from contains(char.w, '-')
-    yield from contains(char.n, '|' + COMMIT_NODE_CHAR)
+    yield from contains(char.n, '|' + COMMIT_NODE_CHARS)
     yield from contains(char.n.e, '/')
     yield from contains(char.n.w, '\\')
 
@@ -252,7 +252,7 @@ def before_dot(char):
 @follow('|', "down")
 def after_vertical_bar(char):
     # type: (Char) -> Iterator[Char]
-    yield from contains(char.s, '|/' + COMMIT_NODE_CHAR)
+    yield from contains(char.s, '|/' + COMMIT_NODE_CHARS)
 
     # Check crossing line before following '/'
     # | |/ / /
@@ -269,7 +269,7 @@ def after_vertical_bar(char):
 @follow('|', "up")
 def before_vertical_bar(char):
     # type: (Char) -> Iterator[Char]
-    yield from contains(char.n, '|' + COMMIT_NODE_CHAR)
+    yield from contains(char.n, '|' + COMMIT_NODE_CHARS)
     if char.w != '/' and char.n.w != '_':
         yield from contains(char.n.e, '/')
     yield from contains(char.n.w, '\\')
@@ -279,7 +279,7 @@ def before_vertical_bar(char):
 def after_backslash(char):
     # type: (Char) -> Iterator[Char]
     yield from contains(char.s, '/')
-    yield from contains(char.se, '\\|' + COMMIT_NODE_CHAR)
+    yield from contains(char.se, '\\|' + COMMIT_NODE_CHARS)
 
 
 @follow('\\', "up")
@@ -288,7 +288,7 @@ def before_backslash(char):
     # Don't forget multi merge octopoi
     # *---.
     # | \  \
-    yield from contains(char.n.w, '\\.|-' + COMMIT_NODE_CHAR)
+    yield from contains(char.n.w, '\\.|-' + COMMIT_NODE_CHARS)
 
 
 @follow('/', "down")
@@ -309,7 +309,7 @@ def after_forwardslash(char):
         #   ^
         yield from contains(char.w.sw, '/')
     else:
-        yield from contains(char.sw, '/|' + COMMIT_NODE_CHAR)
+        yield from contains(char.sw, '/|' + COMMIT_NODE_CHARS)
 
 
 @follow('/', "up")
@@ -318,7 +318,7 @@ def before_forwardslash(char):
     yield from contains(char.n.e.e, '_')
     yield from contains(char.n.e.e, '/')
     if char.n.e.e != '_' and char.n.e.e != '/':
-        yield from contains(char.n.e, '/|' + COMMIT_NODE_CHAR)
+        yield from contains(char.n.e, '/|' + COMMIT_NODE_CHARS)
     yield from contains(char.n, '|\\')
 
 
@@ -364,7 +364,7 @@ def after_horizontal_bar(char):
 
 @follow('-', "up")
 def before_horizontal_bar(char):
-    yield from contains(char.w, '-' + COMMIT_NODE_CHAR)
+    yield from contains(char.w, '-' + COMMIT_NODE_CHARS)
 
 
 @follow('.', "down")

--- a/core/commands/log_graph_colorizer.py
+++ b/core/commands/log_graph_colorizer.py
@@ -162,14 +162,15 @@ PATH_CACHE = Cache()  # type: MutableMapping[Tuple[Char, Direction], List[Char]]
 # code is straight forward, and you basically have to look at some
 # graphs (turn block cursor on in Sublime!) and peek around.
 
-def follow(ch, direction):
+def follow(chars, direction):
     # type: (str, Direction) -> Callable[[NextFn], NextFn]
     def decorator(fn):
         # type: (NextFn) -> NextFn
-        registry = down_handlers if direction == "down" else up_handlers
-        if ch in registry:
-            raise RuntimeError('{} already has a handler registered'.format(ch))
-        registry[ch] = fn
+        for ch in chars:
+            registry = down_handlers if direction == "down" else up_handlers
+            if ch in registry:
+                raise RuntimeError('{} already has a handler registered'.format(ch))
+            registry[ch] = fn
         return fn
 
     return decorator
@@ -213,7 +214,7 @@ def __follow_path(dot, direction):
     while stack:
         c = stack.popleft()
         yield c
-        if c != COMMIT_NODE_CHAR:
+        if c.char() not in COMMIT_NODE_CHAR:
             stack.extendleft(reversed(list(follow_char(c, direction))))
 
 

--- a/core/commands/log_graph_colorizer.py
+++ b/core/commands/log_graph_colorizer.py
@@ -25,7 +25,7 @@ NextFn = Callable[['Char'], Iterator['Char']]
 Direction = Literal["down", "up"]
 
 
-COMMIT_NODE_CHARS = '●'
+COMMIT_NODE_CHARS = "●*⌂"
 
 
 class Char:

--- a/syntax/graph.sublime-syntax
+++ b/syntax/graph.sublime-syntax
@@ -8,7 +8,7 @@ scope: git-savvy.graph
 variables:
   sha: '[0-9a-f]{6,40}'
   ascii_art: (?:[| \\/_.])+
-  dot: '[*●]'
+  dot: '[●*⌂]'
 
 contexts:
   main:

--- a/tests/fixtures/log_graph_1.txt
+++ b/tests/fixtures/log_graph_1.txt
@@ -1,14 +1,14 @@
-* fec0aca|HEAD -> improve-graph-view|Respect any other way a user can hide or show a panel|
-* f461ea1||Cache `git show ...` command as it's immutable|
-* 1c6ff56||Fix: Only hide our own panel.|
-* 3543eee||Ensure to restore the cursors after drawing|
-* c658951||Build actual git command on refresh|
-* 5c6f063||Move `GsLogGraphCommand` and add comment|
-* 5c15c8e||Move `GsLogActionCommand` to bottom and fix comment|
-* 00e7e61||Make a comment a bit clearer|
-* 667cc20||Make the listener a `ViewEventListener`|
-* 4bd960c||Update info panel `on_selection_modified`|
-* c08cd48||Navigate *after* first draw|
-* 4496f75||Handle one-time side-effects after view creation|
-* d0d4321||Make GsLogGraphRefreshCommand an async command|
-* 57b00b1|origin/dev, dev|Merge pull request #1033 from kaste/optimize-status-interface|
+* fec0aca|HEAD -> improve-graph-view|Respect any other way a user can hide or show a panel||parent
+* f461ea1||Cache `git show ...` command as it's immutable||parent
+* 1c6ff56||Fix: Only hide our own panel.||parent
+* 3543eee||Ensure to restore the cursors after drawing||parent
+* c658951||Build actual git command on refresh||parent
+* 5c6f063||Move `GsLogGraphCommand` and add comment||parent
+* 5c15c8e||Move `GsLogActionCommand` to bottom and fix comment||parent
+* 00e7e61||Make a comment a bit clearer||parent
+* 667cc20||Make the listener a `ViewEventListener`||parent
+* 4bd960c||Update info panel `on_selection_modified`||parent
+* c08cd48||Navigate *after* first draw||parent
+* 4496f75||Handle one-time side-effects after view creation||parent
+* d0d4321||Make GsLogGraphRefreshCommand an async command||parent
+* 57b00b1|origin/dev, dev|Merge pull request #1033 from kaste/optimize-status-interface||


### PR DESCRIPTION
In the graph root nodes can be very hard to see (if you have multiple
of them) when they appear on the same indentation as the surrounding
"normal" commit nodes.

Let's give them a different char, `"⌂"` for now.  The exact style
does maybe not even matter.