### PR TITLE
Make `o` consistent in diff views

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -712,7 +712,7 @@
     },
     {
         "keys": ["o"],
-        "command": "gs_diff_open_file_at_hunk",
+        "command": "gs_diff_open_hunk_on_working_dir",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.commit_view", "operator": "equal", "operand": true },
@@ -1059,7 +1059,15 @@
     },
     {
         "keys": ["o"],
-        "command": "gs_diff_open_file_at_hunk",
+        "command": "gs_diff_open_hunk_on_working_dir",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.diff_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["O"],
+        "command": "gs_diff_open_hunk_at_target_revision",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.diff_view", "operator": "equal", "operand": true }
@@ -2311,7 +2319,7 @@
     },
     {
         "keys": ["O"],
-        "command": "gs_diff_open_file_at_hunk",
+        "command": "gs_diff_open_hunk_at_target_revision",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.line_history_view", "operator": "equal", "operand": true }

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1186,7 +1186,7 @@
     },
     {
         "keys": ["o"],
-        "command": "gs_show_commit_open_file_at_hunk",
+        "command": "gs_diff_open_hunk_at_target_revision",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.show_commit_view", "operator": "equal", "operand": true }

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1194,7 +1194,7 @@
     },
     {
         "keys": ["O"],
-        "command": "gs_show_commit_show_hunk_on_working_dir",
+        "command": "gs_diff_open_hunk_on_working_dir",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.show_commit_view", "operator": "equal", "operand": true }

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -3,6 +3,7 @@ Implements a special view to visualize and stage pieces of a project's
 current diff.
 """
 from __future__ import annotations
+from abc import ABC, abstractmethod
 from collections import defaultdict
 from contextlib import contextmanager
 import difflib
@@ -45,7 +46,6 @@ __all__ = (
     "gs_diff_zoom",
     "gs_diff_stage_or_reset_hunk",
     "gs_initiate_fixup_commit",
-    "gs_diff_open_file_at_hunk",
     "gs_diff_open_hunk_on_working_dir",
     "gs_diff_open_hunk_at_target_revision",
     "gs_diff_navigate",
@@ -1469,7 +1469,7 @@ class JumpTo(NamedTuple):
     col: ColNo
 
 
-class gs_diff_open_file_at_hunk(TextCommand, GitCommand):
+class _GsDiffOpenFileAtHunk(TextCommand, GitCommand, ABC):
 
     """
     For each cursor in the view, identify the hunk in which the cursor lies,
@@ -1513,34 +1513,14 @@ class gs_diff_open_file_at_hunk(TextCommand, GitCommand):
             for jp in jump_positions:
                 self.load_file_at_line(*jp)
 
-    def load_file_at_line(self, commit_hash, filename, line, col):
-        # type: (Optional[str], str, LineNo, ColNo) -> None
-        """
-        Show file at target commit if `git_savvy.diff_view.target_commit` is non-empty.
-        Otherwise, open the file directly.
-        """
-        full_path = os.path.join(self.repo_path, filename)
-        window = self.view.window()
-        if not window:
-            return
-
-        target_commit = effective_target_commit(self.view)
-        if commit_hash or target_commit:
-            window.run_command("gs_show_file_at_commit", {
-                "commit_hash": commit_hash or self.resolve_commitish(target_commit),  # type: ignore[arg-type]
-                "filepath": full_path,
-                "position": Position(line - 1, col - 1, None),
-            })
-        else:
-            if self.view.settings().get("git_savvy.diff_view.in_cached_mode"):
-                line = self.reverse_find_matching_lineno(None, None, line=line, file_path=full_path)
-            window.open_file(
-                "{file}:{line}:{col}".format(file=full_path, line=line, col=col),
-                sublime.ENCODED_POSITION
-            )
+    @abstractmethod
+    def load_file_at_line(
+        self, commit_hash: Optional[str], filename: str, line: LineNo, col: ColNo
+    ) -> None:
+        raise NotImplementedError
 
 
-class gs_diff_open_hunk_on_working_dir(gs_diff_open_file_at_hunk):
+class gs_diff_open_hunk_on_working_dir(_GsDiffOpenFileAtHunk):
     def load_file_at_line(
         self, commit_hash: Optional[str], filename: str, line: LineNo, col: ColNo
     ) -> None:
@@ -1571,7 +1551,7 @@ class gs_diff_open_hunk_on_working_dir(gs_diff_open_file_at_hunk):
         )
 
 
