### PR TITLE
Add viewport revision navigation

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1355,6 +1355,22 @@
         ]
     },
     {
+        "keys": ["P"],
+        "command": "gs_show_file_at_commit_open_previous_change",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.show_file_at_commit_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["N"],
+        "command": "gs_show_file_at_commit_open_next_change",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.show_file_at_commit_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
         "keys": ["i"],
         "command": "gs_show_file_at_commit_open_info_popup",
         "context": [

--- a/README.md
+++ b/README.md
@@ -203,8 +203,11 @@ yet, as usual.)
  the *"hunk-history"*, so to speak.
 
 *Even deeper*: After `[o]` or `[O]` you can navigate around in time with `[n]` (next) and `[p]`
- (previous).  You can show the commit's context using `[g]`, and the hunks context by opening the
- inline diff.  That's easier with more keybindings:
+ (previous).  In file-at-commit views, `[N]` skips unrelated file revisions and jumps to the previous
+ revision that changed the code currently visible in the viewport. `[P]` returns through those jumps.
+ This is useful when you want to follow the evolution of a function or feature without stepping through
+ every noisy commit that touched the file.  You can show the commit's context using `[g]`, and the
+ hunks context by opening the inline diff.  That's easier with more keybindings:
 
 ```
   { "keys": ["ctrl+shift+,"], "command": "gs_inline_diff" },

--- a/core/commands/help_panel.py
+++ b/core/commands/help_panel.py
@@ -229,6 +229,7 @@ class gs_show_file_at_commit_help_panel(GsAbstractOpenHelpPanel):
     [O]            open working dir file
     [g]            show in graph
     [n]/[p]        show next/previous revision of this file
+    [N]/[P]        show previous revision of visible code / return
     [l]            choose different revision of this file
     [,]/[.]        go to next/previous hunk
 

--- a/core/commands/show_file_at_commit.py
+++ b/core/commands/show_file_at_commit.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from contextlib import contextmanager
 from functools import lru_cache
 import os
 import re
@@ -40,7 +41,7 @@ __all__ = (
 )
 
 
-from typing import Dict, NamedTuple, Optional, Set, Tuple
+from typing import Dict, Iterator, NamedTuple, Optional, Set, Tuple
 
 
 SHOW_COMMIT_TITLE = "FILE: {}, {}"
@@ -284,12 +285,10 @@ class gs_show_file_at_commit_open_previous_commit(GsTextCommand):
             )
             position = Position(line - 1, col, offset)
 
-        popup_was_visible = settings.get("git_savvy.show_file_at_commit.info_popup_visible")
-        view.run_command("gs_show_file_at_commit_refresh", {
-            "position": position
-        })
-        if popup_was_visible:
-            view.run_command("gs_show_file_at_commit_open_info_popup")
+        with keep_info_popup_state(view):
+            view.run_command("gs_show_file_at_commit_refresh", {
+                "position": position
+            })
 
 
 class gs_show_file_at_commit_open_next_commit(GsTextCommand):
@@ -325,12 +324,10 @@ class gs_show_file_at_commit_open_next_commit(GsTextCommand):
             )
             position = Position(line - 1, col, offset)
 
-        popup_was_visible = settings.get("git_savvy.show_file_at_commit.info_popup_visible")
-        view.run_command("gs_show_file_at_commit_refresh", {
-            "position": position
-        })
-        if popup_was_visible:
-            view.run_command("gs_show_file_at_commit_open_info_popup")
+        with keep_info_popup_state(view):
+            view.run_command("gs_show_file_at_commit_refresh", {
+                "position": position
+            })
 
 
 class gs_show_file_at_commit_open_next_change(GsTextCommand):
@@ -373,7 +370,8 @@ class gs_show_file_at_commit_open_next_change(GsTextCommand):
             )
             position = Position(line - 1, col, offset)
 
-        refresh_show_file_at_commit_view(view, position)
+        with keep_info_popup_state(view):
+            view.run_command("gs_show_file_at_commit_refresh", {"position": position})
 
 
 class gs_show_file_at_commit_open_previous_change(GsTextCommand):
@@ -388,9 +386,9 @@ class gs_show_file_at_commit_open_previous_change(GsTextCommand):
 
         settings.set("git_savvy.show_file_at_commit_view.commit", previous["to_commit"])
         position = position_from_setting(previous.get("position"))
-        refresh_show_file_at_commit_view(view, position)
 
-
+        with keep_info_popup_state(view):
+            view.run_command("gs_show_file_at_commit_refresh", {"position": position})
 
 
 def visible_line_range(view: sublime.View) -> Optional[Tuple[int, int]]:
@@ -403,16 +401,16 @@ def visible_line_range(view: sublime.View) -> Optional[Tuple[int, int]]:
     return start_row + 1, end_row + 1
 
 
-def refresh_show_file_at_commit_view(
-    view: sublime.View,
-    position: Optional[Position]
-) -> None:
+@contextmanager
+def keep_info_popup_state(view: sublime.View) -> Iterator[None]:
     popup_was_visible = view.settings().get(
         "git_savvy.show_file_at_commit.info_popup_visible"
     )
-    view.run_command("gs_show_file_at_commit_refresh", {"position": position})
-    if popup_was_visible:
-        view.run_command("gs_show_file_at_commit_open_info_popup")
+    try:
+        yield
+    finally:
+        if popup_was_visible:
+            view.run_command("gs_show_file_at_commit_open_info_popup")
 
 
 def get_next_commit(

--- a/core/commands/show_file_at_commit.py
+++ b/core/commands/show_file_at_commit.py
@@ -344,17 +344,12 @@ class gs_show_file_at_commit_open_next_change(GsTextCommand):
             flash(view, "No visible lines to inspect.")
             return
 
-        try:
-            commit = recent_commit_for_line_range(
-                self,
-                commit_hash,
-                file_path,
-                line_range
-            )
-        except GitSavvyError:
-            flash(view, "Could not inspect the visible lines.")
-            return
-
+        commit = self.recent_commit_for_line_range(
+            commit_hash,
+            file_path,
+            line_range,
+            skip_current=True
+        )
         if not commit:
             flash(view, "No older change found in the visible lines.")
             return
@@ -393,26 +388,6 @@ class gs_show_file_at_commit_open_previous_change(GsTextCommand):
         refresh_show_file_at_commit_view(view, position)
 
 
-def recent_commit_for_line_range(
-    cmd: GitCommand,
-    commit_hash: str,
-    file_path: str,
-    line_range: Tuple[int, int]
-) -> Optional[str]:
-    commit_hash = cmd.get_short_hash(commit_hash)
-    file_path_at_commit = cmd.filename_at_commit(file_path, commit_hash)
-    relative_path = cmd.to_rel_path(file_path_at_commit)
-    start_line, end_line = line_range
-    output = cmd.git(
-        "log",
-        "--format=%x1e%h",
-        "-2",
-        f"-L{start_line},{end_line}:{relative_path}",
-        commit_hash,
-        # show_panel_on_error=False
-    )
-    commits = re.findall(r"\x1e([0-9a-f]+)", output)
-    return next((commit for commit in commits if commit != commit_hash), None)
 
 
 def visible_line_range(view: sublime.View) -> Optional[Tuple[int, int]]:

--- a/core/commands/show_file_at_commit.py
+++ b/core/commands/show_file_at_commit.py
@@ -363,13 +363,16 @@ class gs_show_file_at_commit_open_next_change(GsTextCommand):
         })
 
         settings.set("git_savvy.show_file_at_commit_view.commit", commit)
-        position = translate_position_between_commits(
-            self,
-            file_path,
-            commit_hash,
-            commit,
-            current_position
-        )
+        position = None
+        if current_position is not None:
+            row, col, offset = current_position
+            line = self.find_matching_lineno_between_files(
+                (commit_hash, self.filename_at_commit(file_path, commit_hash)),
+                (commit, self.filename_at_commit(file_path, commit)),
+                row + 1
+            )
+            position = Position(line - 1, col, offset)
+
         refresh_show_file_at_commit_view(view, position)
 
 
@@ -398,25 +401,6 @@ def visible_line_range(view: sublime.View) -> Optional[Tuple[int, int]]:
     start_row, _ = view.rowcol(visible_region.a)
     end_row, _ = view.rowcol(visible_region.b)
     return start_row + 1, end_row + 1
-
-
-def translate_position_between_commits(
-    cmd: GitCommand,
-    file_path: str,
-    from_commit: str,
-    to_commit: str,
-    position: Optional[Position]
-) -> Optional[Position]:
-    if position is None:
-        return None
-
-    row, col, offset = position
-    line = cmd.find_matching_lineno_between_files(
-        (from_commit, cmd.filename_at_commit(file_path, from_commit)),
-        (to_commit, cmd.filename_at_commit(file_path, to_commit)),
-        row + 1
-    )
-    return Position(line - 1, col, offset)
 
 
 def refresh_show_file_at_commit_view(

--- a/core/commands/show_file_at_commit.py
+++ b/core/commands/show_file_at_commit.py
@@ -30,6 +30,8 @@ __all__ = (
     "gs_show_file_at_commit_open_log",
     "gs_show_file_at_commit_open_previous_commit",
     "gs_show_file_at_commit_open_next_commit",
+    "gs_show_file_at_commit_open_previous_change",
+    "gs_show_file_at_commit_open_next_change",
     "gs_show_file_at_commit_open_commit",
     "gs_show_file_at_commit_open_file_on_working_dir",
     "gs_show_file_at_commit_open_graph_context",
@@ -331,6 +333,129 @@ class gs_show_file_at_commit_open_next_commit(GsTextCommand):
             view.run_command("gs_show_file_at_commit_open_info_popup")
 
 
+class gs_show_file_at_commit_open_next_change(GsTextCommand):
+    def run(self, edit) -> None:
+        view = self.view
+        settings = view.settings()
+        file_path: str = settings.get("git_savvy.file_path")
+        commit_hash: str = settings.get("git_savvy.show_file_at_commit_view.commit")
+        line_range = visible_line_range(view)
+        if line_range is None:
+            flash(view, "No visible lines to inspect.")
+            return
+
+        try:
+            commit = recent_commit_for_line_range(
+                self,
+                commit_hash,
+                file_path,
+                line_range
+            )
+        except GitSavvyError:
+            flash(view, "Could not inspect the visible lines.")
+            return
+
+        if not commit:
+            flash(view, "No older change found in the visible lines.")
+            return
+
+        current_position = capture_cur_position(view)
+        remember_line_change_navigation(view, {
+            "from_commit": commit,
+            "to_commit": commit_hash,
+            "line_range": list(line_range),
+            "position": list(current_position) if current_position else None,
+        })
+
+        settings.set("git_savvy.show_file_at_commit_view.commit", commit)
+        position = translate_position_between_commits(
+            self,
+            file_path,
+            commit_hash,
+            commit,
+            current_position
+        )
+        refresh_show_file_at_commit_view(view, position)
+
+
+class gs_show_file_at_commit_open_previous_change(GsTextCommand):
+    def run(self, edit) -> None:
+        view = self.view
+        settings = view.settings()
+        commit_hash: str = settings.get("git_savvy.show_file_at_commit_view.commit")
+        previous = pop_line_change_navigation(view, commit_hash)
+        if not previous:
+            flash(view, "No line-change navigation to undo.")
+            return
+
+        settings.set("git_savvy.show_file_at_commit_view.commit", previous["to_commit"])
+        position = position_from_setting(previous.get("position"))
+        refresh_show_file_at_commit_view(view, position)
+
+
+def recent_commit_for_line_range(
+    cmd: GitCommand,
+    commit_hash: str,
+    file_path: str,
+    line_range: Tuple[int, int]
+) -> Optional[str]:
+    commit_hash = cmd.get_short_hash(commit_hash)
+    file_path_at_commit = cmd.filename_at_commit(file_path, commit_hash)
+    relative_path = cmd.to_rel_path(file_path_at_commit)
+    start_line, end_line = line_range
+    output = cmd.git(
+        "log",
+        "--format=%x1e%h",
+        "-2",
+        f"-L{start_line},{end_line}:{relative_path}",
+        commit_hash,
+        # show_panel_on_error=False
+    )
+    commits = re.findall(r"\x1e([0-9a-f]+)", output)
+    return next((commit for commit in commits if commit != commit_hash), None)
+
+
+def visible_line_range(view: sublime.View) -> Optional[Tuple[int, int]]:
+    if view.size() == 0:
+        return None
+
+    visible_region = view.visible_region()
+    start_row, _ = view.rowcol(visible_region.a)
+    end_row, _ = view.rowcol(visible_region.b)
+    return start_row + 1, end_row + 1
+
+
+def translate_position_between_commits(
+    cmd: GitCommand,
+    file_path: str,
+    from_commit: str,
+    to_commit: str,
+    position: Optional[Position]
+) -> Optional[Position]:
+    if position is None:
+        return None
+
+    row, col, offset = position
+    line = cmd.find_matching_lineno_between_files(
+        (from_commit, cmd.filename_at_commit(file_path, from_commit)),
+        (to_commit, cmd.filename_at_commit(file_path, to_commit)),
+        row + 1
+    )
+    return Position(line - 1, col, offset)
+
+
+def refresh_show_file_at_commit_view(
+    view: sublime.View,
+    position: Optional[Position]
+) -> None:
+    popup_was_visible = view.settings().get(
+        "git_savvy.show_file_at_commit.info_popup_visible"
+    )
+    view.run_command("gs_show_file_at_commit_refresh", {"position": position})
+    if popup_was_visible:
+        view.run_command("gs_show_file_at_commit_open_info_popup")
+
+
 def get_next_commit(
     cmd: GitCommand,
     view: sublime.View,
@@ -384,6 +509,37 @@ def get_branch_hint_for_view(cmd: GitCommand, view: sublime.View, commit_hash: s
     branch_hint = cmd.get_branch_hint_for_commit(commit_hash)
     remember_branch_hint_for(view, branch_hint)
     return branch_hint
+
+
+def remember_line_change_navigation(view: sublime.View, entry: Dict) -> None:
+    settings = view.settings()
+    stack = settings.get("git_savvy.line_change_navigation", [])
+    stack.append(entry)
+    settings.set("git_savvy.line_change_navigation", stack)
+
+
+def pop_line_change_navigation(
+    view: sublime.View,
+    commit_hash: str
+) -> Optional[Dict]:
+    settings = view.settings()
+    stack: list[dict] = settings.get("git_savvy.line_change_navigation", [])
+    while stack:
+        entry = stack.pop()
+        if entry.get("from_commit") == commit_hash:
+            settings.set("git_savvy.line_change_navigation", stack)
+            return entry
+
+    settings.set("git_savvy.line_change_navigation", stack)
+    return None
+
+
+def position_from_setting(value) -> Optional[Position]:
+    if value is None:
+        return None
+
+    row, col, offset = value
+    return Position(row, col, offset)
 
 
 def remember_next_commit_for(view: sublime.View, mapping: Dict[str, str]) -> None:

--- a/core/git_mixins/history.py
+++ b/core/git_mixins/history.py
@@ -629,6 +629,24 @@ class HistoryMixin(mixin_base):
             None
         )
 
+    def recent_commit_for_line_range(
+        self,
+        current_commit: str,
+        file_path: str,
+        line_range: tuple[int, int],
+        skip_current: bool = False
+    ) -> Optional[str]:
+        current_commit = self.get_short_hash(current_commit)
+        commits = self._log_commits_for_line_range(
+            current_commit,
+            file_path,
+            line_range
+        )
+        return next(
+            (commit for commit in commits if not skip_current or commit != current_commit),
+            None
+        )
+
     def next_commit(self, current_commit, file_path=None, follow=False):
         # type: (str, Optional[str], bool) -> Optional[str]
         return last(
@@ -676,6 +694,29 @@ class HistoryMixin(mixin_base):
                 return ""
             else:
                 raise ValueError(f"{commit_hash} seems orphaned")
+
+    @cached(not_if={"current_commit": is_dynamic_ref})
+    def _log_commits_for_line_range(
+        self,
+        current_commit: str,
+        file_path: str,
+        line_range: tuple[int, int]
+    ) -> list[str]:
+        file_path_at_commit = self.filename_at_commit(file_path, current_commit)
+        relative_path = self.to_rel_path(file_path_at_commit)
+        start_line, end_line = line_range
+        output = self.git(
+            "log",
+            "--format=%x1e%h",
+            "-2",
+            f"-L{start_line},{end_line}:{relative_path}",
+            current_commit
+        )
+        return [
+            line.strip()
+            for record in output.split("\x1e")
+            if record and (line := record.splitlines()[0])
+        ]
 
     def _log_commits_linewise(
         self,


### PR DESCRIPTION
Add N/P commands in file-at-commit views to jump to the previous
revision that changed the currently visible code, and to return through
those jumps.  Use a view-local stack for the return path so the forward
navigation can always use the current viewport.

Document the new key bindings in the help panel and README.