### PR TITLE
Fix interpreting slow_repo state

### DIFF
--- a/core/git_mixins/branches.py
+++ b/core/git_mixins/branches.py
@@ -186,7 +186,7 @@ class BranchesMixin(mixin_base):
         slow_repo = self.current_state().get("slow_repo", None)
         supports_ahead_behind = (
             self.git_version >= FOR_EACH_REF_SUPPORTS_AHEAD_BEHIND
-            and slow_repo is not False
+            and slow_repo is not True
         )
         probe_speed = slow_repo is None and supports_ahead_behind
         return get_branches__(probe_speed, supports_ahead_behind)

--- a/core/git_mixins/branches.py
+++ b/core/git_mixins/branches.py
@@ -184,12 +184,12 @@ class BranchesMixin(mixin_base):
             return branches
 
         slow_repo = self.current_state().get("slow_repo", None)
-        supports_ahead_behind = (
+        compute_ahead_behind = (
             self.git_version >= FOR_EACH_REF_SUPPORTS_AHEAD_BEHIND
-            and slow_repo is not True
+            and not slow_repo
         )
-        probe_speed = slow_repo is None and supports_ahead_behind
-        return get_branches__(probe_speed, supports_ahead_behind)
+        probe_speed = compute_ahead_behind and slow_repo is None
+        return get_branches__(probe_speed, compute_ahead_behind)
 
     def _cache_branches(self, branches, refs):
         # type: (List[Branch], Sequence[str]) -> None


### PR DESCRIPTION
Fixes #1939

That's an obvious bug due to a obviously wrong interpretation of a
variable.

`supports_ahead_behind` actually means `compute_ahead_and_behind` and
that computation should be done if `slow_repo` is in `(False, None)`
state.