### PR TITLE
Add multi selection feature

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -492,7 +492,7 @@
         "command": "gs_interface_show_commit",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
-            { "key": "selector", "operand": "meta.git-savvy.summary-header meta.git-savvy.commit-info" }
+            { "key": "selector", "operand": "meta.git-savvy.summary-header comment.git-savvy.summary-header.head-summary" }
         ]
     },
     {

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -191,6 +191,22 @@
     /////////////////////////////////
 
     {
+        "keys": [" "],
+        "command": "gs_dashboard_multiselect",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.status_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["ctrl+space"],
+        "command": "gs_clear_multiselect",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.status_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
         "keys": ["o"],
         "command": "gs_status_open_file",
         "context": [
@@ -1522,6 +1538,22 @@
     ///////////////
 
     {
+        "keys": [" "],
+        "command": "gs_dashboard_multiselect",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.tags_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["ctrl+space"],
+        "command": "gs_clear_multiselect",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.tags_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
         "keys": ["?"],
         "command": "gs_interface_toggle_help",
         "context": [
@@ -1684,6 +1716,22 @@
     // BRANCHES VIEW //
     ///////////////////
 
+    {
+        "keys": [" "],
+        "command": "gs_dashboard_multiselect",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.branch_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["ctrl+space"],
+        "command": "gs_clear_multiselect",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.branch_view", "operator": "equal", "operand": true }
+        ]
+    },
     {
         "keys": ["c"],
         "command": "gs_branches_checkout",

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -785,6 +785,22 @@
     ///////////////
 
     {
+        "keys": [" "],
+        "command": "gs_diff_multiselect",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.diff_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["ctrl+space"],
+        "command": "gs_clear_multiselect",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.diff_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
         "keys": ["h"],
         "command": "gs_diff_stage_or_reset_hunk",
         "context": [

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -717,6 +717,24 @@
         ]
     },
     {
+        "keys": [" "],
+        "command": "gs_diff_multiselect",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.commit_view", "operator": "equal", "operand": true },
+            { "key": "selector", "operand": "git-savvy.make-commit meta.dropped.git.commit" }
+        ]
+    },
+    {
+        "keys": ["ctrl+space"],
+        "command": "gs_clear_multiselect",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.commit_view", "operator": "equal", "operand": true },
+            { "key": "selector", "operand": "git-savvy.make-commit meta.dropped.git.commit" }
+        ]
+    },
+    {
         "keys": ["u"],
         "command": "gs_diff_stage_or_reset_hunk",
         "context": [

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1894,6 +1894,22 @@
     ////////////////
 
     {
+        "keys": [" "],
+        "command": "gs_log_graph_multiselect",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.log_graph_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["ctrl+space"],
+        "command": "gs_clear_multiselect",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.log_graph_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
         "keys": ["enter"],
         "command": "gs_log_graph_action",
         "context": [

--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -110,6 +110,10 @@
         "commit": {
             "multiselect_foreground": "#0af",
             "multiselect_background": "#0af1"
+        },
+        "dashboard": {
+            "multiselect_foreground": "#0af",
+            "multiselect_background": "#0af1"
         }
     },
 

--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -102,6 +102,10 @@
             "matching_commit_background": "#199",
             "multiselect_foreground": "#0aa",
             "multiselect_background": "#0aa1"
+        },
+        "diff": {
+            "multiselect_foreground": "#0af",
+            "multiselect_background": "#0af1"
         }
     },
 

--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -99,7 +99,9 @@
             "path_above_foreground": "#19d",
             "path_above_background": "#99991109",
             "matching_commit_foreground": "#1991",
-            "matching_commit_background": "#199"
+            "matching_commit_background": "#199",
+            "multiselect_foreground": "#0aa",
+            "multiselect_background": "#0aa1"
         }
     },
 

--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -106,6 +106,10 @@
         "diff": {
             "multiselect_foreground": "#0af",
             "multiselect_background": "#0af1"
+        },
+        "commit": {
+            "multiselect_foreground": "#0af",
+            "multiselect_background": "#0af1"
         }
     },
 

--- a/core/commands/__init__.py
+++ b/core/commands/__init__.py
@@ -23,6 +23,7 @@ from .log_graph import *
 from .log_graph_rebase_actions import *
 from .log_graph_smart_copy import *
 from .merge import *
+from .multi_selector import *
 from .mv import *
 from .navigate import *
 from .next_hunk import *

--- a/core/commands/help_panel.py
+++ b/core/commands/help_panel.py
@@ -178,6 +178,7 @@ class gs_diff_help_panel(GsAbstractOpenHelpPanel):
     [tab]          switch between staged/unstaged area
     [s]/[u]/[d]    stage, unstage, or discard hunk or selection
     [S]/[U]/[D]    stage, unstage, or discard complete file
+    [space]        select line or hunk; [{cr}+space] to clear the selection
     [{cr}-z]       undo last action
 
     [c]/[C]        commit ([C] to include unstaged)
@@ -238,6 +239,7 @@ class gs_show_file_at_commit_help_panel(GsAbstractOpenHelpPanel):
 class gs_log_graph_help_panel(GsAbstractOpenHelpPanel):
     key_bindings = dedent("""\
     [enter]        open main menu with additional commands
+    [space]        select commit; [{cr}+space] to clear the selection
     [o]            open commit in a new view; on `#issues`, open a browser
     [m]/[M]        toggle commit panel on the bottom, [M] to also focus the panel
     [{cr}+C]       copy commit's hash, subject or a combination to the clipboard

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -17,7 +17,9 @@ from typing import NamedTuple
 import sublime
 from sublime_plugin import WindowCommand, TextCommand, EventListener
 
-from . import log_graph_colorizer as colorizer, show_commit_info
+from . import log_graph_colorizer as colorizer
+from . import multi_selector
+from . import show_commit_info
 from .log import gs_log
 from .. import utils
 from ..base_commands import GsTextCommand
@@ -323,6 +325,12 @@ def augment_color_scheme(view):
         MATCHING_COMMIT_SCOPE,
         background=colors['matching_commit_background'],
         foreground=colors['matching_commit_foreground'],
+    )
+    themeGenerator.add_scoped_style(
+        "GitSavvy Multiselect Marker",
+        multi_selector.MULTISELECT_SCOPE,
+        background=colors['multiselect_foreground'],
+        foreground=colors['multiselect_background'],
     )
     themeGenerator.apply_new_theme("log_graph_view", view)
 
@@ -2811,7 +2819,7 @@ class gs_log_graph_action(WindowCommand, GitCommand):
             describe_graph_line(line, branches)
             for line in unique(
                 view.substr(line)
-                for s in view.sel()
+                for s in multi_selector.get_selection(view)
                 for line in view.lines(s)
             )
         ))

--- a/core/commands/log_graph_rebase_actions.py
+++ b/core/commands/log_graph_rebase_actions.py
@@ -18,6 +18,7 @@ from GitSavvy.core.runtime import on_new_thread, run_on_new_thread, throttled
 from GitSavvy.core.ui_mixins.input_panel import show_single_line_input_panel
 from GitSavvy.core.utils import flash, noop, show_actions_panel, yes_no_switch, SEPARATOR
 from GitSavvy.core.view import replace_view_content
+from . import multi_selector
 
 
 __all__ = (
@@ -217,7 +218,7 @@ class gs_rebase_action(GsWindowCommand):
             log_graph.describe_graph_line(line, known_branches={})
             for line in unique(
                 view.substr(line)
-                for s in view.sel()
+                for s in multi_selector.get_selection(view)
                 for line in view.lines(s)
             )
         ))

--- a/core/commands/multi_selector.py
+++ b/core/commands/multi_selector.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+from itertools import starmap
+from . import log_graph
+
+from typing import Iterable
+from typing_extensions import TypeAlias
+
+import sublime
+from sublime_plugin import TextCommand
+
+
+__all__ = (
+    "gs_log_graph_multiselect",
+    "gs_clear_multiselect",
+)
+
+
+# Should be `tuple[int, int]` but Sublime serializes tuples to a list
+Region: TypeAlias = "list[int]"
+
+
+def get_selection(view: sublime.View) -> Iterable[sublime.Region]:
+    multi_selection: list[Region] = view.settings().get("git_savvy.multi_selection", [])
+    return (
+        sorted(starmap(sublime.Region, multi_selection))
+        if multi_selection
+        else view.sel()
+    )
+
+
+class gs_log_graph_multiselect(TextCommand):
+    def run(self, edit) -> None:
+        view = self.view
+        frozen_sel = list(view.sel())
+
+        multi_selection: list[Region] = view.settings().get("git_savvy.multi_selection", [])
+
+        regions = multi_selection[:]
+        for s in frozen_sel:
+            line_spans = view.lines(s)
+            for line_span in line_spans:
+                line_text = view.substr(line_span)
+                match = log_graph.COMMIT_LINE.search(line_text)
+                if match:
+                    # a, _ = match.span('dot')
+                    b, c = match.span('commit_hash')
+                    wanted = [line_span.a + b, line_span.a + c]
+                    if wanted in multi_selection:
+                        if wanted in regions:
+                            regions.remove(wanted)
+                    else:
+                        regions.append(wanted)
+
+        view.settings().set("git_savvy.multi_selection", regions)
+        set_multiselect_markers(view, list(starmap(sublime.Region, regions)))
+
+        view.sel().clear()
+        view.sel().add_all([sublime.Region(frozen_sel[-1].b)])
+        if (
+            len(frozen_sel) == 1
+            and frozen_sel[0].empty()
+            and any(r not in multi_selection for r in regions)
+        ):
+            view.run_command("gs_log_graph_navigate", {"natural_movement": True})
+
+
+class gs_clear_multiselect(TextCommand):
+    def run(self, edit) -> None:
+        view = self.view
+        view.settings().set("git_savvy.multi_selection", [])
+        set_multiselect_markers(view, [])
+
+
+MULTISELECT_SCOPE = 'git_savvy.multiselect'
+DEFAULT_STYLE = {"scope": MULTISELECT_SCOPE, "flags": "fill"}
+BASE_FLAGS = sublime.DRAW_EMPTY | sublime.PERSISTENT | sublime.RegionFlags.NO_UNDO
+STYLES = {
+    "fill": BASE_FLAGS,
+    "outline": BASE_FLAGS | sublime.DRAW_NO_FILL,
+    "hidden": sublime.HIDDEN | sublime.PERSISTENT | sublime.RegionFlags.NO_UNDO,
+}
+REGION_KEY = "git_savvy.multiselect"
+
+
+def set_multiselect_markers(view, regions: list[sublime.Region], styles=DEFAULT_STYLE):
+    if regions:
+        if isinstance(styles["flags"], str):
+            try:
+                styles["flags"] = STYLES[styles["flags"]]
+            except LookupError:
+                styles["flags"] = STYLES["hidden"]
+
+        view.add_regions(REGION_KEY, regions, **styles)
+        regions_count = len(regions)
+        s = "" if regions_count == 1 else "s"
+        view.set_status("gs_multiselect_info", f"{regions_count} saved selection{s}")
+    else:
+        view.erase_regions(REGION_KEY)
+        view.erase_status("gs_multiselect_info")

--- a/core/commands/multi_selector.py
+++ b/core/commands/multi_selector.py
@@ -137,14 +137,24 @@ REGION_KEY = "git_savvy.multiselect"
 
 def set_multiselect_markers(view, regions: list[sublime.Region], styles=DEFAULT_STYLE):
     if regions:
+        # Combine adjacent `regions` to `regions_`
+        regions_: list[sublime.Region] = []
+        for r in sorted(regions):
+            if not regions_:
+                regions_.append(r)
+            elif (r.a - regions_[-1].b) in (0, 1):
+                regions_[-1].b = r.b
+            else:
+                regions_.append(r)
+
         if isinstance(styles["flags"], str):
             try:
                 styles["flags"] = STYLES[styles["flags"]]
             except LookupError:
                 styles["flags"] = STYLES["hidden"]
 
-        view.add_regions(REGION_KEY, regions, **styles)
-        regions_count = len(regions)
+        view.add_regions(REGION_KEY, regions_, **styles)
+        regions_count = len(regions_)
         s = "" if regions_count == 1 else "s"
         view.set_status("gs_multiselect_info", f"{regions_count} saved selection{s}")
     else:

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -108,6 +108,9 @@ class BranchInterface(ui.ReactiveInterface, GitCommand):
       [H] diff history against active               [g] show branch log graph
       [E] edit branch description
 
+      [space] to select multiple items
+      [ctrl-space] to clear selection
+
       [e]         toggle display of remote branches
       [tab]       transition to next dashboard
       [SHIFT-tab] transition to previous dashboard

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -113,7 +113,7 @@ class BranchInterface(ui.ReactiveInterface, GitCommand):
 
       [e]         toggle display of remote branches
       [tab]       transition to next dashboard
-      [SHIFT-tab] transition to previous dashboard
+      [shift-tab] transition to previous dashboard
       [r]         refresh
       [?]         toggle this help menu
 

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -169,7 +169,7 @@ class StatusInterface(ui.ReactiveInterface, GitCommand):
       [G]         show overview of branches and tags
       [?]         toggle this help menu
       [tab]       transition to next dashboard
-      [SHIFT-tab] transition to previous dashboard
+      [shift-tab] transition to previous dashboard
       [.]         move cursor to next file
       [,]         move cursor to previous file
     {conflicts_bindings}

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -190,6 +190,9 @@ class StatusInterface(ui.ReactiveInterface, GitCommand):
 
       [l] diff file inline                  [f] diff all files
       [e] diff file                         [F] diff all cached files
+
+      [space] to select multiple items
+      [ctrl-space] to clear selection
     """ + _template_help
 
     template_help_on_added = template_help.replace(
@@ -211,6 +214,9 @@ class StatusInterface(ui.ReactiveInterface, GitCommand):
 
                                             [f] diff all files
                                             [F] diff all cached files
+
+      [space] to select multiple items
+      [ctrl-space] to clear selection
     """ + _template_help
 
     conflicts_keybindings = ui.indent_by_2("""

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -124,6 +124,9 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
       [o] show commit
       [g] show log graph
 
+      [space] to select multiple items
+      [ctrl-space] to clear selection
+
     -
     """
 

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -120,7 +120,7 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
       [s] create smart tag            [?]         toggle this help menu
       [d] delete                      [e]         toggle display of remote branches
       [p] push to remote              [tab]       transition to next dashboard
-                                      [SHIFT-tab] transition to previous dashboard
+                                      [shift-tab] transition to previous dashboard
       [o] show commit
       [g] show log graph
 


### PR DESCRIPTION
That is huge.  Bind `<space>` to select an item, e.g. a commit in the graph, or a line or hunk in the diff.  Do this multiple times to form a multi selection just with the keyboard, and then do the action as always.  

Implemented for the diff, the graph, and the dashboards.

![image](https://github.com/user-attachments/assets/bfec1666-1c5a-438a-aa32-5cdcd70c2a79)

![image](https://github.com/user-attachments/assets/d935fb15-f3c2-41a9-81d4-e3cbc8bcb263)

![image](https://github.com/user-attachments/assets/8d2d0d91-64fc-4156-9dac-c4e4d518c87c)

