### PR TITLE
Iterate the branches dashboard

### DIFF
--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -195,6 +195,11 @@
     "sort_by_recent_in_branch_dashboard": false,
 
     /*
+        Group branches by their distance to HEAD.  Requires git 2.41.0.
+    */
+    "group_by_distance_to_head_in_branch_dashboard": true,
+
+    /*
         Set this to `true` to display remotes in the branch dashboard by default.
      */
     "show_remotes_in_branch_dashboard": false,

--- a/core/git_mixins/branches.py
+++ b/core/git_mixins/branches.py
@@ -36,6 +36,8 @@ class Branch(NamedTuple):
     active: bool
     is_remote: bool
     committerdate: int
+    human_committerdate: str
+    relative_committerdate: str
     upstream: Optional[Upstream]
     distance_to_head: Optional[AheadBehind]
 
@@ -109,6 +111,8 @@ class BranchesMixin(mixin_base):
                             "%(upstream:remotename)",
                             "%(upstream:track,nobracket)",
                             "%(committerdate:unix)",
+                            "%(committerdate:human)",
+                            "%(committerdate:relative)",
                             "%(objectname)",
                             "%(contents:subject)",
                             "%(ahead-behind:HEAD)" if supports_ahead_behind else ""
@@ -189,7 +193,8 @@ class BranchesMixin(mixin_base):
     def _parse_branch_line(self, line):
         # type: (str) -> Branch
         (head, ref, upstream, upstream_remote, upstream_status,
-         committerdate, commit_hash, commit_msg, ahead_behind) = line.split("\x00")
+         committerdate, human_committerdate, relative_committerdate,
+         commit_hash, commit_msg, ahead_behind) = line.split("\x00")
 
         active = head == "*"
         is_remote = ref.startswith("refs/remotes/")
@@ -224,6 +229,8 @@ class BranchesMixin(mixin_base):
             active,
             is_remote,
             int(committerdate),
