### PR TITLE
Tune commit selection (`[o]`) in the dashboard headers

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -476,7 +476,7 @@
         "command": "gs_interface_show_commit",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
-            { "key": "selector", "operand": "meta.git-savvy.summary-header constant.other.git-savvy.sha1" }
+            { "key": "selector", "operand": "meta.git-savvy.summary-header meta.git-savvy.commit-info" }
         ]
     },
     {

--- a/common/ui.py
+++ b/common/ui.py
@@ -645,8 +645,9 @@ class gs_interface_show_commit(TextCommand):
 
         for r in view.find_by_selector("constant.other.git-savvy.sha1"):
             for s in frozen_sel:
-                if r.a <= s.a <= r.b:
-                    window.run_command("gs_show_commit", {"commit_hash": view.substr(r)})
+                for line in view.lines(s):
+                    if line.a <= r.a < line.b:
+                        window.run_command("gs_show_commit", {"commit_hash": view.substr(r)})
 
 
 class EditView():

--- a/syntax/dashboard.sublime-syntax
+++ b/syntax/dashboard.sublime-syntax
@@ -46,12 +46,14 @@ contexts:
           captures:
             2: string.other.git-savvy.todo-item
 
-        - match: ^  (HEAD:)(?:\s+([0-9a-f]{7,40}) .+)?
+        - match: ^  (HEAD:)(?:\s+(([0-9a-f]{7,40}) (.+)))?
           comment: head summary
           scope: comment.git-savvy.summary-header.head-summary
           captures:
             1: comment.git-savvy.summary-header.title.head
-            2: constant.other.git-savvy.sha1
+            2: meta.git-savvy.commit-info
+            3: constant.other.git-savvy.sha1
+            4: comment.git-savvy.summary-header.commit-subject
 
         - match: ^\s{4,11}\x{200b} +(⋮)
           comment: line denoting we dropped some commits
@@ -66,18 +68,21 @@ contexts:
             1: punctuation.other.commit-decoration.git-savvy
             2: comment.git-savvy.summary-header.head-summary constant.other.git.branch.git-savvy
 
-        - match: ^\s{4,11}([0-9a-f]{7,40}) \x{200b}(.+)
+        - match: ^\s{4,11}(([0-9a-f]{7,40}) \x{200b}(.+))
           comment: stand-alone decoration line
           scope: comment.git-savvy.summary-header.head-summary
           captures:
-            1: constant.other.git-savvy.sha1
-            2: constant.other.git.branch.git-savvy
+            1: meta.git-savvy.commit-info
+            2: constant.other.git-savvy.sha1
+            3: constant.other.git.branch.git-savvy
 
-        - match: ^\s{4,11}(?:([0-9a-f]{7,40}) .+)?
+        - match: ^\s{4,11}(([0-9a-f]{7,40}) (.+))?
           comment: stand-alone commit line
           scope: comment.git-savvy.summary-header.head-summary
           captures:
-            1: constant.other.git-savvy.sha1
+            1: meta.git-savvy.commit-info
+            2: constant.other.git-savvy.sha1
+            3: comment.git-savvy.summary-header.commit-subject
 
     - match: "^  (#{3,})"
       comment: Key-bindings menu


### PR DESCRIPTION
Allow the cursor to be on the commit, from the sha to the end of that line.