### PR TITLE
Tune guessing the next commit

### DIFF
--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -1010,10 +1010,12 @@ class gs_inline_diff_next_commit(TextCommand, GitCommand):
 
         target_commit = settings.get("git_savvy.inline_diff_view.target_commit")
         new_base_commit = target_commit
-        new_target_commit = (
-            show_file_at_commit.recall_next_commit_for(view, target_commit)
-            or self.next_commit(target_commit, file_path)
-        )
+        try:
+            new_target_commit = show_file_at_commit.get_next_commit(self, view, target_commit, file_path)
+        except ValueError:
+            flash(view, "Can't find a newer commit; it looks orphaned.")
+            return
+
         if not new_target_commit:
             new_base_commit = None
 

--- a/core/commands/show_commit.py
+++ b/core/commands/show_commit.py
@@ -353,10 +353,12 @@ class gs_show_commit_open_next_commit(TextCommand, GitCommand):
         settings = view.settings()
         file_path: Optional[str] = settings.get("git_savvy.file_path")
         commit_hash: str = settings.get("git_savvy.show_commit_view.commit")
-        next_commit = (
-            show_file_at_commit.recall_next_commit_for(view, commit_hash)
-            or self.next_commit(commit_hash, file_path)
-        )
+        try:
+            next_commit = show_file_at_commit.get_next_commit(self, view, commit_hash, file_path)
+        except ValueError:
+            flash(view, "Can't find a newer commit; it looks orphaned.")
+            return
+
         if not next_commit:
             flash(view, "No newer commit found.")
             return


### PR DESCRIPTION
Given a random commit we always looked from "HEAD" up to that commit to find (or rather guess) the next commit.  This fails if the user is looking at a commit not contained in the current line.

Tune this and check first for a branch that contains the commit.  If there are many, take the one that has the most recent changes.  Then graph the line from the commit to the tip of the branch.

Since guessing a next commit is not cacheable, this new approach would require two git calls per user action.  To avoid that take the whole log line and store it on the view so that subsequent `[n]ext`-actions are free.  T.i. cache for the lifetime of the view.