### PR TITLE
Avoid doubled v in tag messages

### DIFF
--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -167,6 +167,10 @@
     /*
         When entering a tag message, this will be used if the message is empty.
         The replacement value "{tag_name}" is optional, but recommended.
+
+        If this is configured with a literal `v` before the placeholder, e.g.
+        "v{tag_name}", GitSavvy will avoid doubling it for tag names that
+        already start with `v`.
      */
     "default_tag_message": "Tag {tag_name}",
 

--- a/core/commands/tag.py
+++ b/core/commands/tag.py
@@ -80,6 +80,14 @@ def smart_incremented_tag(tag, release_type):
     return None
 
 
+def default_tag_message(message_template: str, tag_name: str) -> str:
+    if tag_name[:1].lower() == "v":
+        message_template = message_template.replace("v{tag_name}", "{tag_name}")
+        message_template = message_template.replace("V{tag_name}", "{tag_name}")
+
+    return message_template.format(tag_name=tag_name)
+
+
 class gs_tag_create(GsTextCommand):
 
     """
@@ -123,7 +131,7 @@ class gs_tag_create(GsTextCommand):
         if MAYBE_SEMVER.search(tag_name) and self.savvy_settings.get("only_ask_to_annotate_versions"):
             show_single_line_input_panel(
                 TAG_CREATE_MESSAGE_PROMPT,
-                self.savvy_settings.get("default_tag_message").format(tag_name=tag_name),
+                default_tag_message(self.savvy_settings.get("default_tag_message"), tag_name),
                 self.on_entered_message
             )
         else:

--- a/tests/test_smart_tag.py
+++ b/tests/test_smart_tag.py
@@ -1,9 +1,16 @@
-from GitSavvy.core.commands.tag import smart_incremented_tag
+from GitSavvy.core.commands.tag import default_tag_message, smart_incremented_tag
 
 import unittest
 
 
 class TestSmartTag(unittest.TestCase):
+    def test_default_tag_message(self):
+        self.assertEqual(default_tag_message('v{tag_name}', '2.1.0'), 'v2.1.0')
+        self.assertEqual(default_tag_message('v{tag_name}', 'v2.1.0'), 'v2.1.0')
+        self.assertEqual(default_tag_message('V{tag_name}', 'v2.1.0'), 'v2.1.0')
+        self.assertEqual(default_tag_message('Tag {tag_name}', 'v2.1.0'), 'Tag v2.1.0')
+        self.assertEqual(default_tag_message('Release v{tag_name}', 'v2.1.0'), 'Release v2.1.0')
+
     def test_smart_tag(self):
         self.assertEqual(smart_incremented_tag('v1.3.2', "prerelease"), 'v1.3.3-0')
         self.assertEqual(smart_incremented_tag('v1.3.2', "prepatch"), 'v1.3.3-0')


### PR DESCRIPTION
When the default tag message prefixes the tag name with a literal v, do not add another one for tag names that already start with v.

Document the behavior and cover the helper with tests.