### PR TITLE
Mark special remote branches in the graph

### DIFF
--- a/syntax/graph.sublime-syntax
+++ b/syntax/graph.sublime-syntax
@@ -102,6 +102,8 @@ contexts:
             2: punctuation.expression.dirty.git-savvy
         - match: (master|main|dev|trunk)\b
           scope: constant.other.git.branch.special.git-savvy gitsavvy.gotosymbol
+        - match: (origin/master|origin/main)\b
+          scope: constant.other.git.branch.special.remote.git-savvy gitsavvy.gotosymbol
         - match: (\d+)?([^ ,#/)]*)?/?(#?\d+)?([^ ,)]+)
           scope: constant.other.git.branch.git-savvy gitsavvy.gotosymbol
           captures:


### PR DESCRIPTION
As it is more and more common to work off the remote branches directly, mark them similar to how we marked the local branches "main" and "master".

This is opt-in as the user has to tweak their color scheme to support that.

The branch are tagged `constant.other.git.branch.special.remote.git-savvy`, the local special branches are tagged `constant.other.git.branch.special.git-savvy` (unchanged).