### PR TITLE
Fancy `[M]` and `[m]` in the graph and commit view

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1149,6 +1149,15 @@
         ]
     },
     {
+        "keys": ["m"],
+        "command": "gs_log_graph_toggle_commit_info_panel",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.show_commit_view", "operator": "equal", "operand": true },
+            { "key": "panel_has_focus" }
+        ]
+    },
+    {
         "keys": ["?"],
         "command": "gs_show_commit_help_panel",
         "context": [

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1848,7 +1848,7 @@
     },
     {
         "keys": ["m"],
-        "command": "gs_log_graph_toggle_more_info",
+        "command": "gs_log_graph_toggle_commit_info_panel",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.log_graph_view", "operator": "equal", "operand": true }

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1855,6 +1855,15 @@
         ]
     },
     {
+        "keys": ["M"],
+        "command": "gs_log_graph_show_and_focus_panel",
+        "args": {"panel": "show_commit_info"},
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.log_graph_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
         "keys": ["a"],
         "command": "gs_log_graph_toggle_all_setting",
         "context": [

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1152,9 +1152,36 @@
         "keys": ["m"],
         "command": "gs_log_graph_toggle_commit_info_panel",
         "context": [
-            { "key": "setting.command_mode", "operator": "equal", "operand": false },
-            { "key": "setting.git_savvy.show_commit_view", "operator": "equal", "operand": true },
-            { "key": "panel_has_focus" }
+            { "key": "setting.command_mode", "operand": false },
+            { "key": "setting.git_savvy.show_commit_view" },
+            { "key": "panel_has_focus" }                     // ==is panel
+        ]
+    },
+    {
+        "keys": ["M"],
+        "command": "gs_show_commit_info_maximize_panel",
+        "context": [
+            { "key": "setting.command_mode", "operand": false },
+            { "key": "setting.git_savvy.show_commit_view" },
+            { "key": "panel_has_focus" }                     // ==is panel
+        ]
+    },
+    {
+        "keys": ["M"],
+        "command": "gs_show_commit_info_minimize_view",
+        "context": [
+            { "key": "setting.command_mode", "operand": false },
+            { "key": "setting.git_savvy.show_commit_view" },
+            { "key": "panel_has_focus", "operand": false }   // ==is full view
+        ]
+    },
+    {
+        "keys": ["m"],
+        "command": "gs_show_commit_info_minimize_view",
+        "context": [
+            { "key": "setting.command_mode", "operand": false },
+            { "key": "setting.git_savvy.show_commit_view" },
+            { "key": "panel_has_focus", "operand": false }   // ==is full view
         ]
     },
     {

--- a/core/commands/help_panel.py
+++ b/core/commands/help_panel.py
@@ -213,6 +213,8 @@ class gs_show_commit_help_panel(GsAbstractOpenHelpPanel):
     ### Other ###
     [w]            ignore white space
     [?]            show this help popup
+    [M]            toggle between a full view and a panel
+    [m]            minimize to a panel, or close if already minimized
     [{cr}-,]       Change Settings for current syntax
     """)
 

--- a/core/commands/help_panel.py
+++ b/core/commands/help_panel.py
@@ -237,7 +237,7 @@ class gs_log_graph_help_panel(GsAbstractOpenHelpPanel):
     key_bindings = dedent("""\
     [enter]        open main menu with additional commands
     [o]            open commit in a new view; on `#issues`, open a browser
-    [m]            toggle commit details panel on the bottom
+    [m]/[M]        toggle commit panel on the bottom, [M] to also focus the panel
     [{cr}+C]       copy commit's hash, subject or a combination to the clipboard
 
     [s]            toggle to overview mode

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -75,7 +75,7 @@ __all__ = (
     "gs_log_graph_edit_files",
     "gs_log_graph_toggle_all_setting",
     "gs_log_graph_open_commit",
-    "gs_log_graph_toggle_more_info",
+    "gs_log_graph_toggle_commit_info_panel",
     "gs_log_graph_action",
     "GsLogGraphCursorListener",
 )
@@ -2656,7 +2656,7 @@ def extract_commit_hash(line):
     return match.group('commit_hash') if match else ""
 
 
-class gs_log_graph_toggle_more_info(WindowCommand, GitCommand):
+class gs_log_graph_toggle_commit_info_panel(WindowCommand, GitCommand):
 
     """
     Toggle commit info output panel.

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -2658,11 +2658,7 @@ def extract_commit_hash(line):
 
 
 class gs_log_graph_toggle_commit_info_panel(WindowCommand, GitCommand):
-
-    """
-    Toggle commit info output panel.
-    """
-
+    """ Toggle commit info output panel."""
     def run(self):
         if show_commit_info.panel_is_visible(self.window):
             self.window.run_command("hide_panel", {"panel": "output.show_commit_info"})

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -76,6 +76,7 @@ __all__ = (
     "gs_log_graph_toggle_all_setting",
     "gs_log_graph_open_commit",
     "gs_log_graph_toggle_commit_info_panel",
+    "gs_log_graph_show_and_focus_panel",
     "gs_log_graph_action",
     "GsLogGraphCursorListener",
 )
@@ -2667,6 +2668,18 @@ class gs_log_graph_toggle_commit_info_panel(WindowCommand, GitCommand):
             self.window.run_command("hide_panel", {"panel": "output.show_commit_info"})
         else:
             self.window.run_command("show_panel", {"panel": "output.show_commit_info"})
+
+
+class gs_log_graph_show_and_focus_panel(WindowCommand, GitCommand):
+    def run(self, panel: str) -> None:
+        if self.window.active_panel() != f"output.{panel}":
+            self.window.run_command("show_panel", {"panel": f"output.{panel}"})
+
+        panel_view = self.window.find_output_panel(panel)
+        if not panel_view:
+            return
+
+        self.window.focus_view(panel_view)
 
 
 class LineInfo(TypedDict, total=False):

--- a/tests/test_graph_view.py
+++ b/tests/test_graph_view.py
@@ -197,7 +197,7 @@ class TestGraphViewInteractionWithCommitInfoPanel(DeferrableTestCase):
     def test_if_the_user_issues_our_toggle_command_open_the_panel(self):
         yield from self.setup_graph_view_async(show_commit_info_setting=False)
 
-        self.window.run_command('gs_log_graph_toggle_more_info')
+        self.window.run_command('gs_log_graph_toggle_commit_info_panel')
         yield from self.await_active_panel_to_be('output.show_commit_info')
 
         actual = self.window.active_panel()
@@ -234,7 +234,7 @@ class TestGraphViewInteractionWithCommitInfoPanel(DeferrableTestCase):
     def test_if_the_user_issues_our_toggle_command_close_the_panel_and_keep_it(self):
         log_view = yield from self.setup_graph_view_async()
 
-        self.window.run_command('gs_log_graph_toggle_more_info')
+        self.window.run_command('gs_log_graph_toggle_commit_info_panel')
         actual = self.window.active_panel()
         expected = None
         self.assertEqual(actual, expected)
@@ -281,13 +281,13 @@ class TestGraphViewInteractionWithCommitInfoPanel(DeferrableTestCase):
         log_view = yield from self.setup_graph_view_async()
         panel = self.window.find_output_panel('show_commit_info')
         # close panel
-        self.window.run_command('gs_log_graph_toggle_more_info')
+        self.window.run_command('gs_log_graph_toggle_commit_info_panel')
 
         # move around
         navigate_to_symbol(log_view, 'f461ea1')
 
         # show panel
-        self.window.run_command('gs_log_graph_toggle_more_info')
+        self.window.run_command('gs_log_graph_toggle_commit_info_panel')
 
         yield from self.await_string_in_view(panel, COMMIT_2)
 
@@ -295,7 +295,7 @@ class TestGraphViewInteractionWithCommitInfoPanel(DeferrableTestCase):
         log_view = yield from self.setup_graph_view_async()
         panel = self.window.find_output_panel('show_commit_info')
         # close panel
-        self.window.run_command('gs_log_graph_toggle_more_info')
+        self.window.run_command('gs_log_graph_toggle_commit_info_panel')
 
         # move around
         navigate_to_symbol(log_view, 'f461ea1')


### PR DESCRIPTION
Generally we show commits/patches in the panel at the bottom or in a separate view.  (Basically, `m` and `o` when in the graph view.

Let's make that fluid:  In the graph, `m` to toggle the panel (as before), but `M` to open the panel and put the cursor in it.  While in the panel `M` to maximize that to a full view and back.  `m` to close the panel again. 