### PR TITLE
Ensure we can delete branches fast in the dashboard

### DIFF
--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -135,7 +135,10 @@ class BranchInterface(ui.ReactiveInterface, GitCommand):
 
     def refresh_view_state(self):
         # type: () -> None
-        enqueue_on_worker(self.get_branches)
+        if self.view.settings().get("git_savvy.update_view_in_a_blocking_manner"):
+            self.get_branches()
+        else:
+            enqueue_on_worker(self.get_branches)
         enqueue_on_worker(self.fetch_branch_description_subjects)
         enqueue_on_worker(self.get_latest_commits)
         enqueue_on_worker(self.get_remotes)
@@ -433,6 +436,7 @@ class gs_branches_delete(CommandForSingleBranch):
         if self.selected_branch.is_remote:
             self.delete_remote_branch(self.selected_branch.remote, self.selected_branch.name, force)
         else:
+            self.view.settings().set("git_savvy.update_view_in_a_blocking_manner", True)
             self.window.run_command("gs_delete_branch", {"branch": self.selected_branch.name, "force": force})
 
     @util.actions.destructive(description="delete a remote branch")


### PR DESCRIPTION
We want to enable e.g. `ddd` to delete three branches in a row.  Hence we must stay on the main thread ("sync" or blocking) so that after the deletion, first the view updates and only then the next key press is processed.

Note that we have similar problem in the status view where we call `interface.refresh_repo_status_and_render()` to have a blocking update, which is more elegant and self-contained.  That is not done easily here as we call out to a command `gs_delete_branch` which is commonly used. To make this command parametric just to change its final side-effect `util.view.refresh_gitsavvy_interfaces(self.window)` seems more work and might not worth it.

Truly a technical debt PR.