### PR TITLE
Support dired views

### DIFF
--- a/core/git_command.py
+++ b/core/git_command.py
@@ -652,6 +652,12 @@ class _GitCommand(SettingsMixin):
             if file_name:
                 yield os.path.dirname(file_name)
 
+            # Support https://packagecontrol.io/packages/dired or the compatible
+            # https://packagecontrol.io/packages/FileBrowser
+            if view := self._current_view():
+                if dired_path := view.settings().get("dired_path"):
+                    yield dired_path
+
             window = self._current_window()
             if window:
                 folders = window.folders()


### PR DESCRIPTION
"dired" views are directory views from the "FileBrowser" or (original) "dired" package.

Use the shown path to find a suitable git path.  This, for example, allows directly switching to a dahboard view.