### PR TITLE
Switch help tooltips to a help panel

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -179,7 +179,7 @@
 
     {
         "keys": ["?"],
-        "command": "gs_inline_diff_help_tooltip",
+        "command": "gs_inline_diff_help_panel",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.inline_diff_view", "operator": "equal", "operand": true }
@@ -1010,7 +1010,7 @@
 
     {
         "keys": ["?"],
-        "command": "gs_diff_help_tooltip",
+        "command": "gs_diff_help_panel",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.diff_view", "operator": "equal", "operand": true }
@@ -1142,7 +1142,7 @@
     },
     {
         "keys": ["?"],
-        "command": "gs_show_commit_help_tooltip",
+        "command": "gs_show_commit_help_panel",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.show_commit_view", "operator": "equal", "operand": true }
@@ -1236,7 +1236,7 @@
     },
     {
         "keys": ["?"],
-        "command": "gs_show_file_at_commit_help_tooltip",
+        "command": "gs_show_file_at_commit_help_panel",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.show_file_at_commit_view", "operator": "equal", "operand": true }
@@ -1407,7 +1407,7 @@
     },
     {
         "keys": ["?"],
-        "command": "gs_blame_help_tooltip",
+        "command": "gs_blame_help_panel",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.blame_view", "operator": "equal", "operand": true }
@@ -1977,7 +1977,7 @@
 
     {
         "keys": ["?"],
-        "command": "gs_log_graph_help_tooltip",
+        "command": "gs_log_graph_help_panel",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.log_graph_view", "operator": "equal", "operand": true }
@@ -2175,7 +2175,7 @@
     },
     {
         "keys": ["?"],
-        "command": "gs_line_history_help_tooltip",
+        "command": "gs_line_history_help_panel",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.line_history_view", "operator": "equal", "operand": true }
@@ -2570,7 +2570,7 @@
     },
     {
         "keys": ["?"],
-        "command": "gs_stash_help_tooltip",
+        "command": "gs_stash_help_panel",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.stash_view", "operator": "equal", "operand": true }
@@ -2584,6 +2584,14 @@
         "command": "gs_github_open_issue_at_cursor",
         "context": [
             { "key": "selector", "operand": "meta.git-savvy.issue-reference" }
+        ]
+    },
+    {
+        "keys": ["?"],
+        "command": "hide_panel",
+        "context": [
+            { "key": "setting.command_mode", "operand": false },
+            { "key": "setting.git_savvy.help_view"}
         ]
     }
 ]

--- a/core/commands/__init__.py
+++ b/core/commands/__init__.py
@@ -1,4 +1,3 @@
-from ._help_popups import *
 from .amend import *
 from .blame import *
 from .branch import *
@@ -13,6 +12,7 @@ from .diff import *
 from .fetch import *
 from .fixup import *
 from .flow import *
+from .help_panel import *
 from .ignore import *
 from .init import *
 from .inline_diff import *

--- a/core/commands/show_commit_info.py
+++ b/core/commands/show_commit_info.py
@@ -38,6 +38,10 @@ def ensure_panel(window, name=PANEL_NAME, syntax="Packages/GitSavvy/syntax/show_
     return output_view
 
 
+def show_panel(window: sublime.Window, name: str = PANEL_NAME) -> None:
+    window.run_command("show_panel", {"panel": "output.{}".format(PANEL_NAME)})
+
+
 def panel_is_visible(window, name=PANEL_NAME):
     # type: (sublime.Window, str) -> bool
     return window.active_panel() == "output.{}".format(name)

--- a/syntax/help.sublime-settings
+++ b/syntax/help.sublime-settings
@@ -1,0 +1,22 @@
+{
+    // same on all syntaxes
+    "auto_indent": false,
+    "detect_indentation": false,
+    "draw_indent_guides": false,
+    "draw_white_space": "None",
+    "gutter": false,
+    "line_numbers": false,
+    "margin": 20,
+    "rulers": [],
+    "translate_tabs_to_spaces": false,
+    "word_wrap": false,
+
+    // syntax specific
+    "gutter": true,
+    "margin": -8,
+    "highlight_line": true,
+    "fold_buttons": false,
+    "fade_fold_buttons": false,
+    "match_brackets": false,
+    "match_tags": false
+}

--- a/syntax/help.sublime-syntax
+++ b/syntax/help.sublime-syntax
@@ -1,0 +1,48 @@
+%YAML 1.2
+---
+name: GitSavvy Help
+hidden: true
+scope: git-savvy.help
+contexts:
+  main:
+    - meta_scope: comment.git-savvy.key-bindings-menu
+    - match: '(##+) ([A-Z ]+)(?: (##+))?'
+      scope: meta.git-savvy.key-bindings-header
+      captures:
+        1: punctuation.definition.git-savvy.section
+        2: support.type.git-savvy.key-bindings-header-text
+        3: punctuation.definition.git-savvy.section
+
+    - match: "#{3,}"
+      scope: punctuation.definition.git-savvy.section
+
+    - match: '(\[)([A-Za-z\,\.\-\+\?]+)(\])'
+      scope: meta.git-savvy.key-bindings-key-stroke
+      captures:
+        1: punctuation.definition.git-savvy.key-bindings-key-stroke
+        2: constant.character.git-savvy-key-binding-key
+        3: punctuation.definition.git-savvy.key-bindings-key-stroke
+      push:
+        - match: (?=\[|`|$)
+          pop: true
+        - match: \s+([\w\s,\(\)]+)
+          captures:
+            1: comment.git-savvy.key-bindings-menu.key-binding-description
+
+    - match: '(`)(.+)(`)'
+      scope: meta.git-savvy.key-bindings-key-stroke
+      captures:
+        0: constant.character.tag.git-savvy-key-binding-key
+        1: punctuation.definition.git-savvy.key-bindings-key-stroke
+        2: constant.character.git-savvy-key-binding-key
+        3: punctuation.definition.git-savvy.key-bindings-key-stroke
+
+    - match: '(\*\*) ([^\*]+) (\*\*)'
+      comment: ux note
+      scope: support.type.git-savvy.ux-note
+      captures:
+        1: punctuation.definition.git-savvy.note
+        2: support.type.git-savvy.ux-note.text
+        3: punctuation.definition.git-savvy.note
+
+


### PR DESCRIPTION
I never liked the tooltips because they disappear immediately and I usually forget the shortcut when they do.  So I have to open them again, ... and so forth.  

Just make them a help panel at the bottom.  This could be expanded to a context based help too in the future.