### PR TITLE
Let "smart copy" select the current line if the selection is empty

### DIFF
--- a/core/commands/show_commit.py
+++ b/core/commands/show_commit.py
@@ -493,16 +493,16 @@ class GsShowCommitCopyCommitMessageHelper(EventListener):
         selected_text = TextRange(view.substr(sel), *sel)
         by_line = [
             line[4:] if line.text.startswith("    ") else line
-            for line in selected_text.lines()
+            for line in selected_text.lines(keepends=False)
         ]
-        string_for_clipboard = "".join(line.text for line in by_line)
+        string_for_clipboard = "\n".join(line.text for line in by_line)
         clip_content = sublime.get_clipboard(2048)
 
         if string_for_clipboard == clip_content:
             set_clipboard_and_flash(view, selected_text.text, [selected_text.region()])
             return "noop"
 
-        regions = [line.region()[:-1] for line in by_line]
+        regions = [line.region() for line in by_line]
         set_clipboard_and_flash(view, string_for_clipboard, regions)
         return "noop"
 

--- a/core/commands/show_commit.py
+++ b/core/commands/show_commit.py
@@ -482,11 +482,13 @@ class GsShowCommitCopyCommitMessageHelper(EventListener):
             return None
 
         sel = frozen_sel[0]
-        if sel.empty():
-            return None
-
         if not view.match_selector(sel.begin(), "git-savvy.commit meta.commit_message"):
             return None
+
+        if sel.empty():
+            if not view.settings().get("copy_with_empty_selection"):
+                return None
+            sel = view.line(sel.a)
 
         selected_text = TextRange(view.substr(sel), *sel)
         by_line = [

--- a/core/parse_diff.py
+++ b/core/parse_diff.py
@@ -169,13 +169,13 @@ class TextRange:
         # type: () -> Region
         return Region(self.a, self.b)
 
-    def lines(self, _factory=None):
-        # type: (Type[TextRange]) -> List[TextRange]
-        factory = _factory or TextRange
+    def lines(self, factory=None, keepends=True):
+        # type: (Type[TextRange], bool) -> List[TextRange]
+        factory_ = factory or TextRange
         lines = self.text.splitlines(keepends=True)
         return [
-            factory(line, *a_b)
-            for line, a_b in zip(lines, pairwise(accumulate(map(len, lines), initial=self.a)))
+            factory_(line if keepends else line.rstrip("\n"), a)
+            for line, a in zip(lines, accumulate(map(len, lines), initial=self.a))
         ]
 
 
@@ -311,7 +311,7 @@ class HunkContent(TextRange):
     def lines(self):  # type: ignore
         # type: () -> List[HunkLine]
         factory = partial(HunkLine, mode_len=self.mode_len)
-        return super().lines(_factory=factory)  # type: ignore
+        return super().lines(factory=factory)  # type: ignore
 
 
 class Region(sublime.Region):


### PR DESCRIPTION
(This respects Sublime's `"copy_with_empty_selection"` setting.)