### PR TITLE
Iterate on "Rename Remote"

### DIFF
--- a/core/commands/remote.py
+++ b/core/commands/remote.py
@@ -77,6 +77,10 @@ class gs_remote_rename(GsWindowCommand):
         show_single_line_input_panel("New name", remote, self.on_enter_name)
 
     def on_enter_name(self, new_name):
+        if not new_name:
+            return
+        if new_name == self.remote:
+            return
         self.git("remote", "rename", self.remote, new_name)
         self.window.status_message("remote {} was renamed as {}.".format(self.remote, new_name))
         util.view.refresh_gitsavvy_interfaces(self.window, refresh_status_bar=False)


### PR DESCRIPTION
Before this change it says e.g. "Remote name: origin".  So, it is not
clear if it just confirms the selected origin as the remote we want
to rename, or if we should enter the new name *for* origin now.

Make that clear.

Also abort if no new name is provided.