### PR TITLE
Route `next_commits` through `_fetch_info_for_commit_file_path_pairs`

### DIFF
--- a/core/commands/show_file_at_commit.py
+++ b/core/commands/show_file_at_commit.py
@@ -350,7 +350,6 @@ def get_next_commit(
         next_commits = cmd.next_commits(
             commit_hash,
             file_path,
-            follow=bool(file_path),
             branch_hint=branch_hint
         )
     except GitSavvyError as e:

--- a/core/git_mixins/history.py
+++ b/core/git_mixins/history.py
@@ -615,7 +615,6 @@ class HistoryMixin(mixin_base):
         self,
         current_commit: str,
         file_path: str | None = None,
-        follow: bool = False,
         branch_hint: str | None = None,
     ) -> dict[str, str] | None:
         if current_commit != self.get_short_hash(current_commit):
@@ -624,17 +623,15 @@ class HistoryMixin(mixin_base):
         if branch_hint is None:
             branch_hint = self.get_branch_hint_for_commit(current_commit)
 
-        commits = []
-        for commit in self._log_commits_linewise(f"{branch_hint}", file_path, follow):
-            commits.append(commit)
-            if commit == current_commit:
-                break
-        else:
+        hashes = self._fetch_info_for_commit_file_path_pairs(
+            file_path, start_commit=branch_hint, stop_at=current_commit
+        )
+        if not hashes or hashes[-1] != current_commit:
             return None
 
         return {
             right: left
-            for left, right in pairwise(commits)
+            for left, right in pairwise(hashes)
         }
 
     def get_branch_hint_for_commit(self, commit_hash: str) -> str:
@@ -684,10 +681,11 @@ class HistoryMixin(mixin_base):
         self,
         file_path: Optional[str] = None,
         start_commit: str = "HEAD",
+        stop_at: Optional[str] = None,
+        limit: int = 200,
         file_cache: FileHistoryCache = file_history_cache,
         commit_cache: CommitInfoCache = commit_info_cache,
-        limit: int = 200
-    ) -> None:
+    ) -> List[str]:
         """
         Populate file-history info for a single logical file history.
 
@@ -721,6 +719,16 @@ class HistoryMixin(mixin_base):
         `date` is the committer date from `%ci`, normalized to the same year-month-day
         format that `commit_subject_and_date_from_patch` returns.
 
+        If `stop_at` is given, fetch the chain from `start_commit` down to and
+        including `stop_at` (regardless of `limit`).  In this mode the
+        `file_cache` entry for `stop_at` itself is intentionally *not* written
+        — we don't have its parent in this fetch, so its `previous_commit`
+        would be a lie.  `commit_cache` is populated for every fetched commit
+        including `stop_at` (subject/date don't depend on the parent).
+
+        Returns the ordered list of short hashes that were fetched, newest to
+        oldest.  Existing callers can ignore the return value.
+
         All hashes are short hashes.
         """
         RS = "%x1e"  # record separator
@@ -731,8 +739,9 @@ class HistoryMixin(mixin_base):
             "--topo-order",
             f"--format={RS}%h{US}%ci{US}%s",
             "-z",
-            f"-{limit + 1}",
+            None if stop_at else f"-{limit + 1}",
             start_commit,
+            f"^{stop_at}^@" if stop_at else None,
             *(
                 "--follow",
                 "--name-status",
@@ -741,21 +750,34 @@ class HistoryMixin(mixin_base):
             ) if file_path else ()
         )
         records = parse_file_history_log(log_output)
+        pairs = pairwise(chain(records, [None]))
+        if stop_at is None:
+            pairs = take(limit, pairs)
+
         filename = file_path
-        for record, right in take(limit, pairwise(chain(records, [None]))):
+        hashes: List[str] = []
+        for record, right in pairs:
             assert record
-            info = FileHistoryInfo(
-                filename,
-                right.short_hash if right else None
-            )
-            file_cache[(record.short_hash, file_path)] = info
+            hashes.append(record.short_hash)
             commit_cache[record.short_hash] = CommitHistoryInfo(
                 record.subject,
                 record.date
             )
+            if stop_at is not None and right is None:
+                # `record` is `stop_at`; we don't have its parent in this
+                # fetch, so writing `file_cache` would lie about
+                # `previous_commit`.  Leave the file-cache entry off so a
+                # subsequent `previous_commit(stop_at)` re-fetches from there.
+                break
+            file_cache[(record.short_hash, file_path)] = FileHistoryInfo(
+                filename,
+                right.short_hash if right else None
+            )
 
             if status := record.status:
                 filename = self.to_abs_path(status.from_path)
+
+        return hashes
 
 
 def parse_file_history_log(output: str) -> Iterator[FileHistoryEntry]:

