### PR TITLE
Implement `query` parameter when searching for PR's

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -125,8 +125,13 @@
         "command": "gs_github_open_repo"
     },
     {
-        "caption": "github: review pull request",
+        "caption": "github: review pull request (show: all)",
         "command": "gs_github_pull_request"
+    },
+    {
+        "caption": "github: review pull request (show: mine)",
+        "command": "gs_github_pull_request",
+        "args": { "query": "involves:@me" }
     },
     {
         "caption": "github: set remote for integration",

--- a/github/github.py
+++ b/github/github.py
@@ -171,7 +171,9 @@ def query_github(api_url_template: str, github_repo: GitHubRepo):
 get_repo_data = partial(query_github, "/repos/{owner}/{repo}")
 
 
-def iteratively_query_github(api_url_template: str, github_repo: GitHubRepo, query: dict = {}):
+def iteratively_query_github(
+    api_url_template: str, github_repo: GitHubRepo, query: dict = {}, yield_: str = None
+):
     """
     Like `query_github` but return a generator by repeatedly
     iterating until no link to next page.
@@ -201,8 +203,10 @@ def iteratively_query_github(api_url_template: str, github_repo: GitHubRepo, que
         validate_response(response)
 
         if response.payload:
-            for item in response.payload:
-                yield item
+            if yield_:
+                yield from response.payload[yield_]
+            else:
+                yield from response.payload
         else:
             break
 

--- a/github/github.py
+++ b/github/github.py
@@ -171,13 +171,14 @@ def query_github(api_url_template: str, github_repo: GitHubRepo):
 get_repo_data = partial(query_github, "/repos/{owner}/{repo}")
 
 
-def iteratively_query_github(api_url_template: str, github_repo: GitHubRepo):
+def iteratively_query_github(api_url_template: str, github_repo: GitHubRepo, query: dict = {}):
     """
     Like `query_github` but return a generator by repeatedly
     iterating until no link to next page.
     """
-    fqdn, path = github_api_url(api_url_template, github_repo,
-                                per_page=GITHUB_PER_PAGE_MAX)
+    default_query = {"per_page": GITHUB_PER_PAGE_MAX}
+    query_ = {**default_query, **query}
+    fqdn, path = github_api_url(api_url_template, github_repo, **query_)
     auth = (github_repo.token, "x-oauth-basic") if github_repo.token else None
 
     response = None

--- a/github/github.py
+++ b/github/github.py
@@ -120,7 +120,9 @@ def get_api_fqdn(github_repo):
     return True, github_repo.fqdn
 
 
-def github_api_url(api_url_template, repository, **kwargs):
+def github_api_url(
+    api_url_template: str, repository: GitHubRepo, **kwargs: dict[str, str]
+) -> tuple[str, str]:
     """
     Construct a github URL to query using the given url template string,
     and a github.GitHubRepo instance, and optionally query parameters
@@ -151,7 +153,7 @@ def validate_response(response, method="GET"):
             action=action, payload=response.payload))
 
 
-def query_github(api_url_template, github_repo):
+def query_github(api_url_template: str, github_repo: GitHubRepo):
     """
     Takes a URL template that takes `owner` and `repo` template variables
     and as a GitHub repo object.  Do a GET for the provided URL and return
@@ -169,7 +171,7 @@ def query_github(api_url_template, github_repo):
 get_repo_data = partial(query_github, "/repos/{owner}/{repo}")
 
 
-def iteratively_query_github(api_url_template, github_repo):
+def iteratively_query_github(api_url_template: str, github_repo: GitHubRepo):
     """
     Like `query_github` but return a generator by repeatedly
     iterating until no link to next page.


### PR DESCRIPTION
Fixes #1937

Add `query` argument to `gs_github_pull_request` (default: "") to filter
the list of PR's we fetch.  As the search API does return a subset of
the information we need, query the full PR response in a second step
(but in the background using a future).

The query parameter is a string and can be basically anything a user
would also type in on Github's website.

Interesting candidates are e.g. "involves:@me" which is also added to
the Command Palette.
