### PR TITLE
Fix dot colorizer colorizing the dirty indicator

### DIFF
--- a/core/commands/log_graph_colorizer.py
+++ b/core/commands/log_graph_colorizer.py
@@ -25,7 +25,7 @@ NextFn = Callable[['Char'], Iterator['Char']]
 Direction = Literal["down", "up"]
 
 
-COMMIT_NODE_CHARS = "●*⌂"
+COMMIT_NODE_CHARS = "●⌂*"
 
 
 class Char:


### PR DESCRIPTION
When HEAD is dirty and the root node, the colorizer used to find the dirty indicator (the `*` in `HEAD*`).

This is a precedence error, easy to fix.