### PR TITLE
Clearly initialize state for new dashboard views

### DIFF
--- a/common/ui.py
+++ b/common/ui.py
@@ -309,7 +309,7 @@ def distinct_until_state_changed(just_render_fn):
 
 class ReactiveInterface(Interface, GitCommand, Generic[T_state]):
     state: T_state
-    subscribe_to: Set[str] = set()
+    subscribe_to: Set[str]
 
     def __init__(self, *args, **kwargs):
         self._lock = threading.Lock()

--- a/common/ui.py
+++ b/common/ui.py
@@ -38,7 +38,7 @@ from typing import (
 )
 T = TypeVar("T")
 T_fn = TypeVar("T_fn", bound=Callable)
-T_state = TypeVar("T_state", bound=MutableMapping)
+T_state = TypeVar("T_state", Dict, MutableMapping)
 
 SectionRegions = Dict[str, sublime.Region]
 RenderFnReturnType = Union[str, Tuple[str, List["SectionFn"]]]
@@ -350,8 +350,14 @@ class ReactiveInterface(Interface, GitCommand, Generic[T_state]):
         with self.keep_cursor_on_something():
             self.draw(self.title(), content, regions)
 
+    def initial_state(self):
+        # type: () -> Dict
+        """Return the initial state of the view."""
+        return {}
+
     def on_create(self):
         # type: () -> None
+        self.state = self.initial_state()
         self._unsubscribe = store.subscribe(
             self.repo_path,
             self.subscribe_to,

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -121,13 +121,12 @@ class BranchInterface(ui.ReactiveInterface, GitCommand):
     {remote_branch_list}"""
 
     subscribe_to = {"branches", "descriptions", "long_status", "recent_commits", "remotes"}
-    state = {}  # type: BranchViewState
+    state: BranchViewState
 
-    def __init__(self, *args, **kwargs):
-        self.state = {
+    def initial_state(self):
+        return {
             'show_remotes': self.savvy_settings.get("show_remotes_in_branch_dashboard"),
         }
-        super().__init__(*args, **kwargs)
 
     def title(self):
         # type: () -> str

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -213,7 +213,7 @@ class StatusInterface(ui.ReactiveInterface, GitCommand):
     subscribe_to = {
         "branches", "head", "long_status", "recent_commits", "skipped_files", "stashes", "status"
     }
-    state = {}  # type: StatusViewState
+    state: StatusViewState
 
     def title(self):
         # type: () -> str

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -129,14 +129,13 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
     {remote_tags_list}"""
 
     subscribe_to = {"local_tags", "long_status", "recent_commits", "remotes"}
-    state = {}  # type: TagsViewState
+    state: TagsViewState
 
-    def __init__(self, *args, **kwargs):
-        self.state = {
+    def initial_state(self):
+        return {
             'show_remotes': self.savvy_settings.get("show_remotes_in_branch_dashboard"),
             'remote_tags': {}
         }
-        super().__init__(*args, **kwargs)
 
     def title(self):
         # type: () -> str


### PR DESCRIPTION
This fixes a bug as we did not initialize the `state` object for the
status view at all.  T.i. all status dashboards *shared* the same view.
Duh, this did not hurt but produced flicker when flipping between
projects.

All other dashboards initialized their state in `__init__`.  (It should
have been done in `on_create` rather.)  Move that to a template method
`initial_state()`.