-class gs_diff_open_hunk_at_target_revision(gs_diff_open_file_at_hunk):
+class gs_diff_open_hunk_at_target_revision(_GsDiffOpenFileAtHunk):
     def load_file_at_line(
         self, commit_hash: Optional[str], filename: str, line: LineNo, col: ColNo
     ) -> None:

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -46,6 +46,8 @@ __all__ = (
     "gs_diff_stage_or_reset_hunk",
     "gs_initiate_fixup_commit",
     "gs_diff_open_file_at_hunk",
+    "gs_diff_open_hunk_on_working_dir",
+    "gs_diff_open_hunk_at_target_revision",
     "gs_diff_navigate",
     "gs_commit_view_navigate",
     "gs_diff_undo",
@@ -1532,6 +1534,67 @@ class gs_diff_open_file_at_hunk(TextCommand, GitCommand):
         else:
             if self.view.settings().get("git_savvy.diff_view.in_cached_mode"):
                 line = self.reverse_find_matching_lineno(None, None, line=line, file_path=full_path)
+            window.open_file(
+                "{file}:{line}:{col}".format(file=full_path, line=line, col=col),
+                sublime.ENCODED_POSITION
+            )
+
+
+class gs_diff_open_hunk_on_working_dir(gs_diff_open_file_at_hunk):
+    def load_file_at_line(
+        self, commit_hash: Optional[str], filename: str, line: LineNo, col: ColNo
+    ) -> None:
+        full_path = os.path.join(self.repo_path, filename)
+        window = self.view.window()
+        if not window:
+            return
+
+        target_commit = effective_target_commit(self.view)
+        if commit_hash or target_commit:
+            target_side_commit = commit_hash or self.resolve_commitish(target_commit)  # type: ignore[arg-type]
+            line = self.find_matching_lineno(
+                target_side_commit,
+                None,
+                line=line,
+                file_path=full_path
+            )
+        elif self.view.settings().get("git_savvy.diff_view.in_cached_mode"):
+            line = self.reverse_find_matching_lineno(
+                None,
+                None,
+                line=line,
+                file_path=full_path
+            )
+        window.open_file(
+            "{file}:{line}:{col}".format(file=full_path, line=line, col=col),
+            sublime.ENCODED_POSITION
+        )
+
+
+class gs_diff_open_hunk_at_target_revision(gs_diff_open_file_at_hunk):
+    def load_file_at_line(
+        self, commit_hash: Optional[str], filename: str, line: LineNo, col: ColNo
+    ) -> None:
+        full_path = os.path.join(self.repo_path, filename)
+        window = self.view.window()
+        if not window:
+            return
+
+        target_commit = effective_target_commit(self.view)
+        if commit_hash or target_commit:
+            window.run_command("gs_show_file_at_commit", {
+                "commit_hash": commit_hash or self.resolve_commitish(target_commit),  # type: ignore[arg-type]
+                "filepath": full_path,
+                "position": Position(line - 1, col - 1, None),
+            })
+        else:
+            if self.view.settings().get("git_savvy.diff_view.in_cached_mode"):
+                line = self.reverse_find_matching_lineno(
+                    None,
+                    None,
+                    line=line,
+                    file_path=full_path
+                )
             window.open_file(
                 "{file}:{line}:{col}".format(file=full_path, line=line, col=col),
                 sublime.ENCODED_POSITION

--- a/core/commands/help_panel.py
+++ b/core/commands/help_panel.py
@@ -187,7 +187,8 @@ class gs_diff_help_panel(GsAbstractOpenHelpPanel):
     [a]            toggle all files / current file
 
     ### Navigation ###
-    [o]            open file at hunk
+    [o]            open hunk in working dir
+    [O]            open hunk at target revision
     [,]/[.]        go to next/previous chunk
     [alt+]         go to next/previous hunk (also: [j]/[k] in vintageous mode)
 

--- a/core/commands/show_commit.py
+++ b/core/commands/show_commit.py
@@ -1,5 +1,3 @@
-from contextlib import contextmanager
-import os
 import re
 from webbrowser import open as open_in_browser
 
@@ -32,7 +30,6 @@ __all__ = (
     "gs_show_commit_toggle_setting",
     "gs_show_commit_open_previous_commit",
     "gs_show_commit_open_next_commit",
-    "gs_show_commit_show_hunk_on_working_dir",
     "gs_show_commit_open_graph_context",
     "gs_show_commit_initiate_fixup_commit",
     "gs_show_commit_reword_commit",
@@ -44,7 +41,6 @@ __all__ = (
 
 from typing import Dict, Optional, Sequence, Tuple, Union
 from GitSavvy.core.base_commands import GsCommand, Args, Kont
-from GitSavvy.core.types import LineNo, ColNo
 
 
 SUBLIME_SUPPORTS_REGION_ANNOTATIONS = int(sublime.version()) >= 4050
@@ -369,57 +365,6 @@ class gs_show_commit_open_next_commit(TextCommand, GitCommand):
 
         view.run_command("gs_show_commit_refresh")
         flash(view, "On commit {}".format(next_commit))
-
-
-class gs_show_commit_show_hunk_on_working_dir(diff.gs_diff_open_file_at_hunk):
-    def load_file_at_line(self, commit_hash, filename, line, col):
-        # type: (Optional[str], str, LineNo, ColNo) -> None
-        if not commit_hash:
-            flash(self.view, "Could not parse commit for its commit hash")
-            return
-        window = self.view.window()
-        if not window:
-            return
-
-        full_path = os.path.join(self.repo_path, filename)
-        line = self.find_matching_lineno(commit_hash, None, line, full_path)
-
-        with force_remember_commit_info_panel_focus_state(window):
-            view = window.open_file(
-                "{file}:{line}:{col}".format(file=full_path, line=line, col=col),
-                sublime.ENCODED_POSITION
-            )
-            # https://github.com/sublimehq/sublime_text/issues/4418
-            # Sublime Text 4 focuses the view automatically *if* it
-            # was already open, otherwise it makes the view only
-            # visible. Force the focus for a consistent behavior.
-            focus_view(view)
-
-
-@contextmanager
-def force_remember_commit_info_panel_focus_state(window):
-    # Although we automatically detect when the panel loses its focus in `log_graph.py`,
-    # it fails when `window.open_file` brought the file to front *without* focusing
-    # it.  In that case, t.i. when it just *opens* the file, `focus_view()` will first
-    # activate the graph view and *then* the file we just opened.  This looks like
-    # a bug, probably related to https://github.com/sublimehq/sublime_text/issues/4418
-
-    # When `gs_show_commit_show_hunk_on_working_dir` runs and the graph view is the
-    # `active_view`, the panel has the focus as the command is only bound to the panel
-    # view.
-    av = window.active_view()
-    had_focus = (
-        av.settings().get("git_savvy.log_graph_view", False)
-        if av
-        else False
-    )
-
-    yield
-
-    if had_focus:
-        panel_view = window.find_output_panel('show_commit_info')
-        if panel_view:
-            panel_view.settings().set("git_savvy.show_commit_view.had_focus", True)
 
 
 class gs_show_commit_open_graph_context(TextCommand, GitCommand):

--- a/core/commands/show_commit.py
+++ b/core/commands/show_commit.py
@@ -17,7 +17,7 @@ from ..utils import flash, flash_regions, focus_view, Cache
 from ..parse_diff import SplittedDiff
 from ..text_helper import TextRange
 from ..runtime import ensure_on_ui, enqueue_on_worker
-from ..view import replace_view_content, Position
+from ..view import replace_view_content
 from ...common import util
 
 from GitSavvy.github import github
@@ -32,7 +32,6 @@ __all__ = (
     "gs_show_commit_toggle_setting",
     "gs_show_commit_open_previous_commit",
     "gs_show_commit_open_next_commit",
-    "gs_show_commit_open_file_at_hunk",
     "gs_show_commit_show_hunk_on_working_dir",
     "gs_show_commit_open_graph_context",
     "gs_show_commit_initiate_fixup_commit",
@@ -370,34 +369,6 @@ class gs_show_commit_open_next_commit(TextCommand, GitCommand):
 
         view.run_command("gs_show_commit_refresh")
         flash(view, "On commit {}".format(next_commit))
-
-
-class gs_show_commit_open_file_at_hunk(diff.gs_diff_open_file_at_hunk):
-
-    """
-    For each cursor in the view, identify the hunk in which the cursor lies,
-    and open the file at that hunk in a separate view.
-    """
-
-    def load_file_at_line(self, commit_hash, filename, line, col):
-        # type: (Optional[str], str, LineNo, ColNo) -> None
-        """
-        Show file at target commit if `git_savvy.diff_view.target_commit` is non-empty.
-        Otherwise, open the file directly.
-        """
-        if not commit_hash:
-            flash(self.view, "Could not parse commit for its commit hash")
-            return
-        window = self.view.window()
-        if not window:
-            return
-
-        full_path = os.path.join(self.repo_path, filename)
-        window.run_command("gs_show_file_at_commit", {
-            "commit_hash": commit_hash,
-            "filepath": full_path,
-            "position": Position(line - 1, col - 1, None)
-        })
 
 
 class gs_show_commit_show_hunk_on_working_dir(diff.gs_diff_open_file_at_hunk):

--- a/tests/test_diff_view.py
+++ b/tests/test_diff_view.py
@@ -461,7 +461,7 @@ diff --git a/foxx b/boxx
         view.run_command('append', {'characters': VIEW_CONTENT})
         view.set_scratch(True)
 
-        cmd = module.gs_diff_open_file_at_hunk(view)
+        cmd = module.gs_diff_open_hunk_on_working_dir(view)
         when(cmd).load_file_at_line(...)
 
         view.sel().clear()
@@ -496,7 +496,7 @@ diff --git a/fooz b/barz
         view.run_command('append', {'characters': VIEW_CONTENT})
         view.set_scratch(True)
 
-        cmd = module.gs_diff_open_file_at_hunk(view)
+        cmd = module.gs_diff_open_hunk_on_working_dir(view)
         when(cmd).load_file_at_line(...)
 
         view.sel().clear()

--- a/tests/test_diff_view.py
+++ b/tests/test_diff_view.py
@@ -507,6 +507,52 @@ diff --git a/fooz b/barz
         # In all cases here "commit" is `None`
         verify(cmd).load_file_at_line(None, EXPECTED, ...)
 
+    def test_o_opens_historical_diff_hunks_on_the_working_dir(self):
+        repo_path = os.path.dirname(THIS_DIRNAME)
+        full_path = os.path.join(repo_path, "foo.py")
+        view = self.window.new_file()
+        self.addCleanup(view.close)
+        view.settings().set("git_savvy.repo_path", repo_path)
+        view.settings().set("git_savvy.diff_view.target_commit", "HEAD")
+        view.set_scratch(True)
+
+        window = mock()
+        when(view).window().thenReturn(window)
+        when(window).open_file(...)
+        cmd = module.gs_diff_open_hunk_on_working_dir(view)
+        when(cmd).resolve_commitish("HEAD").thenReturn("deadbeef")
+        when(cmd).find_matching_lineno("deadbeef", None, line=17, file_path=full_path).thenReturn(23)
+
+        cmd.load_file_at_line(None, "foo.py", 17, 4)
+
+        verify(window).open_file(
+            "{}:23:4".format(full_path),
+            sublime.ENCODED_POSITION
+        )
+
+    def test_O_opens_historical_diff_hunks_on_the_target_revision(self):
+        repo_path = os.path.dirname(THIS_DIRNAME)
+        full_path = os.path.join(repo_path, "foo.py")
+        view = self.window.new_file()
+        self.addCleanup(view.close)
+        view.settings().set("git_savvy.repo_path", repo_path)
+        view.settings().set("git_savvy.diff_view.target_commit", "HEAD")
+        view.set_scratch(True)
+
+        window = mock()
+        when(view).window().thenReturn(window)
+        when(window).run_command(...)
+        cmd = module.gs_diff_open_hunk_at_target_revision(view)
+        when(cmd).resolve_commitish("HEAD").thenReturn("deadbeef")
+
+        cmd.load_file_at_line(None, "foo.py", 17, 4)
+
+        verify(window).run_command("gs_show_file_at_commit", {
+            "commit_hash": "deadbeef",
+            "filepath": full_path,
+            "position": module.Position(16, 3, None),
+        })
+
 
 class TestDiffViewHunking(DeferrableTestCase):
     @classmethod


### PR DESCRIPTION
Bind diff view `o` to open the selected hunk in the working tree
and add `O` to open the hunk at the target revision.