### PR TITLE
Ensure to denote new sem-versions if there are no remote tags

### DIFF
--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -52,6 +52,7 @@ class Succeeded(TypedDict):
 FetchStateMachine = Union[
     Loading, Erred, Succeeded
 ]
+RemoteTagsInfo = Dict[str, FetchStateMachine]
 
 
 class TagsViewState(TypedDict, total=False):
@@ -59,7 +60,7 @@ class TagsViewState(TypedDict, total=False):
     long_status: str
     local_tags: TagList
     remotes: Dict[str, str]
-    remote_tags_info: Dict[str, FetchStateMachine]
+    remote_tags_info: RemoteTagsInfo
     recent_commits: List[Commit]
     max_items: Optional[int]
     show_remotes: bool
@@ -161,7 +162,7 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
 
     @ui.inject_state()
     def maybe_populate_remote_tags(self, remotes, show_remotes, remote_tags_info):
-        # type: (Dict[str, str], bool, Dict[str, FetchStateMachine]) -> None
+        # type: (Dict[str, str], bool, RemoteTagsInfo) -> None
         def do_tags_fetch(remote_name):
             try:
                 new_state = {
@@ -215,7 +216,7 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
 
     @ui.section("local_tags")
     def render_local_tags(self, local_tags, max_items, remote_tags_info):
-        # type: (TagList, int, Dict[str, FetchStateMachine]) -> ui.RenderFnReturnType
+        # type: (TagList, int, RemoteTagsInfo) -> ui.RenderFnReturnType
         if not any(local_tags.all):
             return NO_LOCAL_TAGS_MESSAGE
 
@@ -265,7 +266,7 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
 
     @ui.section("remote_tags")
     def render_remote_tags(self, remotes, show_remotes, remote_tags_info):
-        # type: (Dict[str, str], bool, Dict[str, FetchStateMachine]) -> ui.RenderFnReturnType
+        # type: (Dict[str, str], bool, RemoteTagsInfo) -> ui.RenderFnReturnType
         if not remotes:
             return "\n"
 

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -161,8 +161,8 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
         })
 
     @ui.inject_state()
-    def maybe_populate_remote_tags(self, remotes, show_remotes, remote_tags_info):
-        # type: (Dict[str, str], bool, RemoteTagsInfo) -> None
+    def maybe_populate_remote_tags(self, remotes, remote_tags_info):
+        # type: (Dict[str, str], RemoteTagsInfo) -> None
         def do_tags_fetch(remote_name):
             try:
                 new_state = {

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -222,17 +222,17 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
         # wait until all settled to prohibit intermediate state to be drawn
         # what we draw explicitly relies on *all* known remote tags
         if remote_tags_info and all(info["state"] != "loading" for info in remote_tags_info.values()):
-            all_remote_tags, all_remote_tag_names = set(), set()
+            remote_tags, remote_tag_names = set(), set()
             for info in remote_tags_info.values():
                 if info["state"] == "succeeded":
                     for tag in info["tags"]:
-                        all_remote_tags.add((tag.sha, tag.tag))
-                        all_remote_tag_names.add(tag.tag)
+                        remote_tags.add((tag.sha, tag.tag))
+                        remote_tag_names.add(tag.tag)
 
             def maybe_mark(tag):
-                if tag.tag not in all_remote_tag_names:
+                if tag.tag not in remote_tag_names:
                     return "*"  # denote new semver
-                if (tag.sha, tag.tag) not in all_remote_tags:
+                if (tag.sha, tag.tag) not in remote_tags:
                     return "!"  # denote known semver on a different hash
                 return " "
 


### PR DESCRIPTION
The code opted out to denote anything when no remote had any tags, which
is at least true for the pristine remote repo.  E.g. we checked:

```
            if remote_tag_names and ...:
            if remote_tags and ...:
```

Remove these (late) checks and instead rely on `self.state.remote_tags`
to be "truthy" which it is as soon as we check any remote for its tags.

This "as soon" is important for the possible initial render where we
don't have any remote tags because we didn't even *start* to fetch any.
Consider that even `self.state.remotes` might not be resolved when the
caches are clean.