### PR TITLE
Undo in graph

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1747,6 +1747,14 @@
         ]
     },
     {
+        "keys": ["primary+z"],
+        "command": "gs_ref_undo",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.tags_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
         "keys": ["c"],
         "command": "gs_tag_create",
         "context": [
@@ -1909,6 +1917,14 @@
         "keys": ["D"],
         "command": "gs_branches_delete",
         "args": { "force": true },
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.branch_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["primary+z"],
+        "command": "gs_ref_undo",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.branch_view", "operator": "equal", "operand": true }

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -2160,6 +2160,22 @@
         ]
     },
     {
+        "keys": ["D"],
+        "command": "gs_log_graph_delete_decoration",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.log_graph_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["primary+z"],
+        "command": "gs_log_graph_undo_ref_action",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.log_graph_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
         "keys": ["m"],
         "command": "gs_log_graph_toggle_commit_info_panel",
         "context": [

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -2169,7 +2169,7 @@
     },
     {
         "keys": ["primary+z"],
-        "command": "gs_log_graph_undo_ref_action",
+        "command": "gs_ref_undo",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.log_graph_view", "operator": "equal", "operand": true }

--- a/core/base_commands.py
+++ b/core/base_commands.py
@@ -195,3 +195,10 @@ ask_for_local_branch = ask_for_branch(
     ignore_current_branch=True,
     local_branches_only=True
 )
+
+
+def std_undo_owner(self: GsCommand, args: Args, done: Kont) -> None:
+    if av := self.window.active_view():
+        done(av.id())
+    else:
+        self.window.status_message("No active_view() available.")

--- a/core/commands/__init__.py
+++ b/core/commands/__init__.py
@@ -34,6 +34,7 @@ from .pull import *
 from .push import *
 from .quick_commit import *
 from .quick_stage import *
+from .ref_undo import *
 from .reflog import *
 from .remote import *
 from .reset import *

--- a/core/commands/branch.py
+++ b/core/commands/branch.py
@@ -1,10 +1,10 @@
+from __future__ import annotations
 from functools import lru_cache
 import inspect
 import re
 import sublime
 
-from . import push
-from .ref_undo import add_branch_undo
+from . import push, ref_undo
 from ..git_command import GitSavvyError
 from ..ui_mixins.input_panel import show_single_line_input_panel
 from ...common import util
@@ -21,7 +21,7 @@ __all__ = (
 )
 
 
-from typing import Callable, TypeVar
+from typing import Callable, Optional, TypeVar
 from GitSavvy.core.base_commands import Args, Kont
 T = TypeVar("T")
 
@@ -161,8 +161,16 @@ class gs_delete_branch(GsWindowCommand):
     }
 
     @util.actions.destructive(description="delete a local branch")
-    def run(self, branch, force=False):
-        # type: (str, bool) -> None
+    def run(
+        self,
+        branch: str,
+        force: bool = False,
+        undo_owner: Optional[sublime.ViewId] = None
+    ) -> None:
+        if undo_owner is None:
+            av = self.window.active_view()
+            undo_owner = av.id() if av else None
+
         old_hash = self.git("rev-parse", "--verify", f"refs/heads/{branch}").strip()
         if force:
             rv = self.git("branch", "-D", branch)
@@ -171,18 +179,20 @@ class gs_delete_branch(GsWindowCommand):
                 rv = self.git_throwing_silently("branch", "-d", branch)
             except GitSavvyError as e:
                 if NOT_MERGED_WARNING.search(e.stderr):
-                    self.offer_force_deletion(branch)
+                    self.offer_force_deletion(branch, undo_owner)
                     return
                 if (
                     CANT_DELETE_USED_BRANCH.search(e.stderr)
                     and branch == self.get_current_branch_name()
                 ):
-                    self.offer_detaching_head(branch)
+                    self.offer_detaching_head(branch, undo_owner)
                     return
                 e.show_error_panel()
                 raise
 
-        add_branch_undo(self, branch, old_hash)
+        if undo_owner:
+            ref_undo.add_branch_undo(self, branch, old_hash, undo_owner)
+
         match = EXTRACT_COMMIT.search(rv.strip())
         if match:
             commit = match.group(1)
@@ -193,23 +203,27 @@ class gs_delete_branch(GsWindowCommand):
         )
         util.view.refresh_gitsavvy_interfaces(self.window)
 
-    def offer_force_deletion(self, branch_name):
-        # type: (str) -> None
+    def offer_force_deletion(self, branch_name: str, undo_owner: Optional[sublime.ViewId]) -> None:
         show_actions_panel(self.window, [
             noop("Abort, '{}' is not fully merged.".format(branch_name)),
             (
                 "Delete anyway.",
                 lambda: self.window.run_command("gs_delete_branch", {
                     "branch": branch_name,
-                    "force": True
+                    "force": True,
+                    "undo_owner": undo_owner
                 })
             )
         ])
 
-    def offer_detaching_head(self, branch):
+    def offer_detaching_head(self, branch: str, undo_owner: Optional[sublime.ViewId]) -> None:
         def kont():
             self.git("checkout", branch, "--detach")