--- a/tests/test_history_mixin.py
+++ b/tests/test_history_mixin.py
@@ -159,6 +159,95 @@ class TestDescribeGraphLine(DeferrableTestCase):
             "c2": CommitHistoryInfo("middle", "2026-4-3")
         })
 
+    def test_fetch_info_with_stop_at_returns_chain_and_warms_caches(self):
+        test = HistoryMixin()
+        when(test).git("log", ...).thenReturn(
+            f"{RS}c3{US}2026-05-07 10:00:00 +0200{US}newest{NUL}"
+            f"{RS}c2{US}2026-04-03 10:00:00 +0200{US}middle{NUL}"
+            f"{RS}c1{US}2026-01-02 10:00:00 +0200{US}target{NUL}"
+        )
+
+        file_cache = {}
+        commit_cache = {}
+        hashes = test._fetch_info_for_commit_file_path_pairs(
+            start_commit="branch_tip",
+            stop_at="c1",
+            file_cache=file_cache,
+            commit_cache=commit_cache,
+        )
+
+        self.assertEqual(hashes, ["c3", "c2", "c1"])
+        # `stop_at`'s file_cache entry would lie about previous_commit, so
+        # only c3 and c2 are written.
+        self.assertEqual(file_cache, {
+            ("c3", None): FileHistoryInfo(None, "c2"),
+            ("c2", None): FileHistoryInfo(None, "c1")
+        })
+        # commit_cache is populated for every fetched commit, including stop_at.
+        self.assertEqual(commit_cache, {
+            "c3": CommitHistoryInfo("newest", "2026-5-7"),
+            "c2": CommitHistoryInfo("middle", "2026-4-3"),
+            "c1": CommitHistoryInfo("target", "2026-1-2")
+        })
+
+    def test_fetch_info_with_stop_at_excludes_via_separate_arg(self):
+        test = HistoryMixin()
+        when(test).git("log", ...).thenReturn("")
+
+        test._fetch_info_for_commit_file_path_pairs(
+            start_commit="branch_tip",
+            stop_at="c1",
+        )
+
+        # The exclusion is passed as a separate `^c1^@` arg, not as a
+        # `c1^@..branch_tip` rev-range (which git rejects as ambiguous).
+        verify(test).git(
+            "log",
+            "--topo-order",
+            "--format=%x1e%h%x1f%ci%x1f%s",
+            "-z",
+            None,
+            "branch_tip",
+            "^c1^@",
+        )
+
+    def test_next_commits_returns_right_to_left_chain_dict(self):
+        test = HistoryMixin()
+        when(test).get_short_hash("c3").thenReturn("c3")
+        when(test).git("log", ...).thenReturn(
+            f"{RS}c5{US}2026-05-07 10:00:00 +0200{US}tip{NUL}"
+            f"{RS}c4{US}2026-04-03 10:00:00 +0200{US}middle{NUL}"
+            f"{RS}c3{US}2026-01-02 10:00:00 +0200{US}target{NUL}"
+        )
+
+        result = test.next_commits("c3", branch_hint="branch_tip")
+
+        self.assertEqual(result, {"c4": "c5", "c3": "c4"})
+
+    def test_next_commits_returns_empty_dict_when_current_is_tip(self):
+        test = HistoryMixin()
+        when(test).get_short_hash("c3").thenReturn("c3")
+        when(test).git("log", ...).thenReturn(
+            f"{RS}c3{US}2026-05-07 10:00:00 +0200{US}tip{NUL}"
+        )
+
+        result = test.next_commits("c3", branch_hint="c3")
+
+        self.assertEqual(result, {})
+
+    def test_next_commits_returns_none_when_current_not_on_branch(self):
+        test = HistoryMixin()
+        when(test).get_short_hash("c3").thenReturn("c3")
+        when(test).git("log", ...).thenReturn(
+            f"{RS}c5{US}2026-05-07 10:00:00 +0200{US}tip{NUL}"
+            f"{RS}c4{US}2026-04-03 10:00:00 +0200{US}middle{NUL}"
+            # c3 is missing from the fetched chain
+        )
+
+        result = test.next_commits("c3", branch_hint="branch_tip")
+
+        self.assertIsNone(result)
+
     def test_filename_at_head_keeps_existing_workdir_path(self):
         test = HistoryMixin()
         when(test).get_repo_path().thenReturn("/repo")


### PR DESCRIPTION
`next_commits` relied on `_log_commits_linewise` and never warmed our caches.  Delegate to `_fetch_info_for_commit_file_path_pairs` with a new `stop_at` arg.  If `stop_at` is set `limit` is ignored for now.

Drop the redundant `follow` arg from `next_commits` and its single caller in `show_file_at_commit.py`; follow is now implicit when a `file_path` is given.