### PR TITLE
Fix `gs_diff_open_file_at_hunk` when `in_cached_mode`

### DIFF
--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -1072,7 +1072,7 @@ class gs_diff_open_file_at_hunk(TextCommand, GitCommand):
             })
         else:
             if self.view.settings().get("git_savvy.diff_view.in_cached_mode"):
-                line = self.find_matching_lineno("HEAD", None, line=line, file_path=full_path)
+                line = self.reverse_find_matching_lineno(None, None, line=line, file_path=full_path)
             window.open_file(
                 "{file}:{line}:{col}".format(file=full_path, line=line, col=col),
                 sublime.ENCODED_POSITION


### PR DESCRIPTION
The previous implementation commit message f0e9bf31 (Implement `gs_diff_open_file_at_hunk` when `in_cached_mode`) correctly states that the staged hunks get applied to HEAD and so are its line numbers in relation to "HEAD".  But that doesn't tangle the problem which is that we might still have a dirty diff between the working dir and HEAD and we in fact want to jump to the workingt dir state.

So we basically need to adjust by comparing to the standard diff, e.g. `git diff -- some_file`.

That would be `find_matching_lineno(None, None)` but the function doesn't accept that and switches the first `None` to an `-R`.  T.i it asks for a *reversed* diff.  Hence we use `reverse_find_matching_lineno` which can interpret this correctly.