### PR TITLE
Exclude development files from sublime-package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,16 +2,16 @@
 # archive files. See http://git-scm.com/docs/gitattributes for details.
 
 # git
-.github/        	export-ignore
-*.git           	export-ignore
-*.gitignore     	export-ignore
-*.gitattributes 	export-ignore
+.github/            export-ignore
+*.git               export-ignore
+*.gitignore         export-ignore
+*.gitattributes     export-ignore
 
 # development
-/scripts			export-ignore
-/stubs				export-ignore
+/scripts            export-ignore
+/stubs              export-ignore
 /tests/             export-ignore
-/__init__.py		export-ignore
-mypy.ini			export-ignore
-setup.cfg			export-ignore
-unittesting.json	export-ignore
+/__init__.py        export-ignore
+mypy.ini            export-ignore
+setup.cfg           export-ignore
+unittesting.json    export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,17 @@
 # Files and directories with the attribute export-ignore won’t be added to
 # archive files. See http://git-scm.com/docs/gitattributes for details.
 
+# git
+.github/        	export-ignore
+*.git           	export-ignore
+*.gitignore     	export-ignore
+*.gitattributes 	export-ignore
+
+# development
+/scripts			export-ignore
+/stubs				export-ignore
 /tests/             export-ignore
+/__init__.py		export-ignore
+mypy.ini			export-ignore
+setup.cfg			export-ignore
+unittesting.json	export-ignore


### PR DESCRIPTION
This PR adds various development related resources to .gitattributes in order to exclude them from GitSavvy.sublime-package installed via Package Control.

Notably `__init__.py` in root directory is excluded to avoid exceptions, when reloading package after upgrade without impact on current development or test workflows. The file is considered a dev-only resource.