### PR TITLE
Warm caches for recent commit lookup

### DIFF
--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -972,7 +972,7 @@ class gs_inline_diff_previous_commit(TextCommand, GitCommand):
         settings = view.settings()
         file_path = settings.get("git_savvy.file_path")
         if is_interactive_diff(view):
-            base_commit = self.recent_commit("HEAD", file_path)
+            base_commit = self.recent_commit("HEAD", file_path, follow=False)
             if not base_commit:
                 flash(view, "No historical version of that file found.")
                 return

--- a/core/commands/show_file_at_commit.py
+++ b/core/commands/show_file_at_commit.py
@@ -206,7 +206,7 @@ class gs_show_file_at_commit_refresh(_gs_show_file_at_commit_refresh_mixin):
             enqueue_on_worker(program)
 
     def update_commit_details(self, commit_hash: str, file_path: str) -> None:
-        commit_details = self.commit_subject_and_date(commit_hash)
+        commit_details = self.commit_subject_and_date(commit_hash, file_path)
         self.update_title(commit_details, file_path)
         self.update_status_bar(commit_details)
 

--- a/core/git_mixins/history.py
+++ b/core/git_mixins/history.py
@@ -531,9 +531,16 @@ class HistoryMixin(mixin_base):
             rv += stdout.decode("utf-8", "replace")
         return rv
 
-    def commit_subject_and_date(self, commit_hash: str) -> CommitInfo:
-        if is_dynamic_ref(commit_hash):
-            return self._commit_subject_and_date(commit_hash)
+    def commit_subject_and_date(self, commit_hash: str, file_path: str | None = None) -> CommitInfo:
+        """
+
+        Note: Providing `file_path` can affect the return value!
+              Only use if you know that (commit_hash, file_path) is a valid pair
+              to warm up the cache.
+              E.g. the semantics of ("HEAD", <file_path>) is: return the CommitInfo
+              of the *most recent* commit that change <file_path>.
+              But ("HEAD", None) returns the CommitInfo of the HEAD commit.
+        """
 
         def to_commit_info(info: CommitHistoryInfo) -> CommitInfo:
             return CommitInfo(
@@ -543,20 +550,18 @@ class HistoryMixin(mixin_base):
                 info.date
             )
 
-        key = commit_hash
+        # `commit_hash` may be a ref (like "HEAD" or a branch name).
+        # If so the key lookup will always fail since we cache by commit_hash,
+        # resulting in a fresh fetch.
         try:
-            return to_commit_info(commit_info_cache[key])
+            return to_commit_info(commit_info_cache[commit_hash])
         except KeyError:
-            self._fetch_info_for_commit_file_path_pairs(None, commit_hash)
-            return to_commit_info(commit_info_cache[key])
-
-    @cached(not_if={"commit_hash": is_dynamic_ref})
-    def _commit_subject_and_date(self, commit_hash: str) -> CommitInfo:
-        # call with the same settings as gs_show_commit to either use or
-        # warm up the cache
-        show_diffstat = self.savvy_settings.get("show_diffstat")
-        patch = self.read_commit(commit_hash, show_diffstat=show_diffstat)
-        return self.commit_subject_and_date_from_patch(patch)
+            hashes = self._fetch_info_for_commit_file_path_pairs(file_path, commit_hash)
+            if not hashes:
+                raise ValueError(
+                    f"no history for {file_path!r} reachable from {commit_hash!r}"
+                )
+            return to_commit_info(commit_info_cache[hashes[0]])
 
     def commit_subject_and_date_from_patch(self, patch: str) -> CommitInfo:
         commit_hash, date, subject = "", "", ""

--- a/core/git_mixins/history.py
+++ b/core/git_mixins/history.py
@@ -577,16 +577,22 @@ class HistoryMixin(mixin_base):
         current_commit: str,
         file_path: str | None = None,
         follow: bool = False
-    ):
-        if is_dynamic_ref(current_commit) or (file_path and not follow):
+    ) -> Optional[str]:
+        if file_path and not follow:
             return self._previous_commit(current_commit, file_path, follow)
 
-        key = (current_commit, file_path)
+        # `current_commit` may be a ref (like "HEAD" or a branch name).
+        # If so the key lookup will always fail since we cache by commit_hash,
+        # resulting in a fresh fetch.
         try:
-            return file_history_cache[key].previous_commit
+            return file_history_cache[(current_commit, file_path)].previous_commit
         except KeyError:
