### PR TITLE
Set `NO_UNDO` for basically all regions as an optimization

### DIFF
--- a/common/ui.py
+++ b/common/ui.py
@@ -473,7 +473,11 @@ class gs_new_content_and_regions(TextCommand):
                     replace_view_content(self.view, txt, region)
 
         for key, region_range in regions.items():
-            self.view.add_regions(region_key(key), [region_from_tuple(region_range)])
+            self.view.add_regions(
+                region_key(key),
+                [region_from_tuple(region_range)],
+                flags=sublime.RegionFlags.NO_UNDO
+            )
 
         for key in self.current_region_names - regions.keys():
             self.view.erase_regions(region_key(key))

--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -395,11 +395,17 @@ class GsPedanticEnforceEventListener(EventListener, SettingsMixin):
 
         warning, illegal = self.find_too_long_lines()
         self.view.add_regions(
-            'make_commit_warning', warning,
-            scope='invalid.deprecated.line-too-long.git-commit', flags=sublime.DRAW_NO_FILL)
+            'make_commit_warning',
+            warning,
+            scope='invalid.deprecated.line-too-long.git-commit',
+            flags=sublime.RegionFlags.DRAW_NO_FILL | sublime.RegionFlags.NO_UNDO
+        )
         self.view.add_regions(
-            'make_commit_illegal', illegal,
-            scope='invalid.deprecated.line-too-long.git-commit')
+            'make_commit_illegal',
+            illegal,
+            scope='invalid.deprecated.line-too-long.git-commit',
+            flags=sublime.RegionFlags.NO_UNDO
+        )
 
     def find_rulers(self):
         on_first_line = False

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -582,22 +582,26 @@ class gs_inline_diff_refresh(TextCommand, GitCommand):
         self.view.add_regions(
             "git-savvy-added-lines",
             add_regions,
-            scope="diff.inserted.git-savvy.inline-diff"
+            scope="diff.inserted.git-savvy.inline-diff",
+            flags=sublime.RegionFlags.NO_UNDO
         )
         self.view.add_regions(
             "git-savvy-removed-lines",
             remove_regions,
-            scope="diff.deleted.git-savvy.inline-diff"
+            scope="diff.deleted.git-savvy.inline-diff",
+            flags=sublime.RegionFlags.NO_UNDO
         )
         self.view.add_regions(
             "git-savvy-added-bold",
             add_bold_regions,
-            scope="diff.inserted.char.git-savvy.inline-diff"
+            scope="diff.inserted.char.git-savvy.inline-diff",
+            flags=sublime.RegionFlags.NO_UNDO
         )
         self.view.add_regions(
             "git-savvy-removed-bold",
             remove_bold_regions,
-            scope="diff.deleted.char.git-savvy.inline-diff"
+            scope="diff.deleted.char.git-savvy.inline-diff",
+            flags=sublime.RegionFlags.NO_UNDO
         )
 
 

--- a/core/commands/intra_line_colorizer.py
+++ b/core/commands/intra_line_colorizer.py
@@ -117,10 +117,16 @@ def compute_intra_line_diffs(view, diff):
 
 def _draw_intra_diff_regions(view, added_regions, removed_regions):
     view.add_regions(
-        "git-savvy-added-bold", added_regions, scope="diff.inserted.char.git-savvy.diff"
+        "git-savvy-added-bold",
+        added_regions,
+        scope="diff.inserted.char.git-savvy.diff",
+        flags=sublime.RegionFlags.NO_UNDO
     )
     view.add_regions(
-        "git-savvy-removed-bold", removed_regions, scope="diff.deleted.char.git-savvy.diff"
+        "git-savvy-removed-bold",
+        removed_regions,
+        scope="diff.deleted.char.git-savvy.diff",
+        flags=sublime.RegionFlags.NO_UNDO
     )
 
 

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -2413,7 +2413,12 @@ def _colorize_dots(vid, dots):
     view = sublime.View(vid)
     to_region = lambda ch: ch.region()  # type: Callable[[colorizer.Char], sublime.Region]
 
-    view.add_regions('gs_log_graph.dot', list(map(to_region, dots)), scope=DOT_SCOPE)
+    view.add_regions(
+        'gs_log_graph.dot',
+        list(map(to_region, dots)),
+        scope=DOT_SCOPE,
+        flags=sublime.RegionFlags.NO_UNDO
+    )
 
     ACTIVE_COMPUTATION[vid] = dots
     __colorize_dots(vid, dots)
@@ -2476,9 +2481,24 @@ def __paint(view, paths_down, paths_up):
         paths_up
     ))
     path_up, dot_up = partition(lambda ch: ch.char() in colorizer.COMMIT_NODE_CHARS, chars_up)
-    view.add_regions('gs_log_graph.path_below', list(map(to_region, path_down)), scope=PATH_SCOPE)
-    view.add_regions('gs_log_graph.path_above', list(map(to_region, path_up)), scope=PATH_ABOVE_SCOPE)
-    view.add_regions('gs_log_graph.dot.above', list(map(to_region, dot_up)), scope=DOT_ABOVE_SCOPE)
+    view.add_regions(
+        'gs_log_graph.path_below',
+        list(map(to_region, path_down)),
+        scope=PATH_SCOPE,
+        flags=sublime.RegionFlags.NO_UNDO
+    )
+    view.add_regions(
+        'gs_log_graph.path_above',
+        list(map(to_region, path_up)),
+        scope=PATH_ABOVE_SCOPE,
+        flags=sublime.RegionFlags.NO_UNDO
+    )
+    view.add_regions(
+        'gs_log_graph.dot.above',
+        list(map(to_region, dot_up)),
+        scope=DOT_ABOVE_SCOPE,
+        flags=sublime.RegionFlags.NO_UNDO
+    )
 
 
 def colorize_fixups(view):
@@ -2496,7 +2516,8 @@ def _colorize_fixups(vid, dots):
     view.add_regions(
         'gs_log_graph_follow_fixups',
         [dot.region() for dot in matching_dots],
-        scope=MATCHING_COMMIT_SCOPE
+        scope=MATCHING_COMMIT_SCOPE,
+        flags=sublime.RegionFlags.NO_UNDO
     )
 
 

--- a/core/commands/show_commit.py
+++ b/core/commands/show_commit.py
@@ -174,7 +174,13 @@ class gs_show_commit_refresh(TextCommand, GithubRemotesMixin, GitCommand):
                 '<a href="{}">Open on GitHub</a>'
                 .format(url)
             ]
-        self.view.add_regions(key, regions, annotations=annotations, annotation_color="#aaa0")
+        self.view.add_regions(
+            key,
+            regions,
+            annotations=annotations,
+            annotation_color="#aaa0",
+            flags=sublime.RegionFlags.NO_UNDO
+        )
 
 
 class gs_show_commit_open_on_github(TextCommand, GithubRemotesMixin, GitCommand):

--- a/core/utils.py
+++ b/core/utils.py
@@ -113,7 +113,7 @@ def flash(view, message):
 
 HIGHLIGHT_REGION_KEY = "GS.flashs.{}"
 DURATION = 0.4
-STYLE = {"scope": "git_savvy.graph.dot", "flags": 0}
+STYLE = {"scope": "git_savvy.graph.dot", "flags": sublime.RegionFlags.NO_UNDO}
 
 
 def flash_regions(view, regions, key="default"):


### PR DESCRIPTION
Whenever we mark something in a read-only view we can be sure that a practical "undo" is not in reach for the user.

When writing the commit message on the other hand we re-compute the regions in "on_selection_modified", making the undo-stack unnecessary.