### PR TITLE
Draw `LineHistory` in a streaming manner

### DIFF
--- a/core/commands/line_history.py
+++ b/core/commands/line_history.py
@@ -11,7 +11,7 @@ from .navigate import GsNavigate
 from ..fns import filter_, pairwise
 from ..git_command import GitCommand
 from ..parse_diff import SplittedDiff
-from ..runtime import enqueue_on_worker
+from ..runtime import run_on_new_thread
 from ..utils import flash
 from ..view import clamp, replace_view_content
 from ...common import util
@@ -263,10 +263,10 @@ class gs_open_line_history(WindowCommand, GitCommand):
                 ]
                 + [commit]
             )
-            output = self.git(*cmd)
-            replace_view_content(view, output)
+            for line in self.git_streaming(*cmd):
+                replace_view_content(view, line, sublime.Region(view.size()))
 
-        enqueue_on_worker(render)
+        run_on_new_thread(render)
 
 
 class gs_line_history_open_commit(TextCommand, GitCommand):

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -498,10 +498,16 @@ class _GitCommand(SettingsMixin):
 
     def lax_decode(self, input):
         # type: (bytes) -> str
-        try:
-            return self.strict_decode(input)
-        except UnicodeDecodeError:
-            return input.decode("utf-8", "replace")
+        return self.lax_decode_(self.get_encoding_candidates(), input)
+
+    def lax_decode_(self, encodings, input):
+        # type: (Sequence[str], bytes) -> str
+        for encoding in encodings:
+            try:
+                return input.decode(encoding)
+            except UnicodeDecodeError:
+                pass
+        return input.decode('utf8', errors='replace')
 
     def try_decode(self, input, encodings):
         # type: (bytes, Sequence[str]) -> Tuple[str, str]

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -26,7 +26,7 @@ from .settings import SettingsMixin
 from GitSavvy.core import store
 from GitSavvy.core.fns import consume, filter_, pairwise
 from GitSavvy.core.runtime import auto_timeout, enqueue_on_worker, run_as_future
-from GitSavvy.core.utils import kill_proc, paths_upwards, resolve_path
+from GitSavvy.core.utils import try_kill_proc, paths_upwards, resolve_path
 
 
 from typing import (
@@ -149,7 +149,7 @@ def stream_stdout_and_err(proc, timeout):
             except IndexError:
                 time.sleep(next(delay) / 1000)
                 if timeout_manager.has_timed_out():
-                    kill_proc(proc)
+                    try_kill_proc(proc)
                     raise TimeoutError("timed out after {} seconds".format(timeout))
 
     # Check and raise exceptions if any

--- a/core/utils.py
+++ b/core/utils.py
@@ -375,6 +375,19 @@ def kill_proc(proc):
         proc.terminate()
 
 
+def try_kill_proc(proc):
+    if proc:
+        try:
+            kill_proc(proc)
+        except ProcessLookupError:
+            pass
+        proc.got_killed = True
+
+
+def proc_has_been_killed(proc):
+    return getattr(proc, "got_killed", False)
+
+
 # `realpath` also supports `bytes` and we don't, hence the indirection
 def _resolve_path(path):
     # type: (str) -> str


### PR DESCRIPTION
For longer graphs, Line History can become slow. So switch from wait and draw to streaming mode.  The code for that is borrowed from the graph drawing.  

Still TODO:  Probably stop after n lines.
YAGNI:  There is no buffering at all.  It looks like Sublime can draw simple "appends" just fast enough.