-            self.window.run_command("gs_delete_branch", {"branch": branch, "force": False})
+            self.window.run_command("gs_delete_branch", {
+                "branch": branch,
+                "force": False,
+                "undo_owner": undo_owner
+            })
 
         show_actions_panel(self.window, [
             noop("Abort, '{}' is checked out.".format(branch)),

--- a/core/commands/branch.py
+++ b/core/commands/branch.py
@@ -4,6 +4,7 @@ import re
 import sublime
 
 from . import push
+from .ref_undo import add_branch_undo
 from ..git_command import GitSavvyError
 from ..ui_mixins.input_panel import show_single_line_input_panel
 from ...common import util
@@ -162,6 +163,7 @@ class gs_delete_branch(GsWindowCommand):
     @util.actions.destructive(description="delete a local branch")
     def run(self, branch, force=False):
         # type: (str, bool) -> None
+        old_hash = self.git("rev-parse", "--verify", f"refs/heads/{branch}").strip()
         if force:
             rv = self.git("branch", "-D", branch)
         else:
@@ -180,6 +182,7 @@ class gs_delete_branch(GsWindowCommand):
                 e.show_error_panel()
                 raise
 
+        add_branch_undo(self, branch, old_hash)
         match = EXTRACT_COMMIT.search(rv.strip())
         if match:
             commit = match.group(1)

--- a/core/commands/branch.py
+++ b/core/commands/branch.py
@@ -8,7 +8,7 @@ from . import push, ref_undo
 from ..git_command import GitSavvyError
 from ..ui_mixins.input_panel import show_single_line_input_panel
 from ...common import util
-from GitSavvy.core.base_commands import ask_for_local_branch, GsWindowCommand
+from GitSavvy.core.base_commands import ask_for_local_branch, std_undo_owner, GsWindowCommand
 from ..ui__quick_panel import noop, show_actions_panel
 from GitSavvy.core.utils import uprint
 
@@ -158,19 +158,16 @@ class gs_unset_tracking_information(GsWindowCommand):
 class gs_delete_branch(GsWindowCommand):
     defaults = {
         "branch": ask_for_local_branch,
+        "undo_owner": std_undo_owner,
     }
 
     @util.actions.destructive(description="delete a local branch")
     def run(
         self,
         branch: str,
-        force: bool = False,
-        undo_owner: Optional[sublime.ViewId] = None
+        undo_owner: sublime.ViewId,
+        force: bool = False
     ) -> None:
-        if undo_owner is None:
-            av = self.window.active_view()
-            undo_owner = av.id() if av else None
-
         old_hash = self.git("rev-parse", "--verify", f"refs/heads/{branch}").strip()
         if force:
             rv = self.git("branch", "-D", branch)

--- a/core/commands/branch.py
+++ b/core/commands/branch.py
@@ -168,7 +168,6 @@ class gs_delete_branch(GsWindowCommand):
         undo_owner: sublime.ViewId,
         force: bool = False
     ) -> None:
-        old_hash = self.git("rev-parse", "--verify", f"refs/heads/{branch}").strip()
         if force:
             rv = self.git("branch", "-D", branch)
         else:
@@ -187,12 +186,10 @@ class gs_delete_branch(GsWindowCommand):
                 e.show_error_panel()
                 raise
 
-        if undo_owner:
-            ref_undo.add_branch_undo(self, branch, old_hash, undo_owner)
-
         match = EXTRACT_COMMIT.search(rv.strip())
         if match:
             commit = match.group(1)
+            ref_undo.add_branch_undo(self, branch, commit, undo_owner)
             uprint(DELETE_UNDO_MESSAGE.format(branch, commit))
         self.window.status_message(
             "Deleted local branch ({}).".format(branch)

--- a/core/commands/branch.py
+++ b/core/commands/branch.py
@@ -83,10 +83,25 @@ def ask_for_name(caption=just(NEW_BRANCH_PROMPT), initial_text=just("")):
 class gs_create_branch(GsWindowCommand):
     defaults = {
         "branch_name": ask_for_name(),
+        "undo_owner": std_undo_owner,
     }
 
-    def run(self, branch_name, start_point=None, force=False):
-        # type: (str, str, bool) -> None
+    def run(
+        self,
+        branch_name: str,
+        undo_owner: sublime.ViewId,
+        start_point: Optional[str] = None,
+        force: bool = False,
+        previous_tip: Optional[str] = None
+    ) -> None:
+        if force and previous_tip is None:
+            previous_tip = self.git(
+                "rev-parse",
+                "--verify",
+                f"refs/heads/{branch_name}",
+                throw_on_error=False
+            ).strip() or None
+
         try:
             self.git_throwing_silently(
                 "branch",
@@ -97,13 +112,19 @@ class gs_create_branch(GsWindowCommand):
         except GitSavvyError as e:
             if BRANCH_ALREADY_EXISTS_MESSAGE.format(branch_name) in e.stderr and not force:
                 def overwrite_action():
-                    old_hash = self.git("rev-parse", branch_name).strip()
-                    uprint(RECREATE_BRANCH_UNDO_MESSAGE.format(branch_name, old_hash))
+                    previous_tip = self.git(
+                        "rev-parse",
+                        "--verify",
+                        f"refs/heads/{branch_name}"
+                    ).strip()
+                    uprint(RECREATE_BRANCH_UNDO_MESSAGE.format(branch_name, previous_tip))
 
                     self.window.run_command("gs_create_branch", {
                         "branch_name": branch_name,
                         "start_point": start_point,
                         "force": True,
+                        "previous_tip": previous_tip,
+                        "undo_owner": undo_owner,
                     })
 
                 show_actions_panel(self.window, [
@@ -118,6 +139,9 @@ class gs_create_branch(GsWindowCommand):
             else:
                 e.show_error_panel()
                 raise
+
+        if force and previous_tip:
+            ref_undo.add_branch_move_undo(self, branch_name, previous_tip, undo_owner)
 
         self.window.status_message("Created {}{}".format(
             branch_name,

--- a/core/commands/help_panel.py
+++ b/core/commands/help_panel.py
@@ -258,6 +258,8 @@ class gs_log_graph_help_panel(GsAbstractOpenHelpPanel):
     [m]/[M]        toggle commit panel on the bottom, [M] to also focus the panel
     [{cr}+c]       copy commit's hash, subject or a combination to the clipboard
                    if you copied a branch name, [ctrl+v] to create such a branch
+    [D]            delete a branch/tag decoration on the commit
+    [{cr}+z]       undo a branch/tag deletion from this graph
 
     [f]            edit filters verbatim
     [l]            list paths to add or remove

--- a/core/commands/help_panel.py
+++ b/core/commands/help_panel.py
@@ -256,8 +256,8 @@ class gs_log_graph_help_panel(GsAbstractOpenHelpPanel):
 
     [o]            open commit in a new view; on `#issues`, open a browser
     [m]/[M]        toggle commit panel on the bottom, [M] to also focus the panel
-    [{cr}+c]       copy commit's hash, subject or a combination to the clipboard
-                   if you copied a branch name, [ctrl+v] to create such a branch
+    [{cr}+c]       cycle-copy hash, tags, branches, subject, or hash+subject
+    [{cr}+v]       paste copied branch/tag onto a commit; paste commits to rebase-insert
     [D]            delete a branch/tag decoration on the commit
     [{cr}+z]       undo a branch/tag deletion from this graph
 

--- a/core/commands/log_graph_main_actions.py
+++ b/core/commands/log_graph_main_actions.py
@@ -138,9 +138,9 @@ class gs_log_graph_action(WindowCommand, GitCommand):
 
     def actions_for_multiple_lines(
         self, view: sublime.View, infos: List[LineInfo]
-    ) -> List[Tuple[str, Callable[[], None]]]:
+    ) -> Sequence[ActionType]:
         file_path = self._get_file_path(view)
-        actions: List[Tuple[str, Callable[[], None]]] = []
+        actions: List[ActionType] = []
 
         if len(infos) == 2:
 
@@ -235,7 +235,7 @@ class gs_log_graph_action(WindowCommand, GitCommand):
 
     def actions_for_single_line(
         self, view: sublime.View, info: LineInfo, branches: Dict[str, Branch]
-    ) -> List[Tuple[str, Callable[[], None]]]:
+    ) -> Sequence[ActionType]:
         head_info = describe_head(view, branches)
         commit_hash = info["commit"]
         good_commit_name = (
@@ -261,7 +261,7 @@ class gs_log_graph_action(WindowCommand, GitCommand):
             else lambda x: []
         )
 
-        actions: List[Tuple[str, Callable[[], None]]] = []
+        actions: List[ActionType] = []
         if in_bisect:
             actions += [
                 ("Good", partial(self.bisect_step, "good")),

--- a/core/commands/log_graph_main_actions.py
+++ b/core/commands/log_graph_main_actions.py
@@ -13,6 +13,7 @@ from ..fns import filter_, take, unique
 from ..git_command import GitCommand
 from ..git_mixins.branches import Branch
 from ..text_helper import line_from_pt
+from ..types import ShortHash
 from ..ui__quick_panel import ActionType, SEPARATOR, show_actions_panel, show_quick_panel
 from ..utils import open_folder_in_new_window
 from . import multi_selector
@@ -65,7 +66,7 @@ class gs_log_graph_delete_decoration(WindowCommand, GitCommand):
         ] + [
             (
                 "Delete tag '{}'".format(tag_name),
-                partial(self.delete_tag, view, tag_name)
+                partial(self.delete_tag, tag_name, info["commit"])
             )
             for tag_name in info.get("tags", [])
         ]
@@ -73,8 +74,8 @@ class gs_log_graph_delete_decoration(WindowCommand, GitCommand):
     def delete_branch(self, branch_name: str) -> None:
         self.window.run_command("gs_delete_branch", {"branch": branch_name})
 
-    def delete_tag(self, view: sublime.View, tag_name: str) -> None:
-        delete_tag_from_graph(self, self.window, tag_name)
+    def delete_tag(self, tag_name: str, commit_hash: ShortHash) -> None:
+        delete_tag_from_graph(self, self.window, tag_name, commit_hash)
 
 
 class gs_log_graph_action(WindowCommand, GitCommand):
@@ -368,7 +369,7 @@ class gs_log_graph_action(WindowCommand, GitCommand):
         ]
 
         actions += [
-            ("Delete tag '{}'".format(tag_name), partial(self.delete_tag, tag_name))
+            ("Delete tag '{}'".format(tag_name), partial(self.delete_tag, tag_name, commit_hash))
             for tag_name in info.get("tags", [])
         ]
 
@@ -646,8 +647,8 @@ class gs_log_graph_action(WindowCommand, GitCommand):
     def create_tag(self, commit_hash):
         self.window.run_command("gs_tag_create", {"target_commit": commit_hash})
 
-    def delete_tag(self, tag_name):
-        delete_tag_from_graph(self, self.window, tag_name)
+    def delete_tag(self, tag_name: str, commit_hash: ShortHash):
+        delete_tag_from_graph(self, self.window, tag_name, commit_hash)
 
     def reset_to(self, commitish):
         self.window.run_command("gs_reset", {"commit_hash": commitish})
@@ -734,12 +735,18 @@ class gs_log_graph_action(WindowCommand, GitCommand):
         util.view.refresh_gitsavvy_interfaces(self.window)
 
 
-def delete_tag_from_graph(cmd: GitCommand, window: sublime.Window, tag_name: str) -> None:
-    ref = f"refs/tags/{tag_name}"
-    tag_ref_hash = cmd.git("rev-parse", "--verify", ref).strip()
-    dereferenced_target_hash = cmd.git("rev-parse", "--verify", f"{ref}^{{}}").strip()
-    cmd.git("tag", "-d", tag_name)
-    ref_undo.add_tag_undo(cmd, tag_name, tag_ref_hash, dereferenced_target_hash)
+def delete_tag_from_graph(
+    cmd: GitCommand,
+    window: sublime.Window,
+    tag_name: str,
+    dereferenced_target_hash: ShortHash
+) -> None:
+    with ref_undo.record_tag_recreate_action(
+        cmd,
+        tag_name,
+        dereferenced_target_hash=dereferenced_target_hash
+    ):
+        cmd.git("tag", "-d", tag_name)
     window.status_message("Deleted tag '{}'.".format(tag_name))
     util.view.refresh_gitsavvy_interfaces(window)
 

--- a/core/commands/log_graph_main_actions.py
+++ b/core/commands/log_graph_main_actions.py
@@ -60,22 +60,30 @@ class gs_log_graph_delete_decoration(WindowCommand, GitCommand):
         return [
             (
                 "Delete branch '{}'".format(branch_name),
-                partial(self.delete_branch, branch_name)
+                partial(self.delete_branch, branch_name, view.id())
             )
             for branch_name in info.get("local_branches", [])
         ] + [
             (
                 "Delete tag '{}'".format(tag_name),
-                partial(self.delete_tag, tag_name, info["commit"])
+                partial(self.delete_tag, tag_name, info["commit"], view.id())
             )
             for tag_name in info.get("tags", [])
         ]
 
-    def delete_branch(self, branch_name: str) -> None:
-        self.window.run_command("gs_delete_branch", {"branch": branch_name})
+    def delete_branch(self, branch_name: str, undo_owner: ref_undo.UndoOwner) -> None:
+        self.window.run_command("gs_delete_branch", {
+            "branch": branch_name,
+            "undo_owner": undo_owner
+        })
 
-    def delete_tag(self, tag_name: str, commit_hash: ShortHash) -> None:
-        delete_tag_from_graph(self, self.window, tag_name, commit_hash)
+    def delete_tag(
+        self,
+        tag_name: str,
+        commit_hash: ShortHash,
+        undo_owner: sublime.ViewId
+    ) -> None:
+        delete_tag_from_graph(self, self.window, tag_name, commit_hash, undo_owner)
 
 
 class gs_log_graph_action(WindowCommand, GitCommand):
@@ -369,7 +377,10 @@ class gs_log_graph_action(WindowCommand, GitCommand):
         ]
 
         actions += [
-            ("Delete tag '{}'".format(tag_name), partial(self.delete_tag, tag_name, commit_hash))
+            (
+                "Delete tag '{}'".format(tag_name),
+                partial(self.delete_tag, tag_name, commit_hash, view.id())
+            )
             for tag_name in info.get("tags", [])
         ]
 
@@ -430,7 +441,10 @@ class gs_log_graph_action(WindowCommand, GitCommand):
                 ]
 
             actions += [
-                ("Delete branch '{}'".format(branch_name), partial(self.delete_branch, branch_name))
+                (
+                    "Delete branch '{}'".format(branch_name),
+                    partial(self.delete_branch, branch_name, view.id())
+                )
                 for branch_name in info.get("local_branches", [])
             ]
 
@@ -627,8 +641,11 @@ class gs_log_graph_action(WindowCommand, GitCommand):
         self.git("branch", "-f", branch_name, target)
         util.view.refresh_gitsavvy_interfaces(self.window)
 
-    def delete_branch(self, branch_name):
-        self.window.run_command("gs_delete_branch", {"branch": branch_name})
+    def delete_branch(self, branch_name: str, undo_owner: sublime.ViewId):
+        self.window.run_command("gs_delete_branch", {
+            "branch": branch_name,
+            "undo_owner": undo_owner
+        })
 
     def show_commit(self, commit_hash):
         self.window.run_command("gs_show_commit", {"commit_hash": commit_hash})
@@ -647,8 +664,13 @@ class gs_log_graph_action(WindowCommand, GitCommand):
     def create_tag(self, commit_hash):
         self.window.run_command("gs_tag_create", {"target_commit": commit_hash})
 
-    def delete_tag(self, tag_name: str, commit_hash: ShortHash):
-        delete_tag_from_graph(self, self.window, tag_name, commit_hash)
+    def delete_tag(
+        self,
+        tag_name: str,
+        commit_hash: ShortHash,
+        undo_owner: sublime.ViewId
+    ) -> None:
+        delete_tag_from_graph(self, self.window, tag_name, commit_hash, undo_owner)
 
     def reset_to(self, commitish):
         self.window.run_command("gs_reset", {"commit_hash": commitish})
@@ -739,12 +761,14 @@ def delete_tag_from_graph(
     cmd: GitCommand,
     window: sublime.Window,
     tag_name: str,
-    dereferenced_target_hash: ShortHash
+    dereferenced_target_hash: ShortHash,
+    undo_owner: sublime.ViewId
 ) -> None:
     with ref_undo.record_tag_recreate_action(
         cmd,
         tag_name,
-        dereferenced_target_hash=dereferenced_target_hash
+        dereferenced_target_hash=dereferenced_target_hash,
+        undo_owner=undo_owner
     ):
         cmd.git("tag", "-d", tag_name)
     window.status_message("Deleted tag '{}'.".format(tag_name))

--- a/core/commands/log_graph_main_actions.py
+++ b/core/commands/log_graph_main_actions.py
@@ -736,10 +736,10 @@ class gs_log_graph_action(WindowCommand, GitCommand):
 
 def delete_tag_from_graph(cmd: GitCommand, window: sublime.Window, tag_name: str) -> None:
     ref = f"refs/tags/{tag_name}"
-    old_hash = cmd.git("rev-parse", "--verify", ref).strip()
-    target_hash = cmd.git("rev-parse", "--short", f"{ref}^{{}}", throw_on_error=False).strip()
+    tag_ref_hash = cmd.git("rev-parse", "--verify", ref).strip()
+    dereferenced_target_hash = cmd.git("rev-parse", "--verify", f"{ref}^{{}}").strip()
     cmd.git("tag", "-d", tag_name)
-    ref_undo.add_tag_undo(cmd, tag_name, old_hash, target_hash)
+    ref_undo.add_tag_undo(cmd, tag_name, tag_ref_hash, dereferenced_target_hash)
     window.status_message("Deleted tag '{}'.".format(tag_name))
     util.view.refresh_gitsavvy_interfaces(window)
 

--- a/core/commands/log_graph_main_actions.py
+++ b/core/commands/log_graph_main_actions.py
@@ -59,7 +59,7 @@ class gs_log_graph_delete_decoration(WindowCommand, GitCommand):
         return [
             (
                 "Delete branch '{}'".format(branch_name),
-                partial(self.delete_branch, view, branch_name)
+                partial(self.delete_branch, branch_name)
             )
             for branch_name in info.get("local_branches", [])
         ] + [
@@ -70,21 +70,11 @@ class gs_log_graph_delete_decoration(WindowCommand, GitCommand):
             for tag_name in info.get("tags", [])
         ]
 
-    def delete_branch(self, view: sublime.View, branch_name: str) -> None:
-        old_hash = self.git("rev-parse", "--verify", f"refs/heads/{branch_name}").strip()
-        self.git("branch", "-D", branch_name)
-        ref_undo.add_branch_undo(self, branch_name, old_hash)
-        self.window.status_message("Deleted branch '{}'.".format(branch_name))
-        util.view.refresh_gitsavvy_interfaces(self.window)
+    def delete_branch(self, branch_name: str) -> None:
+        self.window.run_command("gs_delete_branch", {"branch": branch_name})
 
     def delete_tag(self, view: sublime.View, tag_name: str) -> None:
-        ref = f"refs/tags/{tag_name}"
-        old_hash = self.git("rev-parse", "--verify", ref).strip()
-        target_hash = self.git("rev-parse", "--short", f"{ref}^{{}}", throw_on_error=False).strip()
-        self.git("tag", "-d", tag_name)
-        ref_undo.add_tag_undo(self, tag_name, old_hash, target_hash)
-        self.window.status_message("Deleted tag '{}'.".format(tag_name))
-        util.view.refresh_gitsavvy_interfaces(self.window)
+        delete_tag_from_graph(self, self.window, tag_name)
 
 
 class gs_log_graph_action(WindowCommand, GitCommand):
@@ -657,8 +647,7 @@ class gs_log_graph_action(WindowCommand, GitCommand):
         self.window.run_command("gs_tag_create", {"target_commit": commit_hash})
 
     def delete_tag(self, tag_name):
-        self.git("tag", "-d", tag_name)
-        util.view.refresh_gitsavvy_interfaces(self.window)
+        delete_tag_from_graph(self, self.window, tag_name)
 
     def reset_to(self, commitish):
         self.window.run_command("gs_reset", {"commit_hash": commitish})
@@ -743,6 +732,16 @@ class gs_log_graph_action(WindowCommand, GitCommand):
         )
         self.checkout_ref(commit_hash, fpath=file_path)
         util.view.refresh_gitsavvy_interfaces(self.window)
+
+
+def delete_tag_from_graph(cmd: GitCommand, window: sublime.Window, tag_name: str) -> None:
+    ref = f"refs/tags/{tag_name}"
+    old_hash = cmd.git("rev-parse", "--verify", ref).strip()
+    target_hash = cmd.git("rev-parse", "--short", f"{ref}^{{}}", throw_on_error=False).strip()
+    cmd.git("tag", "-d", tag_name)
+    ref_undo.add_tag_undo(cmd, tag_name, old_hash, target_hash)
+    window.status_message("Deleted tag '{}'.".format(tag_name))
+    util.view.refresh_gitsavvy_interfaces(window)
 
 
 def is_log_graph_view(view: sublime.View) -> bool:

--- a/core/commands/log_graph_main_actions.py
+++ b/core/commands/log_graph_main_actions.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from functools import partial
 import os
 from itertools import chain
-from typing import Callable, Dict, List, Optional, Tuple
+import time
+from typing import Callable, Dict, List, NamedTuple, Optional, Tuple
 
 import sublime
 from sublime_plugin import WindowCommand
@@ -13,7 +14,7 @@ from ..fns import filter_, take, unique
 from ..git_command import GitCommand
 from ..git_mixins.branches import Branch
 from ..text_helper import line_from_pt
-from ..ui__quick_panel import SEPARATOR, show_quick_panel
+from ..ui__quick_panel import SEPARATOR, show_actions_panel, show_quick_panel
 from ..utils import open_folder_in_new_window
 from . import multi_selector
 from . import log_graph_colorizer as colorizer
@@ -29,6 +30,107 @@ from .log_graph_helper import (
 
 
 FOLLOW_DECORATION_LIMIT = 100
+UNDO_REF_ACTIONS: Dict[sublime.ViewId, List["RefUndoAction"]] = {}
+
+
+class RefUndoAction(NamedTuple):
+    description: str
+    command: Tuple[str, ...]
+    timestamp: float
+
+
+class gs_log_graph_delete_decoration(WindowCommand, GitCommand):
+    def run(self) -> None:
+        view = self.window.active_view()
+        if view is None or not is_log_graph_view(view):
+            return
+
+        branches = {b.canonical_name: b for b in self.get_branches()}
+        info = describe_line_at_cursor(view, branches)
+        if not info:
+            return
+
+        actions = self.delete_actions(view, info)
+        if len(actions) == 1:
+            actions[0][1]()
+        elif actions:
+            show_actions_panel(self.window, actions)
+        elif remote_refs := undeletable_refs(info):
+            flash_cannot_delete_remote_ref(view, remote_refs)
+        else:
+            self.window.status_message("No branch or tag on this commit.")
+
+    def delete_actions(
+        self, view: sublime.View, info: LineInfo
+    ) -> List[Tuple[str, Callable[[], None]]]:
+        return [
+            (
+                "Delete branch '{}'".format(branch_name),
+                partial(self.delete_branch, view, branch_name)
+            )
+            for branch_name in info.get("local_branches", [])
+        ] + [
+            (
+                "Delete tag '{}'".format(tag_name),
+                partial(self.delete_tag, view, tag_name)
+            )
+            for tag_name in info.get("tags", [])
+        ]
+
+    def delete_branch(self, view: sublime.View, branch_name: str) -> None:
+        old_hash = self.git("rev-parse", "--verify", f"refs/heads/{branch_name}").strip()
+        self.git("branch", "-D", branch_name)
+        add_undo_ref_action(
+            view,
+            RefUndoAction(
+                "Re-create branch '{}' at {}".format(branch_name, self.get_short_hash(old_hash)),
+                ("branch", branch_name, old_hash),
+                time.time()
+            )
+        )
+        self.window.status_message("Deleted branch '{}'.".format(branch_name))
+        util.view.refresh_gitsavvy_interfaces(self.window)
+
+    def delete_tag(self, view: sublime.View, tag_name: str) -> None:
+        ref = f"refs/tags/{tag_name}"
+        old_hash = self.git("rev-parse", "--verify", ref).strip()
+        target_hash = self.git("rev-parse", "--short", f"{ref}^{{}}", throw_on_error=False).strip()
+        self.git("tag", "-d", tag_name)
+        add_undo_ref_action(
+            view,
+            RefUndoAction(
+                "Re-create tag '{}' at {}".format(tag_name, target_hash or self.get_short_hash(old_hash)),
+                ("update-ref", ref, old_hash),
+                time.time()
+            )
+        )
+        self.window.status_message("Deleted tag '{}'.".format(tag_name))
+        util.view.refresh_gitsavvy_interfaces(self.window)
+
+
+class gs_log_graph_undo_ref_action(WindowCommand, GitCommand):
+    def run(self) -> None:
+        view = self.window.active_view()
+        if view is None or not is_log_graph_view(view):
+            return
+
+        undo_actions = get_undo_ref_actions(view)
+        if not undo_actions:
+            self.window.status_message("No graph ref deletion to undo.")
+            return
+
+        def on_selection(index: int) -> None:
+            undo_action = undo_actions[index]
+            self.git(*undo_action.command)
+            remove_undo_ref_action(view, undo_action)
+            self.window.status_message(undo_action.description + ".")
+            util.view.refresh_gitsavvy_interfaces(self.window)
+
+        show_quick_panel(
+            self.window,
+            [undo_action.description for undo_action in undo_actions],
+            on_selection
+        )
 
 
 class gs_log_graph_action(WindowCommand, GitCommand):
@@ -687,6 +789,64 @@ class gs_log_graph_action(WindowCommand, GitCommand):
         )
         self.checkout_ref(commit_hash, fpath=file_path)
         util.view.refresh_gitsavvy_interfaces(self.window)
+
+
+def is_log_graph_view(view: sublime.View) -> bool:
+    return bool(view.settings().get("git_savvy.log_graph_view"))
+
+
+def describe_line_at_cursor(
+    view: sublime.View, branches: Dict[str, Branch]
+) -> Optional[LineInfo]:
+    try:
+        line = line_from_pt(view, view.sel()[0].b)
+    except IndexError:
+        return None
+
+    return describe_graph_line(line.text, branches)
+
+
+def undeletable_refs(info: LineInfo) -> List[str]:
+    local_branches = set(info.get("local_branches", []))
+    return list(unique(
+        ref for ref in info.get("branches", [])
+        if ref not in local_branches
+    ))
+
+
+def flash_cannot_delete_remote_ref(view: sublime.View, refs: List[str]) -> None:
+    window = view.window()
+    if not window:
+        return
+
+    if len(refs) == 1:
+        window.status_message("Cannot delete remote ref '{}'".format(refs[0]))
+    else:
+        window.status_message("Cannot delete remote refs {}".format(
+            " and ".join("'{}'".format(ref) for ref in refs)
+        ))
+
+
+def add_undo_ref_action(view: sublime.View, undo_action: RefUndoAction) -> None:
+    UNDO_REF_ACTIONS.setdefault(view.id(), []).append(undo_action)
+
+
+def get_undo_ref_actions(view: sublime.View) -> List[RefUndoAction]:
+    return sorted(
+        UNDO_REF_ACTIONS.get(view.id(), []),
+        key=lambda undo_action: undo_action.timestamp,
+        reverse=True
+    )
+
+
+def remove_undo_ref_action(view: sublime.View, undo_action: RefUndoAction) -> None:
+    actions = UNDO_REF_ACTIONS.get(view.id())
+    if not actions:
+        return
+
+    actions.remove(undo_action)
+    if not actions:
+        UNDO_REF_ACTIONS.pop(view.id(), None)
 
 
 def display_name(info: LineInfo) -> str:

--- a/core/commands/log_graph_main_actions.py
+++ b/core/commands/log_graph_main_actions.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 from functools import partial
 import os
 from itertools import chain
-import time
-from typing import Callable, Dict, List, NamedTuple, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Sequence
 
 import sublime
 from sublime_plugin import WindowCommand
@@ -14,9 +13,10 @@ from ..fns import filter_, take, unique
 from ..git_command import GitCommand
 from ..git_mixins.branches import Branch
 from ..text_helper import line_from_pt
-from ..ui__quick_panel import SEPARATOR, show_actions_panel, show_quick_panel
+from ..ui__quick_panel import ActionType, SEPARATOR, show_actions_panel, show_quick_panel
 from ..utils import open_folder_in_new_window
 from . import multi_selector
+from . import ref_undo
 from . import log_graph_colorizer as colorizer
 from .log_graph import dot_from_line, follow_dots
 from .log_graph_helper import (
@@ -30,13 +30,6 @@ from .log_graph_helper import (
 
 
 FOLLOW_DECORATION_LIMIT = 100
-UNDO_REF_ACTIONS: Dict[sublime.ViewId, List["RefUndoAction"]] = {}
-
-
-class RefUndoAction(NamedTuple):
-    description: str
-    command: Tuple[str, ...]
-    timestamp: float
 
 
 class gs_log_graph_delete_decoration(WindowCommand, GitCommand):
@@ -62,7 +55,7 @@ class gs_log_graph_delete_decoration(WindowCommand, GitCommand):
 
     def delete_actions(
         self, view: sublime.View, info: LineInfo
-    ) -> List[Tuple[str, Callable[[], None]]]:
+    ) -> Sequence[ActionType]:
         return [
             (
                 "Delete branch '{}'".format(branch_name),
@@ -80,14 +73,7 @@ class gs_log_graph_delete_decoration(WindowCommand, GitCommand):
     def delete_branch(self, view: sublime.View, branch_name: str) -> None:
         old_hash = self.git("rev-parse", "--verify", f"refs/heads/{branch_name}").strip()
         self.git("branch", "-D", branch_name)
-        add_undo_ref_action(
-            view,
-            RefUndoAction(
-                "Re-create branch '{}' at {}".format(branch_name, self.get_short_hash(old_hash)),
-                ("branch", branch_name, old_hash),
-                time.time()
-            )
-        )
+        ref_undo.add_branch_undo(self, branch_name, old_hash)
         self.window.status_message("Deleted branch '{}'.".format(branch_name))
         util.view.refresh_gitsavvy_interfaces(self.window)
 
@@ -96,41 +82,9 @@ class gs_log_graph_delete_decoration(WindowCommand, GitCommand):
         old_hash = self.git("rev-parse", "--verify", ref).strip()
         target_hash = self.git("rev-parse", "--short", f"{ref}^{{}}", throw_on_error=False).strip()
         self.git("tag", "-d", tag_name)
-        add_undo_ref_action(
-            view,
-            RefUndoAction(
-                "Re-create tag '{}' at {}".format(tag_name, target_hash or self.get_short_hash(old_hash)),
-                ("update-ref", ref, old_hash),
-                time.time()
-            )
-        )
+        ref_undo.add_tag_undo(self, tag_name, old_hash, target_hash)
         self.window.status_message("Deleted tag '{}'.".format(tag_name))
         util.view.refresh_gitsavvy_interfaces(self.window)
-
-
-class gs_log_graph_undo_ref_action(WindowCommand, GitCommand):
-    def run(self) -> None:
-        view = self.window.active_view()
-        if view is None or not is_log_graph_view(view):
-            return
-
-        undo_actions = get_undo_ref_actions(view)
-        if not undo_actions:
-            self.window.status_message("No graph ref deletion to undo.")
-            return
-
-        def on_selection(index: int) -> None:
-            undo_action = undo_actions[index]
-            self.git(*undo_action.command)
-            remove_undo_ref_action(view, undo_action)
-            self.window.status_message(undo_action.description + ".")
-            util.view.refresh_gitsavvy_interfaces(self.window)
-
-        show_quick_panel(
-            self.window,
-            [undo_action.description for undo_action in undo_actions],
-            on_selection
-        )
 
 
 class gs_log_graph_action(WindowCommand, GitCommand):
@@ -825,28 +779,6 @@ def flash_cannot_delete_remote_ref(view: sublime.View, refs: List[str]) -> None:
         window.status_message("Cannot delete remote refs {}".format(
             " and ".join("'{}'".format(ref) for ref in refs)
         ))
-
-
-def add_undo_ref_action(view: sublime.View, undo_action: RefUndoAction) -> None:
-    UNDO_REF_ACTIONS.setdefault(view.id(), []).append(undo_action)
-
-
-def get_undo_ref_actions(view: sublime.View) -> List[RefUndoAction]:
-    return sorted(
-        UNDO_REF_ACTIONS.get(view.id(), []),
-        key=lambda undo_action: undo_action.timestamp,
-        reverse=True
-    )
-
-
-def remove_undo_ref_action(view: sublime.View, undo_action: RefUndoAction) -> None:
-    actions = UNDO_REF_ACTIONS.get(view.id())
-    if not actions:
-        return
-
-    actions.remove(undo_action)
-    if not actions:
-        UNDO_REF_ACTIONS.pop(view.id(), None)
 
 
 def display_name(info: LineInfo) -> str:

--- a/core/commands/ref_undo.py
+++ b/core/commands/ref_undo.py
@@ -57,15 +57,25 @@ def add_branch_undo(cmd: GitCommand, branch_name: str, old_hash: str) -> None:
     )
 
 
-def add_tag_undo(cmd: GitCommand, tag_name: str, old_hash: str, target_hash: str) -> None:
+def add_tag_undo(
+    cmd: GitCommand,
+    tag_name: str,
+    tag_ref_hash: str,
+    dereferenced_target_hash: str,
+) -> None:
+    assert tag_ref_hash and dereferenced_target_hash
+
+    display_hash = cmd.get_short_hash(dereferenced_target_hash)
+    # Undo via `update-ref` instead of `git tag --force` so annotated tags
+    # are restored as the exact same tag object.  That preserves the tagger,
+    # timestamp, annotation message, and signature.  The trade-off is that
+    # the tag object becomes unreachable after deletion and undo can fail if
+    # Git prunes it before the user restores the ref.
     add_undo_action(
         cmd,
         RefUndoAction(
-            "Re-create tag '{}' at {}".format(
-                tag_name,
-                target_hash or cmd.get_short_hash(old_hash)
-            ),
-            ("update-ref", f"refs/tags/{tag_name}", old_hash),
+            "Re-create tag '{}' at {}".format(tag_name, display_hash),
+            ("update-ref", f"refs/tags/{tag_name}", tag_ref_hash),
             time.time()
         )
     )

--- a/core/commands/ref_undo.py
+++ b/core/commands/ref_undo.py
@@ -80,6 +80,22 @@ def add_branch_undo(
     )
 
 
+def add_branch_move_undo(
+    cmd: GitCommand,
+    branch_name: str,
+    old_hash: str,
+    undo_owner: UndoOwner
+) -> None:
+    add_undo_action(
+        undo_owner,
+        RefUndoAction(
+            "Move branch '{}' back to {}".format(branch_name, cmd.get_short_hash(old_hash)),
+            ("branch", "--force", branch_name, old_hash),
+            time.time()
+        )
+    )
+
+
 @contextmanager
 def record_tag_recreate_action(
     cmd: GitCommand,

--- a/core/commands/ref_undo.py
+++ b/core/commands/ref_undo.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
+from contextlib import contextmanager
 import time
-from typing import cast, List, NamedTuple, Tuple
+from typing import cast, Iterator, List, NamedTuple, Tuple
 
 from sublime_plugin import WindowCommand
 
 from ...common import util
 from ..git_command import GitCommand
+from ..types import ShortHash
 from ..ui__quick_panel import show_quick_panel
 
 
@@ -15,6 +17,7 @@ __all__ = (
     "add_branch_undo",
     "add_tag_undo",
     "add_undo_action",
+    "record_tag_recreate_action",
     "gs_ref_undo",
 )
 
@@ -57,15 +60,31 @@ def add_branch_undo(cmd: GitCommand, branch_name: str, old_hash: str) -> None:
     )
 
 
+@contextmanager
+def record_tag_recreate_action(
+    cmd: GitCommand,
+    tag_name: str,
+    tag_ref_hash: ShortHash | None = None,
+    dereferenced_target_hash: ShortHash | None = None
+) -> Iterator[None]:
+    ref = f"refs/tags/{tag_name}"
+    tag_ref_hash = tag_ref_hash or cmd.git("rev-parse", "--short", ref).strip()
+    dereferenced_target_hash = (
+        dereferenced_target_hash
+        or cmd.git("rev-parse", "--short", f"{ref}^{{}}").strip()
+    )
+
+    yield
+
+    add_tag_undo(cmd, tag_name, tag_ref_hash, dereferenced_target_hash)
+
+
 def add_tag_undo(
     cmd: GitCommand,
     tag_name: str,
-    tag_ref_hash: str,
-    dereferenced_target_hash: str,
+    tag_ref_hash: ShortHash,
+    dereferenced_target_hash: ShortHash,
 ) -> None:
-    assert tag_ref_hash and dereferenced_target_hash
-
-    display_hash = cmd.get_short_hash(dereferenced_target_hash)
     # Undo via `update-ref` instead of `git tag --force` so annotated tags
     # are restored as the exact same tag object.  That preserves the tagger,
     # timestamp, annotation message, and signature.  The trade-off is that
@@ -74,7 +93,7 @@ def add_tag_undo(
     add_undo_action(
         cmd,
         RefUndoAction(
-            "Re-create tag '{}' at {}".format(tag_name, display_hash),
+            "Re-create tag '{}' at {}".format(tag_name, dereferenced_target_hash),
             ("update-ref", f"refs/tags/{tag_name}", tag_ref_hash),
             time.time()
         )

--- a/core/commands/ref_undo.py
+++ b/core/commands/ref_undo.py
@@ -9,9 +9,10 @@ from typing import DefaultDict, Iterator, List, NamedTuple, Tuple
 from typing_extensions import TypeAlias
 
 import sublime
-from sublime_plugin import EventListener, WindowCommand
+from sublime_plugin import EventListener
 
 from ...common import util
+from ..base_commands import GsTextCommand
 from ..git_command import GitCommand
 from ..types import ShortHash
 from ..ui__quick_panel import show_quick_panel
@@ -36,13 +37,9 @@ undo_actions_by_owner: DefaultDict[UndoOwner, List[RefUndoAction]] = defaultdict
 lock = threading.Lock()
 
 
-class gs_ref_undo(WindowCommand, GitCommand):
-    def run(self, undo_owner: UndoOwner | None = None) -> None:
-        undo_owner = undo_owner or resolve_undo_owner(self)
-        if undo_owner is None:
-            self.window.status_message("No ref deletion to undo.")
-            return
-
+class gs_ref_undo(GsTextCommand):
+    def run(self, edit) -> None:
+        undo_owner = self.view.id()
         undo_actions = get_undo_actions(undo_owner)
         if not undo_actions:
             self.window.status_message("No ref deletion to undo.")

--- a/core/commands/ref_undo.py
+++ b/core/commands/ref_undo.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+from collections import defaultdict
 from contextlib import contextmanager
+import threading
 import time
-from typing import cast, Iterator, List, NamedTuple, Tuple
+from typing import DefaultDict, Iterator, List, NamedTuple, Tuple
 
-from sublime_plugin import WindowCommand
+from typing_extensions import TypeAlias
+
+import sublime
+from sublime_plugin import EventListener, WindowCommand
 
 from ...common import util
 from ..git_command import GitCommand
@@ -13,12 +18,8 @@ from ..ui__quick_panel import show_quick_panel
 
 
 __all__ = (
-    "RefUndoAction",
-    "add_branch_undo",
-    "add_tag_undo",
-    "add_undo_action",
-    "record_tag_recreate_action",
     "gs_ref_undo",
+    "GsRefUndoCleanup",
 )
 
 
@@ -28,9 +29,21 @@ class RefUndoAction(NamedTuple):
     timestamp: float
 
 
+UndoOwner: TypeAlias = "sublime.ViewId"
+
+
+undo_actions_by_owner: DefaultDict[UndoOwner, List[RefUndoAction]] = defaultdict(list)
+lock = threading.Lock()
+
+
 class gs_ref_undo(WindowCommand, GitCommand):
-    def run(self) -> None:
-        undo_actions = get_undo_actions(self)
+    def run(self, undo_owner: UndoOwner | None = None) -> None:
+        undo_owner = undo_owner or resolve_undo_owner(self)
+        if undo_owner is None:
+            self.window.status_message("No ref deletion to undo.")
+            return
+
+        undo_actions = get_undo_actions(undo_owner)
         if not undo_actions:
             self.window.status_message("No ref deletion to undo.")
             return
@@ -38,7 +51,7 @@ class gs_ref_undo(WindowCommand, GitCommand):
         def on_selection(index: int) -> None:
             undo_action = undo_actions[index]
             self.git(*undo_action.command)
-            remove_undo_action(self, undo_action)
+            remove_undo_action(undo_owner, undo_action)
             self.window.status_message(undo_action.description + ".")
             util.view.refresh_gitsavvy_interfaces(self.window)
 
@@ -49,9 +62,19 @@ class gs_ref_undo(WindowCommand, GitCommand):
         )
 
 
-def add_branch_undo(cmd: GitCommand, branch_name: str, old_hash: str) -> None:
+class GsRefUndoCleanup(EventListener):
+    def on_close(self, view) -> None:
+        clear_undo_actions(view.id())
+
+
+def add_branch_undo(
+    cmd: GitCommand,
+    branch_name: str,
+    old_hash: str,
+    undo_owner: UndoOwner
+) -> None:
     add_undo_action(
-        cmd,
+        undo_owner,
         RefUndoAction(
             "Re-create branch '{}' at {}".format(branch_name, cmd.get_short_hash(old_hash)),
             ("branch", branch_name, old_hash),
@@ -65,7 +88,8 @@ def record_tag_recreate_action(
     cmd: GitCommand,
     tag_name: str,
     tag_ref_hash: ShortHash | None = None,
-    dereferenced_target_hash: ShortHash | None = None
+    dereferenced_target_hash: ShortHash | None = None,
+    undo_owner: UndoOwner | None = None
 ) -> Iterator[None]:
     ref = f"refs/tags/{tag_name}"
     tag_ref_hash = tag_ref_hash or cmd.git("rev-parse", "--short", ref).strip()
@@ -76,7 +100,7 @@ def record_tag_recreate_action(
 
     yield
 
-    add_tag_undo(cmd, tag_name, tag_ref_hash, dereferenced_target_hash)
+    add_tag_undo(cmd, tag_name, tag_ref_hash, dereferenced_target_hash, undo_owner)
 
 
 def add_tag_undo(
@@ -84,14 +108,19 @@ def add_tag_undo(
     tag_name: str,
     tag_ref_hash: ShortHash,
     dereferenced_target_hash: ShortHash,
+    undo_owner: UndoOwner | None = None
 ) -> None:
+    undo_owner = undo_owner or resolve_undo_owner(cmd)
+    if undo_owner is None:
+        return
+
     # Undo via `update-ref` instead of `git tag --force` so annotated tags
     # are restored as the exact same tag object.  That preserves the tagger,
     # timestamp, annotation message, and signature.  The trade-off is that
     # the tag object becomes unreachable after deletion and undo can fail if
     # Git prunes it before the user restores the ref.
     add_undo_action(
-        cmd,
+        undo_owner,
         RefUndoAction(
             "Re-create tag '{}' at {}".format(tag_name, dereferenced_target_hash),
             ("update-ref", f"refs/tags/{tag_name}", tag_ref_hash),
@@ -100,31 +129,40 @@ def add_tag_undo(
     )
 
 
-def add_undo_action(cmd: GitCommand, undo_action: RefUndoAction) -> None:
-    actions = list(current_undo_actions(cmd))
-    actions.append(undo_action)
-    cmd.update_store({"ref_undo_actions": actions})
+def add_undo_action(undo_owner: UndoOwner, undo_action: RefUndoAction) -> None:
+    with lock:
+        undo_actions_by_owner[undo_owner].append(undo_action)
 
 
-def get_undo_actions(cmd: GitCommand) -> List[RefUndoAction]:
+def get_undo_actions(undo_owner: UndoOwner) -> List[RefUndoAction]:
     return sorted(
-        current_undo_actions(cmd),
+        current_undo_actions(undo_owner),
         key=lambda undo_action: undo_action.timestamp,
         reverse=True
     )
 
 
-def remove_undo_action(cmd: GitCommand, undo_action: RefUndoAction) -> None:
-    actions = list(current_undo_actions(cmd))
-    if not actions:
-        return
+def remove_undo_action(undo_owner: UndoOwner, undo_action: RefUndoAction) -> None:
+    with lock:
+        actions = undo_actions_by_owner.get(undo_owner)
+        if not actions:
+            return
 
-    actions.remove(undo_action)
-    cmd.update_store({"ref_undo_actions": actions})
+        actions.remove(undo_action)
+        if not actions:
+            del undo_actions_by_owner[undo_owner]
 
 
-def current_undo_actions(cmd: GitCommand) -> List[RefUndoAction]:
-    return cast(
-        List[RefUndoAction],
-        cmd.current_state().get("ref_undo_actions", [])
-    )
+def clear_undo_actions(undo_owner: UndoOwner) -> None:
+    with lock:
+        undo_actions_by_owner.pop(undo_owner, None)
+
+
+def current_undo_actions(undo_owner: UndoOwner) -> List[RefUndoAction]:
+    with lock:
+        return list(undo_actions_by_owner.get(undo_owner, []))
+
+
+def resolve_undo_owner(cmd: GitCommand) -> UndoOwner | None:
+    view = cmd._current_view()
+    return view.id() if view else None

--- a/core/commands/ref_undo.py
+++ b/core/commands/ref_undo.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import time
+from typing import cast, List, NamedTuple, Tuple
+
+from sublime_plugin import WindowCommand
+
+from ...common import util
+from ..git_command import GitCommand
+from ..ui__quick_panel import show_quick_panel
+
+
+__all__ = (
+    "RefUndoAction",
+    "add_branch_undo",
+    "add_tag_undo",
+    "add_undo_action",
+    "gs_ref_undo",
+)
+
+
+class RefUndoAction(NamedTuple):
+    description: str
+    command: Tuple[str, ...]
+    timestamp: float
+
+
+class gs_ref_undo(WindowCommand, GitCommand):
+    def run(self) -> None:
+        undo_actions = get_undo_actions(self)
+        if not undo_actions:
+            self.window.status_message("No ref deletion to undo.")
+            return
+
+        def on_selection(index: int) -> None:
+            undo_action = undo_actions[index]
+            self.git(*undo_action.command)
+            remove_undo_action(self, undo_action)
+            self.window.status_message(undo_action.description + ".")
+            util.view.refresh_gitsavvy_interfaces(self.window)
+
+        show_quick_panel(
+            self.window,
+            [undo_action.description for undo_action in undo_actions],
+            on_selection
+        )
+
+
+def add_branch_undo(cmd: GitCommand, branch_name: str, old_hash: str) -> None:
+    add_undo_action(
+        cmd,
+        RefUndoAction(
+            "Re-create branch '{}' at {}".format(branch_name, cmd.get_short_hash(old_hash)),
+            ("branch", branch_name, old_hash),
+            time.time()
+        )
+    )
+
+
+def add_tag_undo(cmd: GitCommand, tag_name: str, old_hash: str, target_hash: str) -> None:
+    add_undo_action(
+        cmd,
+        RefUndoAction(
+            "Re-create tag '{}' at {}".format(
+                tag_name,
+                target_hash or cmd.get_short_hash(old_hash)
+            ),
+            ("update-ref", f"refs/tags/{tag_name}", old_hash),
+            time.time()
+        )
+    )
+
+
+def add_undo_action(cmd: GitCommand, undo_action: RefUndoAction) -> None:
+    actions = list(current_undo_actions(cmd))
+    actions.append(undo_action)
+    cmd.update_store({"ref_undo_actions": actions})
+
+
+def get_undo_actions(cmd: GitCommand) -> List[RefUndoAction]:
+    return sorted(
+        current_undo_actions(cmd),
+        key=lambda undo_action: undo_action.timestamp,
+        reverse=True
+    )
+
+
+def remove_undo_action(cmd: GitCommand, undo_action: RefUndoAction) -> None:
+    actions = list(current_undo_actions(cmd))
+    if not actions:
+        return
+
+    actions.remove(undo_action)
+    cmd.update_store({"ref_undo_actions": actions})
+
+
+def current_undo_actions(cmd: GitCommand) -> List[RefUndoAction]:
+    return cast(
+        List[RefUndoAction],
+        cmd.current_state().get("ref_undo_actions", [])
+    )

--- a/core/git_mixins/history.py
+++ b/core/git_mixins/history.py
@@ -583,7 +583,7 @@ class HistoryMixin(mixin_base):
         current_commit: str,
         file_path: str | None = None,
         follow: bool = False
-    ) -> Optional[str]:
+    ) -> ShortHash | None:
         if file_path and not follow:
             return self._previous_commit(current_commit, file_path, follow)
 
@@ -602,7 +602,7 @@ class HistoryMixin(mixin_base):
 
     @cached(not_if={"current_commit": is_dynamic_ref})
     def _previous_commit(self, current_commit, file_path=None, follow=False):
-        # type: (str, Optional[str], bool) -> Optional[str]
+        # type: (str, Optional[str], bool) -> ShortHash | None
         return last(
             self._log_commits_linewise(current_commit, file_path, follow, limit=2),
             None
@@ -613,7 +613,7 @@ class HistoryMixin(mixin_base):
         current_commit: str,
         file_path: str | None = None,
         follow: bool = None,
-    ) -> Optional[str]:
+    ) -> ShortHash | None:
         if file_path and follow is False:
             return self._recent_commit(current_commit, file_path, follow)
 
@@ -624,7 +624,7 @@ class HistoryMixin(mixin_base):
 
     @cached(not_if={"current_commit": is_dynamic_ref})
     def _recent_commit(self, current_commit, file_path=None, follow=False):
-        # type: (str, Optional[str], bool) -> Optional[str]
+        # type: (str, Optional[str], bool) -> ShortHash | None
         return last(
             self._log_commits_linewise(current_commit, file_path, follow, limit=1),
             None
@@ -636,7 +636,7 @@ class HistoryMixin(mixin_base):
         file_path: str,
         line_range: tuple[int, int],
         skip_current: bool = False
-    ) -> Optional[str]:
+    ) -> ShortHash | None:
         current_commit = self.get_short_hash(current_commit)
         commits = self._log_commits_for_line_range(
             current_commit,
@@ -648,8 +648,12 @@ class HistoryMixin(mixin_base):
             None
         )
 
-    def next_commit(self, current_commit, file_path=None, follow=False):
-        # type: (str, Optional[str], bool) -> Optional[str]
+    def next_commit(
+        self,
+        current_commit: str,
+        file_path: str | None = None,
+        follow: bool = False
+    ) -> ShortHash | None:
         return last(
             self._log_commits_linewise(f"{current_commit}..", file_path, follow),
             None
@@ -660,7 +664,7 @@ class HistoryMixin(mixin_base):
         current_commit: str,
         file_path: str | None = None,
         branch_hint: str | None = None,
-    ) -> dict[str, str] | None:
+    ) -> dict[ShortHash, ShortHash] | None:
         if current_commit != self.get_short_hash(current_commit):
             raise RuntimeError("`next_commits` must be called with a short commit hash.")
 
@@ -702,7 +706,7 @@ class HistoryMixin(mixin_base):
         current_commit: str,
         file_path: str,
         line_range: tuple[int, int]
-    ) -> list[str]:
+    ) -> list[ShortHash]:
         file_path_at_commit = self.filename_at_commit(file_path, current_commit)
         relative_path = self.to_short_path(file_path_at_commit)
         start_line, end_line = line_range
@@ -725,7 +729,7 @@ class HistoryMixin(mixin_base):
         file_path: Optional[str],
         follow: bool,
         limit: Optional[int] = None
-    ) -> Iterator[str]:
+    ) -> Iterator[ShortHash]:
         if follow and not file_path:
             raise RuntimeError("follow=True requires file_path")
 
@@ -752,7 +756,7 @@ class HistoryMixin(mixin_base):
         limit: int = 200,
         file_cache: FileHistoryCache = file_history_cache,
         commit_cache: CommitInfoCache = commit_info_cache,
-    ) -> List[str]:
+    ) -> list[ShortHash]:
         """
         Populate file-history info for a single logical file history.
 
@@ -822,7 +826,7 @@ class HistoryMixin(mixin_base):
             pairs = take(limit, pairs)
 
         filename = file_path
-        hashes: List[str] = []
+        hashes: list[ShortHash] = []
         for record, right in pairs:
             assert record
             hashes.append(record.short_hash)

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -10,9 +10,8 @@ import sublime
 from sublime_plugin import WindowCommand
 
 from ...common import ui, util
-from ..commands import GsNavigate
+from ..commands import GsNavigate, ref_undo
 from ..commands.log import LogMixin
-from ..commands.ref_undo import add_branch_undo
 from ..commands import multi_selector
 from ..git_command import GitCommand, GitSavvyError
 from ..ui__busy_spinner import busy_indicator
@@ -693,7 +692,11 @@ class gs_branches_delete(BranchInterfaceCommand):
                 self.delete_worktree(selected_item.worktree, force)
             else:
                 self.view.settings().set("git_savvy.update_view_in_a_blocking_manner", True)
-                self.window.run_command("gs_delete_branch", {"branch": selected_item.branch_name, "force": force})
+                self.window.run_command("gs_delete_branch", {
+                    "branch": selected_item.branch_name,
+                    "force": force,
+                    "undo_owner": self.view.id()
+                })
             return
 
         selected_lines = ui.unique_selected_lines(self.view)
@@ -750,10 +753,10 @@ class gs_branches_delete(BranchInterfaceCommand):
                 *branch_names
             )
         except GitSavvyError as e:
-            record_deleted_branch_undos(self, branch_names, e.stdout)
+            record_deleted_branch_undos(self, branch_names, e.stdout, self.view.id())
             raise
         else:
-            record_deleted_branch_undos(self, branch_names, stdout)
+            record_deleted_branch_undos(self, branch_names, stdout, self.view.id())
         self.window.status_message("Deleted local branches.")
         util.view.refresh_gitsavvy(self.view)
         self.view.run_command("gs_clear_multiselect")
@@ -778,13 +781,14 @@ DELETED_BRANCH_RE = re.compile(r"^Deleted branch (.+?) \\(was ([0-9a-f]+)\\)\\.$
 def record_deleted_branch_undos(
     cmd: GitCommand,
     branch_names: list[str],
-    stdout: str
+    stdout: str,
+    undo_owner: sublime.ViewId
 ) -> None:
     expected_branches = set(branch_names)
     for match in DELETED_BRANCH_RE.finditer(stdout):
         branch_name, commit_hash = match.groups()
         if branch_name in expected_branches:
-            add_branch_undo(cmd, branch_name, commit_hash)
+            ref_undo.add_branch_undo(cmd, branch_name, commit_hash, undo_owner)
 
 
 class gs_branches_rename(CommandForSingleBranch):

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -14,7 +14,7 @@ from ..commands import GsNavigate
 from ..commands.log import LogMixin
 from ..commands.ref_undo import add_branch_undo
 from ..commands import multi_selector
-from ..git_command import GitCommand
+from ..git_command import GitCommand, GitSavvyError
 from ..ui__busy_spinner import busy_indicator
 from ..ui_mixins.quick_panel import show_remote_panel, show_branch_panel
 from ..ui_mixins.input_panel import show_single_line_input_panel
@@ -741,19 +741,19 @@ class gs_branches_delete(BranchInterfaceCommand):
 
     @util.actions.destructive(description="delete local branches")
     @on_worker
-    def delete_local_branches(self, branch_names, force):
-        old_hashes = {
-            branch_name: self.git("rev-parse", "--verify", f"refs/heads/{branch_name}").strip()
-            for branch_name in branch_names
-        }
+    def delete_local_branches(self, branch_names: list[str], force: bool):
         self.window.status_message("Deleting local branches...")
-        self.git(
-            "branch",
-            "-D" if force else "-d",
-            *branch_names
-        )
-        for branch_name, old_hash in old_hashes.items():
-            add_branch_undo(self, branch_name, old_hash)
+        try:
+            stdout = self.git(
+                "branch",
+                "-D" if force else "-d",
+                *branch_names
+            )
+        except GitSavvyError as e:
+            record_deleted_branch_undos(self, branch_names, e.stdout)
+            raise
+        else:
+            record_deleted_branch_undos(self, branch_names, stdout)
         self.window.status_message("Deleted local branches.")
         util.view.refresh_gitsavvy(self.view)
         self.view.run_command("gs_clear_multiselect")
@@ -770,6 +770,21 @@ class gs_branches_delete(BranchInterfaceCommand):
             self.interface.state["worktree_deletions_in_progress"].discard(path)
             self.view.settings().set("git_savvy.update_view_in_a_blocking_manner", True)
             util.view.refresh_gitsavvy(self.view)
+
+
+DELETED_BRANCH_RE = re.compile(r"^Deleted branch (.+?) \\(was ([0-9a-f]+)\\)\\.$", re.MULTILINE)
+
+
+def record_deleted_branch_undos(
+    cmd: GitCommand,
+    branch_names: list[str],
+    stdout: str
+) -> None:
+    expected_branches = set(branch_names)
+    for match in DELETED_BRANCH_RE.finditer(stdout):
+        branch_name, commit_hash = match.groups()
+        if branch_name in expected_branches:
+            add_branch_undo(cmd, branch_name, commit_hash)
 
 
 class gs_branches_rename(CommandForSingleBranch):

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -12,6 +12,7 @@ from sublime_plugin import WindowCommand
 from ...common import ui, util
 from ..commands import GsNavigate
 from ..commands.log import LogMixin
+from ..commands.ref_undo import add_branch_undo
 from ..commands import multi_selector
 from ..git_command import GitCommand
 from ..ui__busy_spinner import busy_indicator
@@ -741,12 +742,18 @@ class gs_branches_delete(BranchInterfaceCommand):
     @util.actions.destructive(description="delete local branches")
     @on_worker
     def delete_local_branches(self, branch_names, force):
+        old_hashes = {
+            branch_name: self.git("rev-parse", "--verify", f"refs/heads/{branch_name}").strip()
+            for branch_name in branch_names
+        }
         self.window.status_message("Deleting local branches...")
         self.git(
             "branch",
             "-D" if force else "-d",
             *branch_names
         )
+        for branch_name, old_hash in old_hashes.items():
+            add_branch_undo(self, branch_name, old_hash)
         self.window.status_message("Deleted local branches.")
         util.view.refresh_gitsavvy(self.view)
         self.view.run_command("gs_clear_multiselect")

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -453,7 +453,9 @@ class gs_tags_delete(TagsInterfaceCommand):
         tags_to_delete = self.selected_local_tags()
         tag_hashes = self.selected_local_commits()
         for tag, tag_hash in zip(tags_to_delete, tag_hashes):
-            with ref_undo.record_tag_recreate_action(self, tag, tag_hash):
+            with ref_undo.record_tag_recreate_action(
+                self, tag, tag_hash, undo_owner=self.view.id()
+            ):
                 rv = self.git("tag", "-d", tag)
 
             match = EXTRACT_COMMIT.search(rv.strip())

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -8,8 +8,7 @@ from webbrowser import open as open_in_browser
 import sublime
 from sublime_plugin import WindowCommand
 
-from ..commands import GsNavigate
-from ..commands.ref_undo import add_tag_undo
+from ..commands import GsNavigate, ref_undo
 from ...common import ui
 from ..git_command import GitCommand, GitSavvyError
 from ..git_mixins.tags import TagList
@@ -452,12 +451,11 @@ class gs_tags_delete(TagsInterfaceCommand):
     def delete_local(self):
         # type: () -> List[str]
         tags_to_delete = self.selected_local_tags()
-        for tag in tags_to_delete:
-            ref = f"refs/tags/{tag}"
-            tag_ref_hash = self.git("rev-parse", "--verify", ref).strip()
-            dereferenced_target_hash = self.git("rev-parse", "--verify", f"{ref}^{{}}").strip()
-            rv = self.git("tag", "-d", tag)
-            add_tag_undo(self, tag, tag_ref_hash, dereferenced_target_hash)
+        tag_hashes = self.selected_local_commits()
+        for tag, tag_hash in zip(tags_to_delete, tag_hashes):
+            with ref_undo.record_tag_recreate_action(self, tag, tag_hash):
+                rv = self.git("tag", "-d", tag)
+
             match = EXTRACT_COMMIT.search(rv.strip())
             if match:
                 commit = match.group(1)

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -9,6 +9,7 @@ import sublime
 from sublime_plugin import WindowCommand
 
 from ..commands import GsNavigate
+from ..commands.ref_undo import add_tag_undo
 from ...common import ui
 from ..git_command import GitCommand, GitSavvyError
 from ..git_mixins.tags import TagList
@@ -452,7 +453,11 @@ class gs_tags_delete(TagsInterfaceCommand):
         # type: () -> List[str]
         tags_to_delete = self.selected_local_tags()
         for tag in tags_to_delete:
+            ref = f"refs/tags/{tag}"
+            old_hash = self.git("rev-parse", "--verify", ref).strip()
+            target_hash = self.git("rev-parse", "--short", f"{ref}^{{}}", throw_on_error=False).strip()
             rv = self.git("tag", "-d", tag)
+            add_tag_undo(self, tag, old_hash, target_hash)
             match = EXTRACT_COMMIT.search(rv.strip())
             if match:
                 commit = match.group(1)

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -454,10 +454,10 @@ class gs_tags_delete(TagsInterfaceCommand):
         tags_to_delete = self.selected_local_tags()
         for tag in tags_to_delete:
             ref = f"refs/tags/{tag}"
-            old_hash = self.git("rev-parse", "--verify", ref).strip()
-            target_hash = self.git("rev-parse", "--short", f"{ref}^{{}}", throw_on_error=False).strip()
+            tag_ref_hash = self.git("rev-parse", "--verify", ref).strip()
+            dereferenced_target_hash = self.git("rev-parse", "--verify", f"{ref}^{{}}").strip()
             rv = self.git("tag", "-d", tag)
-            add_tag_undo(self, tag, old_hash, target_hash)
+            add_tag_undo(self, tag, tag_ref_hash, dereferenced_target_hash)
             match = EXTRACT_COMMIT.search(rv.strip())
             if match:
                 commit = match.group(1)

--- a/core/store.py
+++ b/core/store.py
@@ -18,7 +18,6 @@ if TYPE_CHECKING:
     from GitSavvy.core.git_mixins.stash import Stash
     from GitSavvy.core.git_mixins.tags import TagList
     from GitSavvy.core.git_mixins.status import HeadState, WorkingDirState
-    from GitSavvy.core.commands.ref_undo import RefUndoAction
 
     class RepoStore(TypedDict, total=False):
         status: WorkingDirState
@@ -44,7 +43,6 @@ if TYPE_CHECKING:
         recent_commits: List[Commit]
         descriptions: Dict[str, str]
         default_graph_options: Dict[str, str]
-        ref_undo_actions: List[RefUndoAction]
     RepoPath = str
     SubscriberKey = str
     Keys = AbstractSet[str]

--- a/core/store.py
+++ b/core/store.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from GitSavvy.core.git_mixins.stash import Stash
     from GitSavvy.core.git_mixins.tags import TagList
     from GitSavvy.core.git_mixins.status import HeadState, WorkingDirState
+    from GitSavvy.core.commands.ref_undo import RefUndoAction
 
     class RepoStore(TypedDict, total=False):
         status: WorkingDirState
@@ -43,6 +44,7 @@ if TYPE_CHECKING:
         recent_commits: List[Commit]
         descriptions: Dict[str, str]
         default_graph_options: Dict[str, str]
+        ref_undo_actions: List[RefUndoAction]
     RepoPath = str
     SubscriberKey = str
     Keys = AbstractSet[str]


### PR DESCRIPTION
Bind D in the graph to delete local branch and tag decorations from the
selected commit.  If multiple decorations can be deleted, show an action
panel.  Remote-only refs report that they cannot be deleted.

Track per-view in-memory undo actions for deleted refs and expose them
through primary+z in the graph.