### PR TITLE
Remove special "author" handling

### DIFF
--- a/core/commands/log_graph_rebase_actions.py
+++ b/core/commands/log_graph_rebase_actions.py
@@ -570,7 +570,6 @@ def set_filters(view: sublime.View, new_filters: str) -> None:
     if not settings.get("git_savvy.log_graph_view.apply_filters"):
         settings.set("git_savvy.log_graph_view.apply_filters", True)
         settings.set("git_savvy.log_graph_view.paths", [])
-        settings.set("git_savvy.log_graph_view.filter_by_author", "")
 
 
 class gs_log_graph_add_previous_tip(GsTextCommand):


### PR DESCRIPTION
Probably because of fear, we still had special handling for the "author" constraint, e.g. `filter_by_author`.

(a) But when set, the prelude didn't show it.
(b) The edit filter feature explicitly has the author filtering in its help.

Just remove that and use `filters`.  This way,we have it in the prelude, can edit it with `f` and toggle it with `F`.  Users can still access it from outside as "filters" is exposed in the `gs_graph` constructor.

Win-win?  No compatibility mode included, users must adjust their custom commands.