### PR TITLE
Add "github: copy file url to clipboard"

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -112,8 +112,13 @@
         "command": "gs_graph_pickaxe"
     },
     {
-        "caption": "github: open file on remote",
-        "command": "gs_github_open_file_on_remote",
+        "caption": "github: open file in browser",
+        "command": "gs_github_open_file_in_browser",
+        "args": { "preselect": true }
+    },
+    {
+        "caption": "github: copy file url to clipboard",
+        "command": "gs_github_copy_file_url",
         "args": { "preselect": true }
     },
     {

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -159,8 +159,8 @@
         "command": "gs_github_create_pull_request"
     },
     {
-        "caption": "gitlab: open file on remote",
-        "command": "gs_gitlab_open_file_on_remote",
+        "caption": "gitlab: open file in browser",
+        "command": "gs_gitlab_open_file_in_browser",
         "args": { "preselect": true }
     },
     {

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -500,7 +500,7 @@ class gs_status_open_file_on_remote(StatusInterfaceCommand):
         # type: (sublime.Edit) -> None
         file_paths = self.get_selected_subjects('staged', 'unstaged', 'merge-conflicts')
         if file_paths:
-            self.view.run_command("gs_github_open_file_on_remote", {"fpath": file_paths})
+            self.view.run_command("gs_github_open_file_in_browser", {"fpath": file_paths})
 
 
 class gs_status_diff_inline(StatusInterfaceCommand):

--- a/github/github.py
+++ b/github/github.py
@@ -76,21 +76,19 @@ def parse_remote(remote_url: str) -> GitHubRepo:
     return GitHubRepo(url, fqdn, owner, repo, token)
 
 
-def open_file_in_browser(rel_path, remote_url, commit_hash, start_line=None, end_line=None):
+def construct_github_file_url(rel_path, remote_url, commit_hash, start_line=None, end_line=None) -> str:
     """
     Open the URL corresponding to the provided `rel_path` on `remote_url`.
     """
     github_repo = parse_remote(remote_url)
     line_numbers = "#L{}-L{}".format(start_line, end_line) if start_line is not None else ""
 
-    url = "{repo_url}/blob/{commit_hash}/{path}{lines}".format(
+    return "{repo_url}/blob/{commit_hash}/{path}{lines}".format(
         repo_url=github_repo.url,
         commit_hash=commit_hash,
         path=rel_path,
         lines=line_numbers
     )
-
-    open_in_browser(url)
 
 
 def open_repo(remote_url):

--- a/gitlab/commands/open_on_remote.py
+++ b/gitlab/commands/open_on_remote.py
@@ -9,7 +9,7 @@ from GitSavvy.core.runtime import on_worker
 
 
 __all__ = (
-    "gs_gitlab_open_file_on_remote",
+    "gs_gitlab_open_file_in_browser",
     "gs_gitlab_open_repo",
     "gs_gitlab_open_issues",
 )
@@ -18,7 +18,7 @@ EARLIER_COMMIT_PROMPT = ("The remote chosen may not contain the commit. "
                          "Open the file {} before?")
 
 
-class gs_gitlab_open_file_on_remote(GsTextCommand, GitLabRemotesMixin):
+class gs_gitlab_open_file_in_browser(GsTextCommand, GitLabRemotesMixin):
 
     """
     Open a new browser window to the web-version of the currently opened


### PR DESCRIPTION
Fixes #1854

Also rename "open file on remote" to "open file in browser".

The underlying commands are renamed too:  `gs_[github|gitlab]_open_file_in_browser` which, technically, makes it a breaking change.  