### PR TITLE
Teach diff view to handle untracked files

### DIFF
--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -1290,7 +1290,8 @@ class gs_diff_undo(TextCommand, GitCommand):
 
     # NOTE: Blocking because `set_and_show_cursor` must run within a `TextCommand`
     def run(self, edit):
-        history = self.view.settings().get("git_savvy.diff_view.history")
+        settings = self.view.settings()
+        history = settings.get("git_savvy.diff_view.history")
         if not history:
             flash(self.view, "Undo stack is empty")
             return
@@ -1308,18 +1309,18 @@ class gs_diff_undo(TextCommand, GitCommand):
             args[1] = "-R" if not args[1] else None
             self.git(*args, stdin=stdin)
 
-        self.view.settings().set("git_savvy.diff_view.history", history)
-        self.view.settings().set("git_savvy.diff_view.just_hunked", stdin)
+        settings.set("git_savvy.diff_view.history", history)
+        settings.set("git_savvy.diff_view.just_hunked", stdin)
 
-        if self.view.settings().get("git_savvy.commit_view"):
+        if settings.get("git_savvy.commit_view"):
             self.view.run_command("gs_prepare_commit_refresh_diff")
         else:
             self.view.run_command("gs_diff_refresh")
 
         # The cursor is only applicable if we're still in the same cache/stage mode
         if (
-            self.view.settings().get("git_savvy.diff_view.in_cached_mode") == in_cached_mode
-            or self.view.settings().get("git_savvy.commit_view")
+            settings.get("git_savvy.diff_view.in_cached_mode") == in_cached_mode
+            or settings.get("git_savvy.commit_view")
         ):
             set_and_show_cursor(self.view, cursors)
 

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -562,9 +562,6 @@ class gs_status_diff(StatusInterfaceCommand):
 
     def load_diff_windows(self, window, non_cached_files, cached_files, untracked_files):
         # type: (sublime.Window, List[str], List[str], List[str]) -> None
-        if untracked_files:
-            self.intent_to_add(*untracked_files)
-
         for fpath in non_cached_files + untracked_files:
             window.run_command("gs_diff", {
                 "file_path": fpath,


### PR DESCRIPTION
Just having "UNTRACKED" in the header is lame, temporarily run
`intent_to_add` on that file, and read the diff again. That is mildly easy.

Staging (and undoing that) actually is more code.  Ensure that the status 
view does not intent-to-add untracked files too (which was esp. annoying.)