### PR TITLE
Fix PR remote branch cleanup

### DIFF
--- a/core/commands/remote.py
+++ b/core/commands/remote.py
@@ -70,7 +70,15 @@ class gs_remote_remove(GsWindowCommand):
     @util.actions.destructive(description="remove a remote")
     def on_remote_selection(self, remote):
         self.git("remote", "remove", remote)
+        self.remove_remote_tracking_refs(remote)
         util.view.refresh_gitsavvy_interfaces(self.window, refresh_status_bar=False)
+
+    def remove_remote_tracking_refs(self, remote):
+        prefix = f"refs/remotes/{remote}/"
+        refs = self.git("for-each-ref", "--format=%(refname)", prefix).splitlines()
+        for ref in refs:
+            if ref.startswith(prefix):
+                self.git("update-ref", "--no-deref", "-d", ref)
 
 
 class gs_remote_rename(GsWindowCommand):

--- a/github/commands/pull_request.py
+++ b/github/commands/pull_request.py
@@ -169,7 +169,7 @@ class gs_github_pull_request(GsWindowCommand, git_mixins.GithubRemotesMixin):
                 self.git("config", f"remote.{owner}.tagOpt", "--no-tags")
                 self.git("config", f"remote.{owner}.followRemoteHEAD", "never")
                 if default_branch := self.guess_default_branch(owner):
-                    if default_branch != branch_name:
+                    if default_branch != ref:
                         self.git("config", "--add", f"remote.{owner}.fetch", f"^refs/heads/{default_branch}")
 
             self.git("fetch", owner, ref)


### PR DESCRIPTION
- compare a PR's remote default branch against the PR head ref before adding a negative fetch refspec
- clean stale `refs/remotes/<remote>/...` refs after removing a remote

GitSavvy creates helper remotes for fork and pull-request workflows.  When the
PR head is the fork's default branch, e.g. `kylebebak:master`, the PR checkout
code previously compared the default branch (`master`) to the suggested local
branch (`kylebebak-master`).  That incorrectly excluded the very branch we were
about to fetch via `^refs/heads/master`.

Those excluded refs can survive `git remote remove`, leaving stale remote
branches visible in GitSavvy branch and graph views even though the remote
config is gone.  After removing a remote, GitSavvy now deletes leftover refs in
that remote's conventional tracking namespace.

