### PR TITLE
Bind `[S]` for "stage all" in the status dashboard

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -285,7 +285,15 @@
     /////////////////////////////
 
     {
-        "keys": ["a"],
+        "keys": ["S"],
+        "command": "gs_status_stage_all_files",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.status_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["a"],   // backwards compatibility
         "command": "gs_status_stage_all_files",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -179,7 +179,7 @@ class StatusInterface(ui.ReactiveInterface, GitCommand):
       ## SELECTED FILE ##                   ## ALL FILES ##
       ###################                   ###############
 
-      [o] open file                         [a] stage all unstaged files
+      [o] open file                         [S] stage all unstaged files
       [s] stage file                        [A] stage all unstaged and untracked files
       [u] unstage file                      [U] unstage all staged files
       [d] discard changes to file           [D] discard all unstaged changes
@@ -200,7 +200,7 @@ class StatusInterface(ui.ReactiveInterface, GitCommand):
       ## SELECTED COMMIT ##                 ## ALL FILES ##
       #####################                 ###############
 
-      [o] show commit                       [a] stage all unstaged files
+      [o] show commit                       [S] stage all unstaged files
                                             [A] stage all unstaged and untracked files
                                             [U] unstage all staged files
                                             [D] discard all unstaged changes


### PR DESCRIPTION
We use `[S]` everywhere else for this functionality. `[a]` is still available but not advertised in the help.