### PR TITLE
Redesign the files panel in the diff view

### DIFF
--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -548,13 +548,15 @@ class gs_diff_switch_files(TextCommand, GitCommand):
         # type: (sublime.Edit, bool, bool, Optional[bool]) -> None
         view = self.view
         window = view.window()
-        if not window:
-            return
+        assert window
+
         if view.element() == "quick_panel:input":
             if av := window.active_view():
                 av.settings().set("gs_diff.intentional_hide", True)
                 window.run_command("hide_overlay")
-                av.run_command("gs_diff_switch_files", {"recursed": True, "auto_close": auto_close, "forward": forward})
+                av.run_command("gs_diff_switch_files", {
+                    "recursed": True, "auto_close": auto_close, "forward": forward
+                })
             return
 
         AUTO_CLOSE_AFTER = 1000  # [ms]

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -507,10 +507,9 @@ class gs_diff_toggle_cached_mode(TextCommand):
         last_cursors = settings.get('git_savvy.diff_view.last_cursors') or []
         settings.set('git_savvy.diff_view.last_cursors', pickle_sel(self.view.sel()))
 
-        setting_str = "git_savvy.diff_view.{}".format('in_cached_mode')
-        current_mode = settings.get(setting_str)
+        current_mode = settings.get("git_savvy.diff_view.in_cached_mode")
         next_mode = not current_mode
-        settings.set(setting_str, next_mode)
+        settings.set("git_savvy.diff_view.in_cached_mode", next_mode)
         flash(self.view, "Showing {} changes".format("staged" if next_mode else "unstaged"))
 
         # `gs_diff_refresh` may call us (`gs_diff_toggle_cached_mode`) if

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -1365,6 +1365,10 @@ class gs_diff_navigate(GsNavigate):
         def _gen():
             # type: () -> Iterator[sublime.Region]
             diff = SplittedDiff.from_view(self.view)
+            if not diff.hunks:
+                for header in diff.headers:
+                    yield sublime.Region(header.region().a)
+
             for hunk in diff.hunks:
                 yield sublime.Region(hunk.region().a)
                 chunks = list(chunkby(hunk.content().lines(), lambda line: not line.is_context()))


### PR DESCRIPTION
The goal is esp. to optimize `[N]` and `[P]` after staging:

When a user staged a file, GitSavvy will switch to "staged" mode as soon
as the diff gets clean.  This is implemented, a) to actually see what's
gonna be committed and b) e.g. to issue "Line History" directly to
select a commit to fixup.

Unfortunately this broke `gs_diff_switch_files` intuitive UX.  As we
switched to the staged mode, a subsequent `N` could not select a useful
*next* file to continue staging.

This commit fixes that.  The intended UX is, e.g.
    `[S]` to stage a file, followed by
    `[N]` to switch to the next _unstaged_ file.