### PR TITLE
Follow renames more consistently 

### DIFF
--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -278,11 +278,6 @@
     "log_follow_rename": false,
 
     /*
-        When set to `true`, GitSavvy will follow file renames in blame view
-    */
-    "blame_follow_rename": false,
-
-    /*
         Set it to "file", "commit" or "all_commits" to specify the default detection
         method for the blame view.
     */

--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -275,7 +275,7 @@
     /*
         When set to `true`, GitSavvy will follow file renames when running git log/graph
     */
-    "log_follow_rename": false,
+    "log_follow_rename": true,
 
     /*
         Set it to "file", "commit" or "all_commits" to specify the default detection

--- a/core/commands/blame.py
+++ b/core/commands/blame.py
@@ -161,11 +161,6 @@ class gs_blame_current_file(LogMixin, BlameMixin):
     def selected_index(self, commit_hash):
         return self._commit_hash and commit_hash.startswith(self._commit_hash)
 
-    def log(self, **kwargs):  # type: ignore[override]
-        follow = self.savvy_settings.get("blame_follow_rename")
-        kwargs["follow"] = follow
-        return super().log(**kwargs)
-
 
 class gs_blame_refresh(BlameMixin):
     _highlighted_count = 0  # to be implemented
@@ -226,7 +221,7 @@ class gs_blame_refresh(BlameMixin):
                 scroll_to_pt(self.view, self.view.sel()[0].begin(), yoffset)
 
     def get_content(self, file_path, ignore_whitespace=False, detect_options=None, commit_hash=None):
-        if commit_hash and self.savvy_settings.get("blame_follow_rename"):
+        if commit_hash:
             filename_at_commit = self.filename_at_commit(file_path, commit_hash)
         else:
             filename_at_commit = file_path
@@ -402,8 +397,6 @@ class gs_blame_action(BlameMixin, PanelActionMixin):
         self.window.run_command("gs_show_commit", {"commit_hash": commit_hash})
 
     def blame_neighbor(self, position, selected=False):
-        follow = self.savvy_settings.get("blame_follow_rename")
-
         if position == "newer" and selected:
             raise Exception("blame a commit after selected commit is confusing")
 
@@ -415,7 +408,7 @@ class gs_blame_action(BlameMixin, PanelActionMixin):
 
         assert self.file_path
         if position == "older":
-            neighbor_hash = self.previous_commit(commit_hash, self.file_path, follow)
+            neighbor_hash = self.previous_commit(commit_hash, self.file_path, follow=True)
             if not neighbor_hash:
                 self.window.status_message("Already on the oldest revision.")
                 return
@@ -424,7 +417,7 @@ class gs_blame_action(BlameMixin, PanelActionMixin):
             if not commit_hash:
                 self.window.status_message("Already showing the workdir state.")
                 return
-            neighbor_hash = self.next_commit(commit_hash, self.file_path, follow)
+            neighbor_hash = self.next_commit(commit_hash, self.file_path, follow=True)
 
         if commit_hash == neighbor_hash:
             return

--- a/core/commands/blame.py
+++ b/core/commands/blame.py
@@ -222,13 +222,11 @@ class gs_blame_refresh(BlameMixin):
 
     def get_content(self, file_path, ignore_whitespace=False, detect_options=None, commit_hash=None):
         if commit_hash:
-            filename_at_commit = self.filename_at_commit(file_path, commit_hash)
-        else:
-            filename_at_commit = file_path
+            file_path = self.filename_at_commit(file_path, commit_hash)
 
         blame_porcelain = self.git(
             "blame", "-p", '-w' if ignore_whitespace else None, detect_options,
-            commit_hash, "--", filename_at_commit
+            commit_hash, "--", file_path
         )
         blame_porcelain = unicodedata.normalize('NFC', blame_porcelain)
         blamed_lines, commits = self.parse_blame(blame_porcelain.split('\n'))

--- a/core/commands/blame.py
+++ b/core/commands/blame.py
@@ -450,11 +450,10 @@ class gs_blame_action(BlameMixin, PanelActionMixin):
                 settings.get("git_savvy.commit_hash"), commit_hash, lineno)
 
         assert self.file_path
-        file_path = self.filename_at_commit(self.file_path, commit_hash)
 
         self.window.run_command("gs_show_file_at_commit", {
             "commit_hash": commit_hash,
-            "filepath": file_path,
+            "filepath": self.file_path,
             "position": Position(lineno - 1, 0, None),
             "lang": settings.get('git_savvy.original_syntax', None)
         })

--- a/core/commands/log.py
+++ b/core/commands/log.py
@@ -289,5 +289,11 @@ class gs_log_action(PanelActionMixin, WindowCommand):
         })
 
     def checkout_file_at_commit(self):
-        self.checkout_ref(self._commit_hash, fpath=self._file_path)
+        assert self._file_path
+        file_path = (
+            self.filename_at_commit(self._file_path, self._commit_hash)
+            if self.savvy_settings.get("log_follow_rename") else
+            self._file_path
+        )
+        self.checkout_ref(self._commit_hash, fpath=file_path)
         util.view.refresh_gitsavvy_interfaces(self.window, refresh_sidebar=True)

--- a/core/commands/log_graph_main_actions.py
+++ b/core/commands/log_graph_main_actions.py
@@ -203,6 +203,7 @@ class gs_log_graph_action(WindowCommand, GitCommand):
             else commit_hash
         )
         file_path = self._get_file_path(view)
+        file_path_is_file = os.path.isfile(file_path) if file_path else False
 
         on_checked_out_branch = "HEAD" in info and info["HEAD"] in info.get("local_branches", [])
         head_is_on_a_branch = head_info and head_info["HEAD"] != head_info["commit"]
@@ -300,7 +301,7 @@ class gs_log_graph_action(WindowCommand, GitCommand):
                         ),
                     ]
 
-        if file_path:
+        if file_path and file_path_is_file:
             actions += [
                 ("Show file at commit", partial(self.show_file_at_commit, commit_hash, file_path)),
                 ("Blame file at commit", partial(self.blame_file_atcommit, commit_hash, file_path)),
@@ -478,7 +479,7 @@ class gs_log_graph_action(WindowCommand, GitCommand):
                 ),
             ]
 
-        if file_path:
+        if file_path and file_path_is_file:
             actions += [
                 (
                     "Diff file against workdir",

--- a/core/commands/log_graph_main_actions.py
+++ b/core/commands/log_graph_main_actions.py
@@ -628,7 +628,24 @@ class gs_log_graph_action(WindowCommand, GitCommand):
     def diff(self):
         self.window.run_command("gs_diff", {"in_cached_mode": False})
 
-    def diff_commit(self, base_commit, target_commit=None, file_path=None):
+    def diff_commit(
+        self,
+        base_commit: str,
+        target_commit: str | None = None,
+        file_path: str | None = None
+    ):
+        if file_path:
+            base_path = self.filename_at_commit(file_path, base_commit)
+            target_path = (
+                self.filename_at_commit(file_path, target_commit)
+                if target_commit else
+                self.get_rel_path(file_path)
+            )
+            if base_path != target_path:
+                self.window.status_message("Not implemented across rename boundaries.")
+                return
+            file_path = base_path
+
         self.window.run_command("gs_diff", {
             "in_cached_mode": False,
             "file_path": file_path,

--- a/core/commands/log_graph_main_actions.py
+++ b/core/commands/log_graph_main_actions.py
@@ -649,6 +649,11 @@ class gs_log_graph_action(WindowCommand, GitCommand):
             "file_path": file_path
         })
 
-    def checkout_file_at_commit(self, commit_hash, file_path):
+    def checkout_file_at_commit(self, commit_hash: str, file_path: str):
+        file_path = (
+            self.filename_at_commit(file_path, commit_hash)
+            if self.savvy_settings.get("log_follow_rename") else
+            file_path
+        )
         self.checkout_ref(commit_hash, fpath=file_path)
         util.view.refresh_gitsavvy_interfaces(self.window)

--- a/core/commands/show_commit_info.py
+++ b/core/commands/show_commit_info.py
@@ -96,6 +96,8 @@ class gs_show_commit_info(WindowCommand, GitCommand):
         if commit_hash:
             show_patch = self.savvy_settings.get("show_full_commit_info")
             show_diffstat = self.savvy_settings.get("show_diffstat")
+            if file_path:
+                file_path = self.filename_at_commit(file_path, commit_hash)
             text = self.read_commit(commit_hash, file_path, show_diffstat, show_patch)
         else:
             text = ''

--- a/core/commands/show_commit_info.py
+++ b/core/commands/show_commit_info.py
@@ -6,6 +6,7 @@ from sublime_plugin import TextCommand, WindowCommand
 
 from . import diff
 from . import intra_line_colorizer
+from ..fns import filter_, unique
 from ..git_command import GitCommand
 from ..runtime import enqueue_on_worker, ensure_on_ui, throttled
 from ..view import replace_view_content, scroll_to_pt, y_offset
@@ -96,13 +97,49 @@ class gs_show_commit_info(WindowCommand, GitCommand):
         if commit_hash:
             show_patch = self.savvy_settings.get("show_full_commit_info")
             show_diffstat = self.savvy_settings.get("show_diffstat")
-            if file_path:
-                file_path = self.filename_at_commit(file_path, commit_hash)
-            text = self.read_commit(commit_hash, file_path, show_diffstat, show_patch)
+            text = (
+                self._read_commit_for_file(commit_hash, file_path, show_diffstat, show_patch, settings)
+                if file_path else
+                self.read_commit(commit_hash, None, show_diffstat, show_patch)
+            )
         else:
             text = ''
 
         ensure_on_ui(_draw, self.window, output_view, text, commit_hash, from_log_graph)
+
+    def _read_commit_for_file(self, commit_hash, file_path, show_diffstat, show_patch, settings):
+        """
+        Read a file-scoped commit, optimizing for adjacent commits using the
+        same path.
+
+        The output panel is reused for different graph/log views and for
+        unrestricted commit info.  Keep one cache entry with the requested
+        working-tree path plus the last path that successfully produced a
+        file-scoped commit patch.  Only reuse the cached path if the requested
+        working-tree path matches.
+        """
+        storage_key = "git_savvy.show_commit_info.file_path_cache"
+        _requested_file_path, _successful_file_path = settings.get(storage_key, (None, None))
+        candidates = unique(filter_(
+            get_candidate()
+            for get_candidate in (
+                lambda: (
+                    _successful_file_path
+                    if _successful_file_path and _requested_file_path == file_path else
+                    None
+                ),
+                lambda: file_path,
+                lambda: self.filename_at_commit(file_path, commit_hash)
+            )
+        ))
+
+        for candidate in candidates:
+            text = self.read_commit(commit_hash, candidate, show_diffstat, show_patch)
+            if text:
+                settings.set(storage_key, [file_path, candidate])
+                return text
+
+        return ""
 
 
 def _draw(window, view, text, commit, from_log_graph):

--- a/core/commands/show_file_at_commit.py
+++ b/core/commands/show_file_at_commit.py
@@ -90,6 +90,10 @@ class gs_show_file_at_commit(GsWindowCommand):
 
         if commit_hash:
             commit_hash = self.get_short_hash(commit_hash)
+            # Callers may pass a historical path from a diff hunk.  Keep the
+            # view anchored to the working-dir path and resolve historical
+            # names only when loading content for a specific commit.
+            filepath = self.filename_at_head(filepath, commit_hash)
         else:
             commit_hash = self.recent_commit("HEAD", filepath)
             if not commit_hash:

--- a/core/commands/show_file_at_commit.py
+++ b/core/commands/show_file_at_commit.py
@@ -146,9 +146,10 @@ class _gs_show_file_at_commit_refresh_mixin(GsTextCommand):
         views_with_reference_document.add(self.view)
 
     def previous_file_version(self, current_commit: str, file_path: str) -> str:
-        previous_commit = self.previous_commit(current_commit, file_path)
+        previous_commit = self.previous_commit(current_commit, file_path, follow=True)
         if previous_commit:
-            return self.get_file_content_at_commit(file_path, previous_commit)
+            file_path_at_commit = self.filename_at_commit(file_path, previous_commit)
+            return self.get_file_content_at_commit(file_path_at_commit, previous_commit)
         else:
             # For initial revisions of a file, everything is new/added, and we
             # just compare with the empty "".
@@ -173,7 +174,8 @@ class gs_show_file_at_commit_refresh(_gs_show_file_at_commit_refresh_mixin):
         commit_hash = settings.get("git_savvy.show_file_at_commit_view.commit")
 
         def program():
-            text = self.get_file_content_at_commit(file_path, commit_hash)
+            file_path_at_commit = self.filename_at_commit(file_path, commit_hash)
+            text = self.get_file_content_at_commit(file_path_at_commit, commit_hash)
             render(view, text, position)
             view.reset_reference_document()
             commit_details = self.commit_subject_and_date(commit_hash)
@@ -307,7 +309,7 @@ def get_next_commit(
     if next_commit := recall_next_commit_for(view, commit_hash):
         return next_commit
 
-    next_commits = cmd.next_commits(commit_hash, file_path)
+    next_commits = cmd.next_commits(commit_hash, file_path, follow=bool(file_path))
     remember_next_commit_for(view, next_commits)
     return next_commits.get(commit_hash)
 
@@ -322,7 +324,7 @@ def get_previous_commit(
     if previous := recall_previous_commit_for(view, commit_hash):
         return previous
 
-    if previous := cmd.previous_commit(commit_hash, file_path):
+    if previous := cmd.previous_commit(commit_hash, file_path, follow=bool(file_path)):
         remember_next_commit_for(view, {previous: commit_hash})
     return previous
 

--- a/core/git_mixins/history.py
+++ b/core/git_mixins/history.py
@@ -203,8 +203,8 @@ class HistoryMixin(mixin_base):
     def resolve_commitish(self, ref: str) -> str:
         return self.git("rev-parse", "--short", ref).strip()
 
-    def filename_at_commit(self, filename, commit_hash):
-        # type: (str, str) -> str
+    @cached(not_if={"commit_hash": is_dynamic_ref})
+    def filename_at_commit(self, filename: str, commit_hash: str) -> str:
         lines = self.git(
             "log",
             "--format=",  # we don't need any commit info beside the name status

--- a/core/git_mixins/history.py
+++ b/core/git_mixins/history.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
+from dataclasses import dataclass
 import email.utils
+import os
 from itertools import chain, takewhile
 
 from ..exceptions import GitSavvyError
@@ -38,6 +40,13 @@ class CommitInfo(NamedTuple):
     short_hash: str
     subject: str
     date: str
+
+
+@dataclass(frozen=True)
+class FileStatus:
+    mode: str
+    from_path: str
+    to_path: Optional[str] = None
 
 
 def is_dynamic_ref(ref):
@@ -209,6 +218,53 @@ class HistoryMixin(mixin_base):
             return lines[-1].split("\t")[1]
         except IndexError:
             return filename
+
+    def filename_at_head(self, filename: str, commit_hash: str) -> str:
+        rel_path = self.get_rel_path(filename)
+        was_abs = rel_path != filename
+
+        if os.path.exists(os.path.join(self.repo_path, rel_path)):
+            return filename
+
+        if not self.commit_is_ancestor_of_head(commit_hash):
+            return filename
+
+        current_filename = rel_path
+        seen = set()
+        while current_filename not in seen:
+            seen.add(current_filename)
+            next_filename = self._next_filename_after_commit(current_filename, commit_hash)
+            if not next_filename or next_filename == current_filename:
+                break
+            current_filename = next_filename
+
+        return (
+            os.path.normpath(os.path.join(self.repo_path, current_filename))
+            if was_abs else
+            current_filename
+        )
+
+    def _next_filename_after_commit(self, filename: str, commit_hash: str) -> Optional[str]:
+        commit = self.git(
+            "log",
+            "--follow",
+            "--format=%H",
+            "--name-status",
+            "-1",
+            "-z",
+            "{}..HEAD".format(commit_hash),
+            "--",
+            filename
+        ).split("\0", 1)[0].strip()
+        if not commit:
+            return None
+
+        name_status = self.git("show", "--name-status", "--format=", "-z", commit)
+        for file_status in parse_name_status_z(name_status):
+            if file_status.mode.startswith("R") and file_status.from_path == filename:
+                return file_status.to_path
+
+        return None
 
     @cached(not_if={"base_commit": is_dynamic_ref, "target_commit": is_dynamic_ref})
     def list_touched_filenames(self, base_commit, target_commit, cached=None):
@@ -442,3 +498,20 @@ class HistoryMixin(mixin_base):
                 show_panel_on_error=False
             )
         )
+
+
+def parse_name_status_z(output: str) -> Iterator[FileStatus]:
+    fields = output.rstrip("\0").split("\0")
+    idx = 0
+    while idx < len(fields):
+        mode = fields[idx].strip()
+        idx += 1
+        if not mode:
+            continue
+
+        if mode.startswith(("R", "C")):
+            yield FileStatus(mode, fields[idx], fields[idx + 1])
+            idx += 2
+        else:
+            yield FileStatus(mode, fields[idx])
+            idx += 1

--- a/core/git_mixins/history.py
+++ b/core/git_mixins/history.py
@@ -259,7 +259,11 @@ class HistoryMixin(mixin_base):
         if not commit:
             return None
 
-        name_status = self.git("show", "--name-status", "--format=", "-z", commit)
+        return self._renamed_filename_at_commit(filename, commit)
+
+    @cached(not_if={"commit_hash": is_dynamic_ref})
+    def _renamed_filename_at_commit(self, filename: str, commit_hash: str) -> Optional[str]:
+        name_status = self.git("show", "--name-status", "--format=", "-z", commit_hash)
         for file_status in parse_name_status_z(name_status):
             if file_status.mode.startswith("R") and file_status.from_path == filename:
                 return file_status.to_path

--- a/core/git_mixins/history.py
+++ b/core/git_mixins/history.py
@@ -65,6 +65,8 @@ class HistoryMixin(mixin_base):
             limit=6000, skip=None, reverse=False, all_branches=False, msg_regexp=None,
             diff_regexp=None, first_parent=False, merges=False, no_merges=False, topo_order=False,
             follow=False) -> List[LogEntry]:
+        if follow and not file_path:
+            raise RuntimeError("follow=True requires file_path")
 
         log_output = self.git(
             "log",
@@ -488,6 +490,9 @@ class HistoryMixin(mixin_base):
         follow: bool,
         limit: Optional[int] = None
     ) -> Iterator[str]:
+        if follow and not file_path:
+            raise RuntimeError("follow=True requires file_path")
+
         return (
             line.strip()
             for line in self.git_streaming(

--- a/tests/test_history_mixin.py
+++ b/tests/test_history_mixin.py
@@ -36,6 +36,18 @@ class TestDescribeGraphLine(DeferrableTestCase):
         cmd = ["a", "b", "--", "foofile.py"]
         verify(test).git(*(common + cmd))
 
+    def test_log_follow_requires_file_path(self):
+        test = HistoryMixin()
+
+        with self.assertRaises(RuntimeError):
+            test.log(follow=True)
+
+    def test_log_commits_linewise_follow_requires_file_path(self):
+        test = HistoryMixin()
+
+        with self.assertRaises(RuntimeError):
+            test._log_commits_linewise("HEAD", None, follow=True)
+
     def test_filename_at_head_keeps_existing_workdir_path(self):
         test = HistoryMixin()
         when(test).get_repo_path().thenReturn("/repo")

--- a/tests/test_history_mixin.py
+++ b/tests/test_history_mixin.py
@@ -1,8 +1,10 @@
+import os
+
 from unittesting import DeferrableTestCase
-from GitSavvy.tests.mockito import when, verify
+from GitSavvy.tests.mockito import unstub, when, verify
 from GitSavvy.tests.parameterized import parameterized as p
 
-from GitSavvy.core.git_mixins.history import HistoryMixin
+from GitSavvy.core.git_mixins.history import FileStatus, HistoryMixin, parse_name_status_z
 
 
 examples = [
@@ -15,6 +17,9 @@ examples = [
 
 
 class TestDescribeGraphLine(DeferrableTestCase):
+    def tearDown(self):
+        unstub()
+
     @p.expand(examples)
     def test_no_context_diff_logic(self, _, base, target, cmd):
         test = HistoryMixin()
@@ -30,3 +35,56 @@ class TestDescribeGraphLine(DeferrableTestCase):
         common = ["diff", "--no-color", "-U0"]
         cmd = ["a", "b", "--", "foofile.py"]
         verify(test).git(*(common + cmd))
+
+    def test_filename_at_head_keeps_existing_workdir_path(self):
+        test = HistoryMixin()
+        when(test).get_repo_path().thenReturn("/repo")
+        when(test).get_rel_path("current.py").thenReturn("current.py")
+
+        when(os.path).exists(...).thenReturn(True)
+
+        self.assertEqual(test.filename_at_head("current.py", "abc123"), "current.py")
+
+    def test_filename_at_head_follows_renames_forward(self):
+        test = HistoryMixin()
+        when(test).get_repo_path().thenReturn("/repo")
+        when(test).get_rel_path("old.py").thenReturn("old.py")
+        when(test).commit_is_ancestor_of_head("abc123").thenReturn(True)
+        when(os.path).exists(...).thenReturn(False)
+        when(test).git(
+            "log", "--follow", "--format=%H", "--name-status", "-1", "-z",
+            "abc123..HEAD", "--", "old.py"
+        ).thenReturn("rename1\0\nD\0old.py\0")
+        when(test).git(
+            "show", "--name-status", "--format=", "-z", "rename1"
+        ).thenReturn("R100\0old.py\0new.py\0")
+        when(test).git(
+            "log", "--follow", "--format=%H", "--name-status", "-1", "-z",
+            "abc123..HEAD", "--", "new.py"
+        ).thenReturn("change1\0\nM\0new.py\0")
+        when(test).git(
+            "show", "--name-status", "--format=", "-z", "change1"
+        ).thenReturn("M\0new.py\0")
+
+        self.assertEqual(test.filename_at_head("old.py", "abc123"), "new.py")
+
+    def test_parse_name_status_z_regular_statuses(self):
+        self.assertEqual(
+            list(parse_name_status_z("M\0modified.py\0D\0deleted.py\0")),
+            [FileStatus("M", "modified.py", None), FileStatus("D", "deleted.py", None)]
+        )
+
+    def test_parse_name_status_z_renames(self):
+        self.assertEqual(
+            list(parse_name_status_z("R100\0old.py\0new.py\0")),
+            [FileStatus("R100", "old.py", "new.py")]
+        )
+
+    def test_parse_name_status_z_copies(self):
+        self.assertEqual(
+            list(parse_name_status_z("C100\0source.py\0copy.py\0")),
+            [FileStatus("C100", "source.py", "copy.py")]
+        )
+
+    def test_parse_name_status_z_ignores_empty_records(self):
+        self.assertEqual(list(parse_name_status_z("")), [])


### PR DESCRIPTION
Predecessor is #1750 

Breaking:

- Removed the setting `blame_follow_rename`
- Changed default of `log_follow_rename` to `true`

