### PR TITLE
Open blame from file revisions

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1339,6 +1339,14 @@
         ]
     },
     {
+        "keys": ["b"],
+        "command": "gs_show_file_at_commit_open_blame",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.show_file_at_commit_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
         "keys": ["p"],
         "command": "gs_show_file_at_commit_open_previous_commit",
         "context": [

--- a/README.md
+++ b/README.md
@@ -206,8 +206,9 @@ yet, as usual.)
  (previous).  In file-at-commit views, `[N]` skips unrelated file revisions and jumps to the previous
  revision that changed the code currently visible in the viewport. `[P]` returns through those jumps.
  This is useful when you want to follow the evolution of a function or feature without stepping through
- every noisy commit that touched the file.  You can show the commit's context using `[g]`, and the
- hunks context by opening the inline diff.  That's easier with more keybindings:
+ every noisy commit that touched the file.  You can show the commit's context using `[g]`, open
+ blame for the current revision with `[b]`, and show the hunks context by opening the inline diff.
+ That's easier with more keybindings:
 
 ```
   { "keys": ["ctrl+shift+,"], "command": "gs_inline_diff" },
@@ -228,7 +229,7 @@ GitSavvy offers fixup/squash helpers that can be accessed from various views, in
 GitSavvy provides GitHub integration that allows users to reference issues/collaborators when committing, open the current file or a commit on GitHub at the selected line, and create a new pull request from the current branch.
 
 ## GitHub-Style Blame View
-GitSavvy offers a "blame" view that shows hunk metadata and allows users to view the commit that made the change, similar to GitHub's blame view.
+GitSavvy offers a "blame" view that shows hunk metadata and allows users to view the commit that made the change, similar to GitHub's blame view.  In file-at-commit views, `[b]` opens blame for that revision at the same visible position.
 
 ## Other highlights
 

--- a/core/commands/blame.py
+++ b/core/commands/blame.py
@@ -73,7 +73,14 @@ class BlameMixin(GsTextCommand):
 
 
 class gs_blame(BlameMixin):
-    def run(self, edit, file_path: str = None, repo_path: str = None, commit_hash: str = None):
+    def run(
+        self,
+        edit,
+        file_path: str = None,
+        repo_path: str = None,
+        commit_hash: str = None,
+        position: Position = None
+    ):
         self.__repo_path = repo_path or self.repo_path
         self._file_path = file_path or self.file_path
         if not self._file_path:
@@ -85,6 +92,7 @@ class gs_blame(BlameMixin):
         if commit_hash:
             commit_hash = self.get_short_hash(commit_hash)
         self._commit_hash = commit_hash
+        self._position = Position(*position) if position else None
 
         sublime.set_timeout_async(self.blame)
 
@@ -99,7 +107,15 @@ class gs_blame(BlameMixin):
         settings.set("git_savvy.repo_path", self.__repo_path)
         settings.set("git_savvy.file_path", self._file_path)
 
-        if original_view.settings().get("git_savvy.blame_view"):
+        if self._position:
+            lineno = self._position.row + 1
+            if self._position.offset is not None:
+                settings.set("git_savvy.blame_view.y_offset", self._position.offset)
+            settings.set("git_savvy.blame_view.ignore_whitespace", False)
+            settings.set("git_savvy.blame_view.detect_move_or_copy_within", None)
+            settings.set("git_savvy.original_syntax", original_view.settings().get('syntax'))
+
+        elif original_view.settings().get("git_savvy.blame_view"):
             lineno = self.find_matching_lineno_in_file_history(
                 original_view.settings().get("git_savvy.commit_hash"),
                 self._commit_hash,
@@ -217,12 +233,16 @@ class gs_blame_refresh(BlameMixin):
 
         replace_view_content(self.view, content)
 
+        initial_y_offset = settings.get("git_savvy.blame_view.y_offset")
+        settings.erase("git_savvy.blame_view.y_offset")
         if settings.get("git_savvy.lineno", None) is not None:
             self.select_line(settings.get("git_savvy.lineno"))
             settings.erase("git_savvy.lineno")
 
         if len(self.view.sel()) > 0:
-            if was_empty:
+            if initial_y_offset is not None:
+                scroll_to_pt(self.view, self.view.sel()[0].begin(), initial_y_offset)
+            elif was_empty:
                 # if it was opened as a new file
                 self.view.show_at_center(self.view.line(self.view.sel()[0].begin()).begin())
             else:

--- a/core/commands/help_panel.py
+++ b/core/commands/help_panel.py
@@ -228,6 +228,7 @@ class gs_show_file_at_commit_help_panel(GsAbstractOpenHelpPanel):
     [o]            open commit
     [O]            open working dir file
     [g]            show in graph
+    [b]            open blame view
     [n]/[p]        show next/previous revision of this file
     [N]/[P]        show previous revision of visible code / return
     [l]            choose different revision of this file

--- a/core/commands/show_file_at_commit.py
+++ b/core/commands/show_file_at_commit.py
@@ -33,6 +33,7 @@ __all__ = (
     "gs_show_file_at_commit_open_next_commit",
     "gs_show_file_at_commit_open_previous_change",
     "gs_show_file_at_commit_open_next_change",
+    "gs_show_file_at_commit_open_blame",
     "gs_show_file_at_commit_open_commit",
     "gs_show_file_at_commit_open_file_on_working_dir",
     "gs_show_file_at_commit_open_graph_context",
@@ -700,6 +701,18 @@ class gs_show_file_at_commit_open_log(GsTextCommand):
         view.run_command("gs_show_file_at_commit_refresh", {
             "position": position,
             "sync": False,
+        })
+
+
+class gs_show_file_at_commit_open_blame(GsTextCommand):
+    def run(self, edit) -> None:
+        settings = self.view.settings()
+        position = capture_cur_position(self.view)
+        self.view.run_command("gs_blame", {
+            "repo_path": settings.get("git_savvy.repo_path"),
+            "file_path": settings.get("git_savvy.file_path"),
+            "commit_hash": settings.get("git_savvy.show_file_at_commit_view.commit"),
+            "position": list(position) if position else None,
         })
 
 


### PR DESCRIPTION
Add a file-at-commit command and key binding to open blame for the shown revision.  Pass the captured view position into blame so the new view opens at the same line and vertical offset the user was looking at.

Document the new binding in the help panel and README.