### PR TITLE
Suppress timezone information in the branches dashboard

### DIFF
--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -247,7 +247,9 @@ class BranchInterface(ui.ReactiveInterface, GitCommand):
 
         def get_date(branch):
             if human_dates:
-                return branch.human_committerdate
+                # Remove possible timezone information, e.g. transform "Wed 14:28 -0700"
+                # to just "Wed 14:28".
+                return re.sub(r" [+-]\d{4}$", "", branch.human_committerdate)
 
             d = branch.relative_committerdate
             if d == "12 months ago":

--- a/syntax/branch.sublime-syntax
+++ b/syntax/branch.sublime-syntax
@@ -68,7 +68,7 @@ contexts:
         4: meta.git-savvy.branches.branch.name gitsavvy.gotosymbol
         5: comment.git-savvy.branches.branch.extra-info
 
-    - match: '^  (▸)?\s+([0-9a-f]{7,40}) ([^\s]+)([^(-]+?)?(\(.+?(?:, (gone))?\))?( \- .+)?$'
+    - match: '^  (▸)?\s+([0-9a-f]{7,40}) ([^\s]+)\s([^(-].+?)?((?:, )?\(.+?(?:, (gone))?\))?( ?\- .+)?$'
       captures:
         0: meta.git-savvy.branches.branch
         1: punctuation.symbol.active-branch.git-savvy

--- a/syntax/test/syntax_test_branch.txt
+++ b/syntax/test/syntax_test_branch.txt
@@ -14,4 +14,34 @@
     f21e6a8 old (origin/develop, ahead 13, behind 40)
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.git-savvy.branches.branch.active-branch
 #               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.git-savvy.branches.branch.tracking-info
+    b20264b iter-branches-dashboard-code 12 minutes ago
+#   ^^^^^^^ constant.other.git-savvy.branches.branch.sha1
+#           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.git-savvy.branches.branch.name gitsavvy.gotosymbol
+#                                        ^^^^^^^^^^^^^^ comment.git-savvy.branches.branch.date
+    fb8240d status-bar-updater (fork/status-bar-updater, gone)
+#                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.git-savvy.branches.branch.tracking-info
+#                                                        ^^^^ constant.git-savvy.upstream.gone
+    fb8240d status-bar-updater (fork/status-bar-updater)
+#                              ^^^^^^^^^^^^^^^^^^^^^^^^^ comment.git-savvy.branches.branch.tracking-info
+    369ff34 fix-environment 6 years ago, (origin/fix-environment)
+#                           ^^^^^^^^^^^ comment.git-savvy.branches.branch.date
+#                                        ^^^^^^^^^^^^^^^^^^^^^^^^ comment.git-savvy.branches.branch.tracking-info
+  ▸ 7f561b6 master Wed 20:04 -0700, (origin/master) - desc
+#                  ^^^^^^^^^^^^^^^ comment.git-savvy.branches.branch.date
+#                                    ^^^^^^^^^^^^^^ comment.git-savvy.branches.branch.tracking-info
+#                                                   ^^^^^^ comment.git-savvy.branches.branch.description keyword
+  ▸ 7f561b6 master Wed 20:04 -0700 - desc
+#                  ^^^^^^^^^^^^^^^ comment.git-savvy.branches.branch.date
+#                                  ^^^^^^ comment.git-savvy.branches.branch.description keyword
+    7f561b6 master (origin/master) - desc
+#                  ^^^^^^^^^^^^^^ comment.git-savvy.branches.branch.tracking-info
+#                                 ^^^^^^^ comment.git-savvy.branches.branch.description keyword
+    7f561b6 master - desc
+#                  ^^^^^^ comment.git-savvy.branches.branch.description keyword
+    67df3f5 better-error-handling 12 months ago - desc
+#                                 ^^^^^^^^^^^^^ comment.git-savvy.branches.branch.date
+#                                               ^^^^^^ comment.git-savvy.branches.branch.description keyword
+
+
+
 


### PR DESCRIPTION
Fixes #1941

In fact our syntax did not expect timezone information and broke here.
Remove the timezone as it looks better and the information seems not
necessary in this overview format we have in the branches dashboard.