+            human_committerdate,
+            relative_committerdate,
             upstream=ups,
             distance_to_head=ahead_behind_
         )

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -256,9 +256,9 @@ class BranchInterface(ui.ReactiveInterface, GitCommand):
         paired_with_previous: Iterable[Tuple[Optional[Branch], Branch]] = \
             pairwise(chain([None], branches))  # type: ignore[list-item]
         return "\n".join(
-            "  {indicator} {hash:.7} {name_with_extras}{description}".format(
+            "  {indicator} {hash} {name_with_extras}{description}".format(
                 indicator="▸" if branch.active else " ",
-                hash=branch.commit_hash,
+                hash=self.get_short_hash(branch.commit_hash),
                 name_with_extras=" ".join(filter_((
                     branch.canonical_name[remote_name_length:],
                     ", ".join(filter_((

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -14,7 +14,7 @@ from ..git_command import GitCommand
 from ..ui_mixins.quick_panel import show_remote_panel, show_branch_panel
 from ..ui_mixins.input_panel import show_single_line_input_panel
 from GitSavvy.core.fns import chain, filter_, pairwise
-from GitSavvy.core.utils import flash
+from GitSavvy.core.utils import flash, is_younger_than
 from GitSavvy.core.runtime import enqueue_on_worker, on_new_thread, on_worker
 
 
@@ -200,17 +200,9 @@ class BranchInterface(ui.ReactiveInterface, GitCommand):
 
         has_distance_to_head_information = any(b.distance_to_head for b in local_branches)
         if has_distance_to_head_information and group_by_distance_to_head:
-            def younger_than(
-                timedelta: datetime.timedelta,
-                now: datetime.datetime,
-                timestamp: int
-            ) -> bool:
-                dt = datetime.datetime.utcfromtimestamp(timestamp)
-                return (now - dt) < timedelta
-
             roughly_nine_months = datetime.timedelta(days=9 * 30)
             now = datetime.datetime.utcnow()
-            is_fresh = partial(younger_than, roughly_nine_months, now)
+            is_fresh = partial(is_younger_than, roughly_nine_months, now)
 
             def sort_key(branch):
                 return (

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -238,22 +238,25 @@ class BranchInterface(ui.ReactiveInterface, GitCommand):
 
     def _render_branch_list(self, remote_name, branches, descriptions, human_dates=True):
         # type: (Optional[str], List[Branch], Dict[str, str], bool) -> str
-        remote_name_length = len(remote_name + "/") if remote_name else 0
 
-        def mangle_date(branch: Branch, previous: Optional[Branch]):
-            def get_date(branch):
-                if not human_dates:
-                    d = branch.relative_committerdate
-                    if d == "12 months ago":
-                        d = "1 year ago"
-                    return re.sub(r", \d+ months? ago", " ago", d)
+        def get_date(branch):
+            if human_dates:
                 return branch.human_committerdate
 
+            d = branch.relative_committerdate
+            if d == "12 months ago":
+                d = "1 year ago"
+            # Shorten relative dates with months e.g. "1 year, 1 month ago"
+            # to just "1 year ago".
+            return re.sub(r", \d+ months? ago", " ago", d)
+
+        def mangle_date(branch: Branch, previous: Optional[Branch]):
             date = get_date(branch)
             if human_dates and previous and get_date(previous) == date:
                 return ""
             return date
 
+        remote_name_length = len(remote_name + "/") if remote_name else 0
         paired_with_previous: Iterable[Tuple[Optional[Branch], Branch]] = \
             pairwise(chain([None], branches))  # type: ignore[list-item]
         return "\n".join(

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -246,7 +246,7 @@ class BranchInterface(ui.ReactiveInterface, GitCommand):
                     d = branch.relative_committerdate
                     if d == "12 months ago":
                         d = "1 year ago"
-                    return re.sub(r", \d+ months ago", " ago", d)
+                    return re.sub(r", \d+ months? ago", " ago", d)
                 return branch.human_committerdate
 
             date = get_date(branch)

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -226,22 +226,23 @@ class BranchInterface(ui.ReactiveInterface, GitCommand):
 
             local_branches = sorted(local_branches, key=sectionizer)
             return "\n{}\n".format(" " * 60).join(
-                self._render_branch_list(None, list(branches), descriptions, section_key)
+                self._render_branch_list(
+                    None, list(branches), descriptions, human_dates=section_key != (5, 0))
                 for section_key, branches in groupby(local_branches, sectionizer)
             )
 
         else:
             if sort_by_recent:
                 local_branches = sorted(local_branches, key=lambda branch: -branch.committerdate)
-            return self._render_branch_list(None, local_branches, descriptions, (1, 0))
+            return self._render_branch_list(None, local_branches, descriptions)
 
-    def _render_branch_list(self, remote_name, branches, descriptions, section_key):
-        # type: (Optional[str], List[Branch], Dict[str, str], Tuple) -> str
+    def _render_branch_list(self, remote_name, branches, descriptions, human_dates=True):
+        # type: (Optional[str], List[Branch], Dict[str, str], bool) -> str
         remote_name_length = len(remote_name + "/") if remote_name else 0
 
         def mangle_date(branch: Branch, previous: Optional[Branch]):
             def get_date(branch):
-                if section_key == (5, 0):
+                if not human_dates:
                     d = branch.relative_committerdate
                     if d == "12 months ago":
                         d = "1 year ago"
@@ -249,7 +250,7 @@ class BranchInterface(ui.ReactiveInterface, GitCommand):
                 return branch.human_committerdate
 
             date = get_date(branch)
-            if section_key != (5, 0) and previous and get_date(previous) == date:
+            if human_dates and previous and get_date(previous) == date:
                 return ""
             return date
 
@@ -315,7 +316,7 @@ class BranchInterface(ui.ReactiveInterface, GitCommand):
             def render(remote_name=remote_name, branches=branches) -> str:
                 return self.template_remote.format(
                     remote_name=remote_name,
-                    remote_branch_list=self._render_branch_list(remote_name, branches, {}, (1, 0))
+                    remote_branch_list=self._render_branch_list(remote_name, branches, {})
                 )
 
             render_fns.append(render)

--- a/core/store.py
+++ b/core/store.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
         last_reset_mode_used: Optional[str]
         short_hash_length: int
         skipped_files: List[str]
+        slow_repo: bool
         stashes: List[Stash]
         recent_commits: List[Commit]
         descriptions: Dict[str, str]

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,6 +1,7 @@
 from functools import lru_cache, partial, wraps
 from collections import OrderedDict
 from contextlib import contextmanager
+import datetime
 import html
 import inspect
 from itertools import count
@@ -72,6 +73,11 @@ class timer:
         cur_time = time.perf_counter()
         duration = (cur_time - self._start_time) * 1000
         return duration > ms
+
+
+def is_younger_than(timedelta: datetime.timedelta, now: datetime.datetime, timestamp: int) -> bool:
+    dt = datetime.datetime.utcfromtimestamp(timestamp)
+    return (now - dt) < timedelta
 
 
 @contextmanager

--- a/syntax/branch.sublime-syntax
+++ b/syntax/branch.sublime-syntax
@@ -42,10 +42,12 @@ contexts:
           pop: true
 
   row:
-    - match: '^  (▸)?\s+([0-9a-f]{7,40}) (\S+)\s?(.*)$'
+    - match: '^  (▸)?\s+([0-9a-f]{7,40}) ([^\s]+)([^(-]+?)?(\(.+?\))?( \- .+)?$'
       captures:
         0: meta.git-savvy.branches.branch
         1: punctuation.symbol.active-branch.git-savvy
         2: constant.other.git-savvy.branches.branch.sha1
         3: meta.git-savvy.branches.branch.name gitsavvy.gotosymbol
-        4: comment.git-savvy.branches.branch.extra-info
+        4: comment.git-savvy.branches.branch.date
+        5: comment.git-savvy.branches.branch.tracking-info
+        6: comment.git-savvy.branches.branch.description keyword

--- a/syntax/branch.sublime-syntax
+++ b/syntax/branch.sublime-syntax
@@ -42,7 +42,7 @@ contexts:
           pop: true
 
   row:
-    - match: '^  (▸)?\s+([0-9a-f]{7,40}) ([^\s]+)([^(-]+?)?(\(.+?\))?( \- .+)?$'
+    - match: '^  (▸)?\s+([0-9a-f]{7,40}) ([^\s]+)([^(-]+?)?(\(.+?(?:, (gone))?\))?( \- .+)?$'
       captures:
         0: meta.git-savvy.branches.branch
         1: punctuation.symbol.active-branch.git-savvy
@@ -50,4 +50,5 @@ contexts:
         3: meta.git-savvy.branches.branch.name gitsavvy.gotosymbol
         4: comment.git-savvy.branches.branch.date
         5: comment.git-savvy.branches.branch.tracking-info
-        6: comment.git-savvy.branches.branch.description keyword
+        6: constant.git-savvy.upstream.gone
+        7: comment.git-savvy.branches.branch.description keyword

--- a/syntax/branch.sublime-syntax
+++ b/syntax/branch.sublime-syntax
@@ -42,6 +42,32 @@ contexts:
           pop: true
 
   row:
+    - match: '^    \s+(\\ )?(checked out at: )(.+)$'
+      captures:
+        0: keyword
+        1: keyword
+        2: keyword
+        3: keyword.other.git-savvy.path
+
+
+    - match: '^\s+(<)([0-9a-f]{7,40}) ?(>-?)  (.*)$'
+      captures:
+        0: meta.git-savvy.branches.branch.as-worktree
+        1: punctuation.symbol.foreign-branch
+        2: constant.other.git-savvy.branches.branch.sha1 keyword
+        3: punctuation.symbol.foreign-branch
+        4: keyword
+
+    - match: '^\s+(<)([0-9a-f]{7,40})(>) (\S+)\s?(.*)$'
+      captures:
+
+        0: meta.git-savvy.branches.branch.as-worktree
+        1: punctuation.symbol.foreign-branch
+        2: constant.other.git-savvy.branches.branch.sha1 keyword
+        3: punctuation.symbol.foreign-branch
+        4: meta.git-savvy.branches.branch.name gitsavvy.gotosymbol
+        5: comment.git-savvy.branches.branch.extra-info
+
     - match: '^  (▸)?\s+([0-9a-f]{7,40}) ([^\s]+)([^(-]+?)?(\(.+?(?:, (gone))?\))?( \- .+)?$'
       captures:
         0: meta.git-savvy.branches.branch

--- a/syntax/test/syntax_test_branch.txt
+++ b/syntax/test/syntax_test_branch.txt
@@ -13,5 +13,5 @@
 # <- meta.git-savvy.branches.branch.active-branch
     f21e6a8 old (origin/develop, ahead 13, behind 40)
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.git-savvy.branches.branch.active-branch
-#               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.git-savvy.branches.branch.extra-info
+#               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.git-savvy.branches.branch.tracking-info
 

--- a/tests/test_git_mixins.py
+++ b/tests/test_git_mixins.py
@@ -56,7 +56,7 @@ class TestFetchInterface(TestGitMixinsUsage):
         self.assertRaises(TypeError, lambda: repo.fetch(*parameters.args, **parameters.kwargs))
 
 
-date_sha_and_subject = ["0", "89b79cd737465ed308ecc00289d00a6f923f2da5", "The Subject"]
+date_sha_and_subject = ["0", "now", "now", "89b79cd737465ed308ecc00289d00a6f923f2da5", "The Subject"]
 join0 = lambda x: "\x00".join(x)
 
 
@@ -80,6 +80,8 @@ class TestGetBranchesParsing(TestGitMixinsUsage):
                 False,
                 False,
                 0,
+                "now",
+                "now",
                 git_mixins.branches.Upstream(
                     "origin", "master", "origin/master", ""
                 ),
@@ -106,6 +108,8 @@ class TestGetBranchesParsing(TestGitMixinsUsage):
                 True,
                 False,
                 0,
+                "now",
+                "now",
                 git_mixins.branches.Upstream(
                     "origin", "master", "origin/master", ""
                 ),
@@ -132,6 +136,8 @@ class TestGetBranchesParsing(TestGitMixinsUsage):
                 False,
                 True,
                 0,
+                "now",
+                "now",
                 None,
                 git_mixins.branches.AheadBehind(ahead=0, behind=0)
             )
@@ -156,6 +162,8 @@ class TestGetBranchesParsing(TestGitMixinsUsage):
                 False,
                 False,
                 0,
+                "now",
+                "now",
                 git_mixins.branches.Upstream(
                     "orig/in", "master", "orig/in/master", ""
                 ),
@@ -182,6 +190,8 @@ class TestGetBranchesParsing(TestGitMixinsUsage):
                 False,
                 False,
                 0,
+                "now",
+                "now",
                 git_mixins.branches.Upstream(
                     "origin", "master", "origin/master", "gone"
                 ),
@@ -208,6 +218,8 @@ class TestGetBranchesParsing(TestGitMixinsUsage):
                 False,
                 False,
                 0,
+                "now",
+                "now",
                 git_mixins.branches.Upstream(
                     ".", "update-branch-from-upstream", "update-branch-from-upstream", ""
                 ),
@@ -273,20 +285,25 @@ class TestBranchParsing(EndToEndTestCase):
         repo = self.init_repo(comitterdate="1671490333 +0000")
         commit_hash = repo.get_commit_hash_for_head()
         actual = repo.get_branches()
-        self.assertEqual(actual, [
-            git_mixins.branches.Branch(
-                "master",
-                None,
-                "master",
-                commit_hash,
-                "Initial commit",
-                True,
-                False,
-                1671490333,
-                None,
-                git_mixins.branches.AheadBehind(ahead=0, behind=0)
-            )
-        ])
+        self.assertEqual(
+            list(map(lambda b: b._replace(relative_committerdate="long ago"), actual)),
+            [
+                git_mixins.branches.Branch(
+                    "master",
+                    None,
+                    "master",
+                    commit_hash,
+                    "Initial commit",
+                    True,
+                    False,
+                    1671490333,
+                    "Dec 19 2022",
+                    "long ago",
+                    None,
+                    git_mixins.branches.AheadBehind(ahead=0, behind=0)
+                )
+            ]
+        )
 
     def test_tracking_local_branch(self):
         repo = self.init_repo(comitterdate="1671490333 +0000")
@@ -294,19 +311,24 @@ class TestBranchParsing(EndToEndTestCase):
         repo.git("checkout", "--track", "-b", "feature-branch")
 
         actual = list(b for b in repo.get_branches() if b.name != "master")
-        self.assertEqual(actual, [
-            git_mixins.branches.Branch(
-                "feature-branch",
-                None,
-                "feature-branch",
-                commit_hash,
-                "Initial commit",
-                True,
-                False,
-                1671490333,
-                git_mixins.branches.Upstream(
-                    ".", "master", "master", ""
-                ),
-                git_mixins.branches.AheadBehind(ahead=0, behind=0)
-            )
-        ])
+        self.assertEqual(
+            list(map(lambda b: b._replace(relative_committerdate="long ago"), actual)),
+            [
+                git_mixins.branches.Branch(
+                    "feature-branch",
+                    None,
+                    "feature-branch",
+                    commit_hash,
+                    "Initial commit",
+                    True,
+                    False,
+                    1671490333,
+                    "Dec 19 2022",
+                    "long ago",
+                    git_mixins.branches.Upstream(
+                        ".", "master", "master", ""
+                    ),
+                    git_mixins.branches.AheadBehind(ahead=0, behind=0)
+                )
+            ]
+        )

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -504,6 +504,8 @@ class TestRecentCommitsFormat(DeferrableTestCase):
                 False,
                 False,
                 0,
+                "now",
+                "now",
                 git_mixins.branches.Upstream(
                     "origin", "master", "origin/master", ""
                 ),


### PR DESCRIPTION
Similar of how the overview mode of the graph view sorts the branches,
group the branches in the branches dashboard.

First show the branches that are ahead of HEAD, then the checked out
branch, then the branches that are behind, finally branches that have
diverged (are ahead and behind). Split this last section further and
put stale branches in a separate section.

This leads to a nice representation.

* E.g. the user is on main and sees all feature branches that could be
  merged right above.

* E.g. the user is on a feature branch and sees the dependent feature
  branches up to main directly below the active branch.

The feature requires git v2.41.0 and is pluggable by the
`group_by_distance_to_head_in_branch_dashboard` setting.

Closes #788