### PR TITLE
Support worktree parsing on old Git

### DIFF
--- a/core/git_mixins/worktrees.py
+++ b/core/git_mixins/worktrees.py
@@ -2,13 +2,25 @@ from __future__ import annotations
 from itertools import count
 import os
 
-from typing import NamedTuple
+from typing import Iterable, NamedTuple
 
 import sublime
 
 from GitSavvy.core.fns import filter_
 from GitSavvy.core.caches import cache_in_store_as
 from GitSavvy.core.git_command import mixin_base
+
+
+WORKTREE_LIST_SUPPORTS_Z_FORMAT = (2, 36, 0)
+WORKTREE_LIST_PORCELAIN_FIELD_PREFIXES = (
+    "worktree ",
+    "HEAD ",
+    "branch ",
+    "locked",
+    "prunable",
+    "bare",
+    "detached"
+)
 
 
 class Worktree(NamedTuple):
@@ -27,6 +39,21 @@ class Worktree(NamedTuple):
 class WorktreesMixin(mixin_base):
     @cache_in_store_as("worktrees")
     def get_worktrees(self) -> list[Worktree]:
+        if self.git_version < WORKTREE_LIST_SUPPORTS_Z_FORMAT:
+            return self._get_worktrees_without_z()
+
+        stdout: str = self.git("worktree", "list", "--porcelain", "-z")
+        return self._parse_worktree_entries(stdout.split("\0"))
+
+    def _get_worktrees_without_z(self) -> list[Worktree]:
+        stdout: str = self.git("worktree", "list", "--porcelain")
+        fields = stdout.splitlines()
+        if any(_looks_malformed_non_z_field(field) for field in filter_(fields)):
+            return []
+
+        return self._parse_worktree_entries(fields)
+
+    def _parse_worktree_entries(self, fields: Iterable[str]) -> list[Worktree]:
         normalized_repo_path = self.repo_path.replace("\\", "/")
         worktrees: list[Worktree] = []
 
@@ -47,8 +74,7 @@ class WorktreesMixin(mixin_base):
             ))
 
         current: dict = {}
-        stdout: str = self.git("worktree", "list", "--porcelain", "-z")
-        for field in filter_(stdout.split("\0")):
+        for field in filter_(fields):
             if field.startswith("worktree "):
                 commit_current(current)
                 current = {}
@@ -89,3 +115,10 @@ class WorktreesMixin(mixin_base):
 
     def remove_worktree(self, path: str, *, force: bool = False):
         self.git("worktree", "remove", "-f" if force else None, path)
+
+
+def _looks_malformed_non_z_field(field: str) -> bool:
+    return (
+        field.startswith('worktree "')
+        or not field.startswith(WORKTREE_LIST_PORCELAIN_FIELD_PREFIXES)
+    )

--- a/tests/test_git_mixins.py
+++ b/tests/test_git_mixins.py
@@ -11,6 +11,7 @@ from GitSavvy.tests.parameterized import parameterized as p, param
 
 from GitSavvy.core.git_command import GitCommand
 from GitSavvy.core import git_mixins
+from GitSavvy.core.git_mixins.worktrees import Worktree, WorktreesMixin
 from GitSavvy.core.utils import resolve_path
 
 
@@ -233,6 +234,103 @@ class TestGetBranchesParsing(TestGitMixinsUsage):
                 None
             )
         ])
+
+
+class TestGetWorktreesParsing(TestGitMixinsUsage):
+    def test_old_git_uses_non_z_parser(self):
+        repo = WorktreesTestRepo(
+            (2, 34, 1),
+            "\n".join((
+                "worktree C:/Users/c-flo/AppData/Roaming/Sublime Text/Packages/GitSavvy",
+                "HEAD 0da1384c809f837b835c335ffdc513337308f1d8",
+                "detached",
+                "",
+                "worktree C:/Users/c-flo/Dev/GitSavvy-enhance-merge-branch-list",
+                "HEAD 72021faf22b1377d3c4b72b350a95ea71f585efb",
+                "branch refs/heads/enhance-merge-branch-list",
+                ""
+            )),
+            "C:/Users/c-flo/AppData/Roaming/Sublime Text/Packages/GitSavvy"
+        )
+
+        actual = repo.get_worktrees()
+
+        self.assertEqual(repo.git_args, ("worktree", "list", "--porcelain"))
+        self.assertEqual(actual, [
+            Worktree(
+                "C:/Users/c-flo/AppData/Roaming/Sublime Text/Packages/GitSavvy",
+                "0da1384c809f837b835c335ffdc513337308f1d8",
+                None,
+                True,
+                False,
+                False
+            ),
+            Worktree(
+                "C:/Users/c-flo/Dev/GitSavvy-enhance-merge-branch-list",
+                "72021faf22b1377d3c4b72b350a95ea71f585efb",
+                "enhance-merge-branch-list",
+                False,
+                False,
+                False
+            )
+        ])
+
+    def test_old_git_drops_malformed_non_z_output(self):
+        repo = WorktreesTestRepo(
+            (2, 34, 1),
+            "\n".join((
+                "worktree /tmp/work",
+                "tree",
+                "HEAD 0da1384c809f837b835c335ffdc513337308f1d8",
+                "branch refs/heads/master",
+                ""
+            )),
+            "/tmp/work\ntree"
+        )
+
+        actual = repo.get_worktrees()
+
+        self.assertEqual(actual, [])
+
+    def test_old_git_drops_quoted_non_z_paths(self):
+        repo = WorktreesTestRepo(
+            (2, 34, 1),
+            "\n".join((
+                'worktree "/tmp/work\\ntree"',
+                "HEAD 0da1384c809f837b835c335ffdc513337308f1d8",
+                "branch refs/heads/master",
+                ""
+            )),
+            "/tmp/work\ntree"
+        )
+
+        actual = repo.get_worktrees()
+
+        self.assertEqual(actual, [])
+
+
+class WorktreesTestRepo(WorktreesMixin):
+    def __init__(self, git_version, stdout, repo_path):
+        self._git_version = git_version
+        self.stdout = stdout
+        self._repo_path = repo_path
+        self.git_args = None
+        self.store = None
+
+    @property
+    def git_version(self):
+        return self._git_version
+
+    @property
+    def repo_path(self):
+        return self._repo_path
+
+    def git(self, *args, **kwargs):
+        self.git_args = args
+        return self.stdout
+
+    def update_store(self, partial_state):
+        self.store = partial_state
 
 
 TMPDIR_PREFIX = "GitSavvy-end-to-end-test-"


### PR DESCRIPTION
Fall back to newline-separated porcelain output when Git is older than 2.36 and does not support `git worktree list --porcelain -z`.

If that legacy output appears malformed or contains C-quoted paths, return no worktrees instead of guessing at paths that may contain newlines.

Fixes #2060.