-            self._fetch_info_for_commit_file_path_pairs(file_path, current_commit)
-            return file_history_cache[key].previous_commit
+            hashes = self._fetch_info_for_commit_file_path_pairs(file_path, current_commit)
+            return (
+                file_history_cache[(hashes[0], file_path)].previous_commit
+                if hashes else
+                None
+            )
 
     @cached(not_if={"current_commit": is_dynamic_ref})
     def _previous_commit(self, current_commit, file_path=None, follow=False):

--- a/core/git_mixins/history.py
+++ b/core/git_mixins/history.py
@@ -596,8 +596,22 @@ class HistoryMixin(mixin_base):
             None
         )
 
+    def recent_commit(
+        self,
+        current_commit: str,
+        file_path: str | None = None,
+        follow: bool = None,
+    ) -> Optional[str]:
+        if file_path and follow is False:
+            return self._recent_commit(current_commit, file_path, follow)
+
+        return next(
+            iter(self._fetch_info_for_commit_file_path_pairs(file_path, current_commit)),
+            None
+        )
+
     @cached(not_if={"current_commit": is_dynamic_ref})
-    def recent_commit(self, current_commit, file_path=None, follow=False):
+    def _recent_commit(self, current_commit, file_path=None, follow=False):
         # type: (str, Optional[str], bool) -> Optional[str]
         return last(
             self._log_commits_linewise(current_commit, file_path, follow, limit=1),

--- a/tests/test_history_mixin.py
+++ b/tests/test_history_mixin.py
@@ -325,6 +325,52 @@ class TestDescribeGraphLine(DeferrableTestCase):
 
         self.assertIsNone(result)
 
+    def test_commit_subject_and_date_uses_cache_without_fetching(self):
+        from GitSavvy.core.git_mixins.history import CommitInfo
+        test = HistoryMixin()
+        commit_info_cache.clear()
+        commit_info_cache["c3"] = CommitHistoryInfo("cached subject", "2026-5-7")
+
+        result = test.commit_subject_and_date("c3")
+
+        self.assertEqual(result, CommitInfo("c3", "c3", "cached subject", "2026-5-7"))
+
+    def test_commit_subject_and_date_fetches_on_cache_miss(self):
+        from GitSavvy.core.git_mixins.history import CommitInfo
+        test = HistoryMixin()
+        when(test).git("log", ...).thenReturn(
+            f"{RS}c3{US}2026-05-07 10:00:00 +0200{US}fetched{NUL}"
+        )
+        commit_info_cache.clear()
+
+        result = test.commit_subject_and_date("c3")
+
+        self.assertEqual(result, CommitInfo("c3", "c3", "fetched", "2026-5-7"))
+        self.assertIn("c3", commit_info_cache)
+
+    def test_commit_subject_and_date_resolves_ref_via_first_fetched_hash(self):
+        from GitSavvy.core.git_mixins.history import CommitInfo
+        test = HistoryMixin()
+        when(test).git("log", ...).thenReturn(
+            f"{RS}c3{US}2026-05-07 10:00:00 +0200{US}tip{NUL}"
+            f"{RS}c2{US}2026-04-03 10:00:00 +0200{US}older{NUL}"
+        )
+        commit_info_cache.clear()
+
+        # "HEAD" never appears as a cache key; we read from
+        # `commit_info_cache[hashes[0]]` (i.e. c3) instead.
+        result = test.commit_subject_and_date("HEAD")
+
+        self.assertEqual(result, CommitInfo("HEAD", "HEAD", "tip", "2026-5-7"))
+
+    def test_commit_subject_and_date_raises_when_file_path_not_in_history(self):
+        test = HistoryMixin()
+        when(test).git("log", ...).thenReturn("")
+        commit_info_cache.clear()
+
+        with self.assertRaises(ValueError):
+            test.commit_subject_and_date("c3", "/repo/never-touched.py")
+
     def test_filename_at_head_keeps_existing_workdir_path(self):
         test = HistoryMixin()
         when(test).get_repo_path().thenReturn("/repo")

--- a/tests/test_history_mixin.py
+++ b/tests/test_history_mixin.py
@@ -276,6 +276,55 @@ class TestDescribeGraphLine(DeferrableTestCase):
 
         self.assertIsNone(result)
 
+    def test_previous_commit_with_short_hash_uses_cache_after_fetch(self):
+        test = HistoryMixin()
+        when(test).git("log", ...).thenReturn(
+            f"{RS}c3{US}2026-05-07 10:00:00 +0200{US}newest{NUL}"
+            f"\nM{NUL}foo.py{NUL}"
+            f"{RS}c2{US}2026-04-03 10:00:00 +0200{US}prev{NUL}"
+            f"\nM{NUL}foo.py{NUL}"
+        )
+        when(test).get_repo_path().thenReturn("/repo")
+        file_history_cache.clear()
+        commit_info_cache.clear()
+
+        result = test.previous_commit("c3", "/repo/foo.py", follow=True)
+
+        self.assertEqual(result, "c2")
+        self.assertIn(("c3", "/repo/foo.py"), file_history_cache)
+
+    def test_previous_commit_falls_back_to_list_index_for_non_short_hash_ref(self):
+        test = HistoryMixin()
+        when(test).git("log", ...).thenReturn(
+            f"{RS}c3{US}2026-05-07 10:00:00 +0200{US}newest{NUL}"
+            f"\nM{NUL}foo.py{NUL}"
+            f"{RS}c2{US}2026-04-03 10:00:00 +0200{US}prev{NUL}"
+            f"\nM{NUL}foo.py{NUL}"
+        )
+        when(test).get_repo_path().thenReturn("/repo")
+        file_history_cache.clear()
+        commit_info_cache.clear()
+
+        # `"HEAD"` is not a key the fetch will write — cache misses both
+        # times, fallback returns hashes[1].
+        result = test.previous_commit("HEAD", "/repo/foo.py", follow=True)
+
+        self.assertEqual(result, "c2")
+
+    def test_previous_commit_returns_none_when_only_one_commit_fetched(self):
+        test = HistoryMixin()
+        when(test).git("log", ...).thenReturn(
+            f"{RS}c3{US}2026-05-07 10:00:00 +0200{US}only{NUL}"
+            f"\nM{NUL}foo.py{NUL}"
+        )
+        when(test).get_repo_path().thenReturn("/repo")
+        file_history_cache.clear()
+        commit_info_cache.clear()
+
+        result = test.previous_commit("HEAD", "/repo/foo.py", follow=True)
+
+        self.assertIsNone(result)
+
     def test_filename_at_head_keeps_existing_workdir_path(self):
         test = HistoryMixin()
         when(test).get_repo_path().thenReturn("/repo")

--- a/tests/test_history_mixin.py
+++ b/tests/test_history_mixin.py
@@ -5,7 +5,9 @@ from GitSavvy.tests.mockito import unstub, when, verify
 from GitSavvy.tests.parameterized import parameterized as p
 
 from GitSavvy.core.git_mixins.history import (
+    commit_info_cache,
     CommitHistoryInfo,
+    file_history_cache,
     FileHistoryEntry,
     FileHistoryInfo,
     FileStatus,
@@ -245,6 +247,32 @@ class TestDescribeGraphLine(DeferrableTestCase):
         )
 
         result = test.next_commits("c3", branch_hint="branch_tip")
+
+        self.assertIsNone(result)
+
+    def test_recent_commit_with_file_and_follow_returns_first_and_warms_caches(self):
+        test = HistoryMixin()
+        when(test).git("log", ...).thenReturn(
+            f"{RS}c3{US}2026-05-07 10:00:00 +0200{US}touched{NUL}"
+            f"\nM{NUL}foo.py{NUL}"
+            f"{RS}c2{US}2026-04-03 10:00:00 +0200{US}also{NUL}"
+            f"\nM{NUL}foo.py{NUL}"
+        )
+        when(test).get_repo_path().thenReturn("/repo")
+        file_history_cache.clear()
+        commit_info_cache.clear()
+
+        result = test.recent_commit("c5", "/repo/foo.py", follow=True)
+
+        self.assertEqual(result, "c3")
+        self.assertIn(("c3", "/repo/foo.py"), file_history_cache)
+        self.assertIn("c3", commit_info_cache)
+
+    def test_recent_commit_returns_none_when_history_empty(self):
+        test = HistoryMixin()
+        when(test).git("log", ...).thenReturn("")
+
+        result = test.recent_commit("c5", "/repo/foo.py", follow=True)
 
         self.assertIsNone(result)
 


### PR DESCRIPTION
Route file-scoped recent commit lookups through the history parser so
that commit and file history caches are populated for follow-enabled
queries.

Keep the inline diff previous-commit lookup on the simpler non-follow
path where it only needs the direct parent for the active file.