### PR TITLE
Add setting `fetch_new_remotes: true`

### DIFF
--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -291,6 +291,11 @@
     "confirm_force_push": true,
 
     /*
+        When set to `true`, GitSavvy will fetch newly added remotes automatically.
+     */
+    "fetch_new_remotes": true,
+
+    /*
         When set to `true`, closing the commit message window via keyboard will result
         in a commit action being taken, except in cases where the message is empty.
         The same is also true for amending commits.

--- a/core/commands/remote.py
+++ b/core/commands/remote.py
@@ -43,7 +43,7 @@ class gs_remote_add(GsWindowCommand):
             run_on_new_thread(self.git, "config", "--local", "gitsavvy.pushdefault", remote_name)
             self.update_store({"last_remote_used_for_push": remote_name})
 
-        if sublime.ok_cancel_dialog(
+        if self.savvy_settings.get("fetch_new_remotes", True) or sublime.ok_cancel_dialog(
             "Your remote was added successfully.  "
             "Would you like to fetch from this remote?"
         ):


### PR DESCRIPTION
When adding remotes, we always asked if we should now also fetch this remote.  Add "fetch_new_remotes" and just fetch without asking if set to `True`.

This is also the default because frankly you likely want that.  (Except for huge repos, but then set this in the project settings, no?)