### PR TITLE
Refresh inline diff after reloads

### DIFF
--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -710,7 +710,10 @@ class GsInlineDiffFocusEventListener(EventListener):
         if (
             active_on_activated
             and is_inline_diff_view(view)
-            and not view.settings().get("git_savvy.inline_diff_view.target_commit")
+            and (
+                not view.settings().get("git_savvy.inline_diff_view.target_commit")
+                or view.id() not in diff_view_hunks
+            )
         ):
             view.run_command("gs_inline_diff_refresh", {"sync": False})
 


### PR DESCRIPTION
Since the underlying data of an inline diff view is hold in memory (under `diff_view_hunks`), it is lost when Sublime Text gets restarted. (Or GitSavvy gets reloaded for that matter.)  Force a refresh to load up that data again.