### PR TITLE
Iterate on next/previous commits navigation

### DIFF
--- a/core/commands/blame.py
+++ b/core/commands/blame.py
@@ -34,7 +34,6 @@ BlamedLine = namedtuple("BlamedLine", ("contents", "commit_hash", "orig_lineno",
 
 NOT_COMMITED_HASH = "0000000000000000000000000000000000000000"
 BLAME_TITLE = "BLAME: {}{}"
-DEFAULT_COMMIT_HASH_LENGTH = 8
 
 
 class BlameMixin(GsTextCommand):
@@ -285,8 +284,7 @@ class gs_blame_refresh(BlameMixin):
             match = re.match(r"([0-9a-f]{40}) (\d+) (\d+)( \d+)?", line)
             assert match
             commit_hash, orig_lineno, final_lineno, _ = match.groups()
-            short_hash_length = self.current_state().get("short_hash_length", DEFAULT_COMMIT_HASH_LENGTH)
-            commits[commit_hash]["short_hash"] = commit_hash[:short_hash_length]
+            commits[commit_hash]["short_hash"] = self.get_short_hash(commit_hash)
             commits[commit_hash]["long_hash"] = commit_hash
 
             next_line = next(lines_iter)
@@ -480,7 +478,7 @@ class gs_blame_open_graph_context(BlameMixin):
         commit_hash = self.find_selected_commit_hash()
         self.window.run_command("gs_graph", {
             "all": True,
-            "follow": self.get_short_hash(commit_hash) if commit_hash else "HEAD",
+            "follow": commit_hash or "HEAD",
         })
 
 

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -1084,15 +1084,15 @@ class gs_diff_open_file_at_hunk(TextCommand, GitCommand):
         Show file at target commit if `git_savvy.diff_view.target_commit` is non-empty.
         Otherwise, open the file directly.
         """
-        target_commit = commit_hash or self.view.settings().get("git_savvy.diff_view.target_commit")
         full_path = os.path.join(self.repo_path, filename)
         window = self.view.window()
         if not window:
             return
 
-        if target_commit:
+        target_commit = self.view.settings().get("git_savvy.diff_view.target_commit")
+        if commit_hash or target_commit:
             window.run_command("gs_show_file_at_commit", {
-                "commit_hash": target_commit,
+                "commit_hash": commit_hash or self.resolve_commitish(target_commit),
                 "filepath": full_path,
                 "position": Position(line - 1, col - 1, None),
             })

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -280,7 +280,7 @@ class gs_inline_diff(WindowCommand, GitCommand):
 
         file_path = os.path.normpath(os.path.join(repo_path, jump_position.filename))
         syntax_file = util.file.guess_syntax_for_file(self.window, file_path)
-        target_commit = jump_position.commit_hash
+        target_commit = self.get_short_hash(jump_position.commit_hash)
         base_commit = self.previous_commit(target_commit, file_path)
         cur_pos = Position(
             jump_position.line - 1,

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -983,9 +983,7 @@ class gs_inline_diff_previous_commit(TextCommand, GitCommand):
                 return
 
         new_target_commit = base_commit
-        new_base_commit = self.previous_commit(base_commit, file_path)
-        if new_base_commit:
-            show_file_at_commit.remember_next_commit_for(view, {new_base_commit: base_commit})
+        new_base_commit = show_file_at_commit.get_previous_commit(self, view, base_commit, file_path)
         settings.set("git_savvy.inline_diff_view.base_commit", new_base_commit)
         settings.set("git_savvy.inline_diff_view.target_commit", new_target_commit)
 

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -239,8 +239,8 @@ class gs_inline_diff(WindowCommand, GitCommand):
             "syntax": syntax_file,
             "cached": bool(cached),
             "match_position": cur_pos,
-            "base_commit": base_commit,
-            "target_commit": target_commit
+            "base_commit": self.resolve_commitish(base_commit) if base_commit else None,
+            "target_commit": self.resolve_commitish(target_commit) if target_commit else None
         })
 
     def open_from_show_file_at_commit_view(self, view):

--- a/core/commands/show_commit.py
+++ b/core/commands/show_commit.py
@@ -327,12 +327,11 @@ class gs_show_commit_open_previous_commit(TextCommand, GitCommand):
         file_path: Optional[str] = settings.get("git_savvy.file_path")
         commit_hash: str = settings.get("git_savvy.show_commit_view.commit")
 
-        previous_commit = self.previous_commit(commit_hash, file_path)
+        previous_commit = show_file_at_commit.get_previous_commit(self, view, commit_hash, file_path)
         if not previous_commit:
             flash(view, "No older commit found.")
             return
 
-        show_file_at_commit.remember_next_commit_for(view, {previous_commit: commit_hash})
         show_commit_info.remember_view_state(view)
         settings.set("git_savvy.show_commit_view.commit", previous_commit)
 

--- a/core/commands/show_commit.py
+++ b/core/commands/show_commit.py
@@ -66,6 +66,8 @@ class gs_show_commit(WindowCommand, GitCommand):
         repo_path = self.repo_path
         if commit_hash in {"", "HEAD"}:
             commit_hash = self.git("rev-parse", "--short", "HEAD").strip()
+        else:
+            commit_hash = self.get_short_hash(commit_hash)
 
         this_id = (
             repo_path,
@@ -76,7 +78,7 @@ class gs_show_commit(WindowCommand, GitCommand):
                 focus_view(view)
                 break
         else:
-            title = SHOW_COMMIT_TITLE.format(self.get_short_hash(commit_hash))
+            title = SHOW_COMMIT_TITLE.format(commit_hash)
             view = util.view.create_scratch_view(self.window, "show_commit", {
                 "title": title,
                 "syntax": "Packages/GitSavvy/syntax/show_commit.sublime-syntax",

--- a/core/commands/show_commit_info.py
+++ b/core/commands/show_commit_info.py
@@ -56,6 +56,8 @@ def ensure_panel_is_visible(window, name=PANEL_NAME):
 
 class gs_show_commit_info(WindowCommand, GitCommand):
     def run(self, commit_hash, file_path=None, from_log_graph=False):
+        commit_hash = self.get_short_hash(commit_hash)
+
         # We're running either blocking or lazy, and currently choose
         # automatically.  Generally, we run blocking to reduce multiple
         # UI changes in short times.  Since this panel is a companion

--- a/core/commands/show_file_at_commit.py
+++ b/core/commands/show_file_at_commit.py
@@ -88,7 +88,9 @@ class gs_show_file_at_commit(GsWindowCommand):
             if lang is None:
                 lang = view.settings().get('syntax')
 
-        if not commit_hash:
+        if commit_hash:
+            commit_hash = self.get_short_hash(commit_hash)
+        else:
             commit_hash = self.recent_commit("HEAD", filepath)
             if not commit_hash:
                 self.window.status_message("No older revision of this file found.")
@@ -119,7 +121,7 @@ class gs_show_file_at_commit(GsWindowCommand):
         active_view = self.window.active_view()
         title = SHOW_COMMIT_TITLE.format(
             os.path.basename(file_path),
-            self.get_short_hash(commit_hash),
+            commit_hash,
         )
         view = util.view.create_scratch_view(self.window, "show_file_at_commit", {
             "title": title,
@@ -302,6 +304,7 @@ def get_next_commit(
     commit_hash: str,
     file_path: str | None = None
 ) -> str | None:
+    commit_hash = cmd.get_short_hash(commit_hash)
     if next_commit := recall_next_commit_for(view, commit_hash):
         return next_commit
 
@@ -412,7 +415,7 @@ class gs_show_current_file(LogMixin, GsTextCommand):
 
         view = self.view
         shown_hash = view.settings().get("git_savvy.show_file_at_commit_view.commit")
-        return commit_hash == shown_hash
+        return commit_hash.startswith(shown_hash)
 
 
 class gs_show_file_at_commit_open_commit(TextCommand):

--- a/core/fns.py
+++ b/core/fns.py
@@ -1,12 +1,13 @@
+from __future__ import annotations
 from collections import deque
 from functools import partial
 from itertools import accumulate as accumulate_, chain, islice, tee
 
-from typing import Callable, Iterable, Iterator, List, Optional, Set, Tuple, TypeVar
+from typing import Any, Callable, Iterable, Iterator, List, Optional, Set, Tuple, TypeVar
 T = TypeVar('T')
 U = TypeVar('U')
 
-
+NOT_SET: Any = object()
 filter_ = partial(filter, None)  # type: Callable[[Iterable[Optional[T]]], Iterator[T]]
 flatten = chain.from_iterable
 
@@ -69,6 +70,16 @@ def head(iterable):
 def tail(iterable):
     # type: (Iterable[T]) -> Iterator[T]
     return drop(1, iterable)
+
+
+def last(iterable, default=NOT_SET):
+    # type: (Iterable[T], T | None) -> Optional[T]
+    try:
+        return deque(iterable, 1)[0]
+    except IndexError:
+        if default is NOT_SET:
+            raise
+        return default
 
 
 def unzip(zipped):

--- a/core/git_mixins/history.py
+++ b/core/git_mixins/history.py
@@ -392,6 +392,9 @@ class HistoryMixin(mixin_base):
         follow: bool = False,
         branch_hint: str | None = None,
     ) -> dict[str, str]:
+        if current_commit != self.get_short_hash(current_commit):
+            raise RuntimeError("`next_commits` must be called with a short commit hash.")
+
         if branch_hint is None:
             try:
                 branch_hint = next(iter(
@@ -427,7 +430,7 @@ class HistoryMixin(mixin_base):
     ) -> List[str]:
         return self.git_throwing_silently(
             "log",
-            "--format=%H",
+            "--format=%h",
             "--topo-order",
             "--follow" if follow else None,
             None if limit is None else f"-{limit}",

--- a/core/git_mixins/history.py
+++ b/core/git_mixins/history.py
@@ -4,7 +4,7 @@ from itertools import chain, takewhile
 
 from ..exceptions import GitSavvyError
 from ...common import util
-from GitSavvy.core.fns import pairwise
+from GitSavvy.core.fns import last, pairwise
 from GitSavvy.core.git_command import mixin_base
 from GitSavvy.core.utils import cached
 
@@ -362,31 +362,25 @@ class HistoryMixin(mixin_base):
     @cached(not_if={"current_commit": is_dynamic_ref})
     def previous_commit(self, current_commit, file_path=None, follow=False):
         # type: (str, Optional[str], bool) -> Optional[str]
-        try:
-            return self._log_commits(
-                current_commit, file_path, follow, limit=2
-            )[1]
-        except IndexError:
-            return None
+        return last(
+            self._log_commits(current_commit, file_path, follow, limit=2),
+            None
+        )
 
     @cached(not_if={"current_commit": is_dynamic_ref})
     def recent_commit(self, current_commit, file_path=None, follow=False):
         # type: (str, Optional[str], bool) -> Optional[str]
-        try:
-            return self._log_commits(
-                current_commit, file_path, follow, limit=1
-            )[0]
-        except IndexError:
-            return None
+        return last(
+            self._log_commits(current_commit, file_path, follow, limit=1),
+            None
+        )
 
     def next_commit(self, current_commit, file_path=None, follow=False):
         # type: (str, Optional[str], bool) -> Optional[str]
-        try:
-            return self._log_commits(
-                f"{current_commit}..", file_path, follow
-            )[-1]
-        except IndexError:
-            return None
+        return last(
+            self._log_commits(f"{current_commit}..", file_path, follow),
+            None
+        )
 
     def next_commits(
         self,

--- a/core/git_mixins/history.py
+++ b/core/git_mixins/history.py
@@ -191,6 +191,9 @@ class HistoryMixin(mixin_base):
         self.update_store({"short_hash_length": len(short_hash)})
         return short_hash
 
+    def resolve_commitish(self, ref: str) -> str:
+        return self.git("rev-parse", "--short", ref).strip()
+
     def filename_at_commit(self, filename, commit_hash):
         # type: (str, str) -> str
         lines = self.git(

--- a/core/git_mixins/history.py
+++ b/core/git_mixins/history.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import email.utils
-from itertools import chain
+from itertools import chain, takewhile
 
 from ..exceptions import GitSavvyError
 from ...common import util
@@ -419,7 +419,10 @@ class HistoryMixin(mixin_base):
         return {
             right: left
             for left, right in pairwise(chain(
-                self._log_commits(f"{current_commit}..{branch_hint}", file_path, follow),
+                takewhile(
+                    lambda c: c != current_commit,
+                    self._log_commits(f"{branch_hint}", file_path, follow)
+                ),
                 [current_commit]
             ))
         }

--- a/core/git_mixins/history.py
+++ b/core/git_mixins/history.py
@@ -400,7 +400,8 @@ class HistoryMixin(mixin_base):
                         "--format=%(refname)",
                         "--contains",
                         current_commit,
-                        "--sort=-committerdate"
+                        "--sort=-committerdate",
+                        "--sort=-HEAD"
                     ).strip().splitlines()
                 ))
             except (GitSavvyError, StopIteration):

--- a/tests/test_graph_view.py
+++ b/tests/test_graph_view.py
@@ -150,6 +150,7 @@ class TestGraphViewInteractionWithCommitInfoPanel(DeferrableTestCase):
     def register_commit_info(self, info):
         for sha1, info in info.items():
             when(gs_show_commit_info).read_commit(sha1, ...).thenReturn(info)
+            when(gs_show_commit_info).get_short_hash(sha1).thenReturn(sha1)
 
     def create_graph_view_async(self, repo_path, log, wait_for):
         when(gs_log_graph_refresh).read_graph(...).thenReturn(


### PR DESCRIPTION
Internally we switch to short_hashes.  This can be a temporary switch as we gain more information of the places where we actually uses hashes or allow also revs (e.g. branch names).  After all, if we mark all places we *could* implement an internal map from short to long hashes (e.g. whenever we draw the graph), and switch to long hashes without a big cost.  Note: we switch to short hashes here but it actually was wild, no-rules before, so we basically normalize our usages and get a sense of it.

Other than that:  there is obviously no simple solution to which is the best newer or older commit of a given commit (as there might be many), so it is likely there are some decision made I don't remember right now.