### PR TITLE
Refactor tag creation command

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -446,7 +446,7 @@
     },
     {
         "caption": "git: quick tag",
-        "command": "gs_tag_create"
+        "command": "gs_create_tag"
     },
     {
         "caption": "git: smart tag",

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1756,7 +1756,7 @@
     },
     {
         "keys": ["c"],
-        "command": "gs_tag_create",
+        "command": "gs_create_tag",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.tags_view", "operator": "equal", "operand": true }

--- a/core/base_commands.py
+++ b/core/base_commands.py
@@ -17,8 +17,9 @@ class Kont(Protocol):
         pass
 
 
+T = TypeVar("T")
 CommandT = TypeVar("CommandT", bound="GsCommand")
-Args = Dict[str, object]
+Args = Dict[str, Any]
 ArgProvider = Callable[[CommandT, Args, Kont], None]
 
 
@@ -202,3 +203,8 @@ def std_undo_owner(self: GsCommand, args: Args, done: Kont) -> None:
         done(av.id())
     else:
         self.window.status_message("No active_view() available.")
+
+
+def call_with_wanted_args(fn: Callable[..., T], args: Args) -> T:
+    fs = _signature(fn)
+    return fn(**{k: args[k] for k in fs.parameters.keys() if k in args})

--- a/core/commands/branch.py
+++ b/core/commands/branch.py
@@ -1,6 +1,4 @@
 from __future__ import annotations
-from functools import lru_cache
-import inspect
 import re
 import sublime
 
@@ -8,9 +6,11 @@ from . import push, ref_undo
 from ..git_command import GitSavvyError
 from ..ui_mixins.input_panel import show_single_line_input_panel
 from ...common import util
-from GitSavvy.core.base_commands import ask_for_local_branch, std_undo_owner, GsWindowCommand
+from GitSavvy.core.base_commands import (
+    ask_for_local_branch, call_with_wanted_args, std_undo_owner,
+    GsWindowCommand)
 from ..ui__quick_panel import noop, show_actions_panel
-from GitSavvy.core.utils import uprint
+from GitSavvy.core.utils import just, uprint
 from GitSavvy.core.types import FullHash, ShortHash
 
 
@@ -22,7 +22,7 @@ __all__ = (
 )
 
 
-from typing import Callable, Optional, TypeVar
+from typing import Optional, TypeVar
 from GitSavvy.core.base_commands import Args, Kont
 T = TypeVar("T")
 
@@ -42,22 +42,6 @@ GitSavvy: Re-created branch '{0}', in case you want to undo, run:
 EXTRACT_COMMIT = re.compile(r"\(was (.+)\)")
 NOT_MERGED_WARNING = re.compile(r"the branch.*is not fully merged", re.I)
 CANT_DELETE_USED_BRANCH = re.compile(r"cannot delete branch .+ (checked out|used by worktree) at ", re.I)
-
-
-def just(value):
-    # type: (T) -> Callable[..., T]
-    return lambda: value
-
-
-def call_with_wanted_args(fn, args):
-    # type: (Callable[..., T], Args) -> T
-    fs = _signature(fn)
-    return fn(**{k: args[k] for k in fs.parameters.keys() if k in args})
-
-
-@lru_cache()
-def _signature(fn):
-    return inspect.signature(fn)
 
 
 def ask_for_name(caption=just(NEW_BRANCH_PROMPT), initial_text=just("")):

--- a/core/commands/log_graph_main_actions.py
+++ b/core/commands/log_graph_main_actions.py
@@ -662,7 +662,7 @@ class gs_log_graph_action(WindowCommand, GitCommand):
         self.window.run_command("gs_create_branch", {"start_point": commit_hash})
 
     def create_tag(self, commit_hash):
-        self.window.run_command("gs_tag_create", {"target_commit": commit_hash})
+        self.window.run_command("gs_create_tag", {"target_commit": commit_hash})
 
     def delete_tag(
         self,

--- a/core/commands/log_graph_main_actions.py
+++ b/core/commands/log_graph_main_actions.py
@@ -13,7 +13,7 @@ from ..fns import filter_, take, unique
 from ..git_command import GitCommand
 from ..git_mixins.branches import Branch
 from ..text_helper import line_from_pt
-from ..types import FullHash, FullPath, ShortHash
+from ..types import FullPath
 from ..ui__quick_panel import ActionType, SEPARATOR, show_actions_panel, show_quick_panel
 from ..utils import open_folder_in_new_window
 from . import multi_selector
@@ -66,7 +66,7 @@ class gs_log_graph_delete_decoration(WindowCommand, GitCommand):
         ] + [
             (
                 "Delete tag '{}'".format(tag_name),
-                partial(self.delete_tag, tag_name, info["commit"], view.id())
+                partial(self.delete_tag, tag_name, view.id())
             )
             for tag_name in info.get("tags", [])
         ]
@@ -80,10 +80,9 @@ class gs_log_graph_delete_decoration(WindowCommand, GitCommand):
     def delete_tag(
         self,
         tag_name: str,
-        commit_hash: ShortHash,
         undo_owner: sublime.ViewId
     ) -> None:
-        delete_tag_from_graph(self, self.window, tag_name, commit_hash, undo_owner)
+        delete_tag_from_graph(self, self.window, tag_name, undo_owner)
 
 
 class gs_log_graph_action(WindowCommand, GitCommand):
@@ -379,7 +378,7 @@ class gs_log_graph_action(WindowCommand, GitCommand):
         actions += [
             (
                 "Delete tag '{}'".format(tag_name),
-                partial(self.delete_tag, tag_name, commit_hash, view.id())
+                partial(self.delete_tag, tag_name, view.id())
             )
             for tag_name in info.get("tags", [])
         ]
@@ -667,10 +666,9 @@ class gs_log_graph_action(WindowCommand, GitCommand):
     def delete_tag(
         self,
         tag_name: str,
-        commit_hash: ShortHash,
         undo_owner: sublime.ViewId
     ) -> None:
-        delete_tag_from_graph(self, self.window, tag_name, commit_hash, undo_owner)
+        delete_tag_from_graph(self, self.window, tag_name, undo_owner)
 
     def reset_to(self, commitish):
         self.window.run_command("gs_reset", {"commit_hash": commitish})
@@ -761,13 +759,11 @@ def delete_tag_from_graph(
     cmd: GitCommand,
     window: sublime.Window,
     tag_name: str,
-    dereferenced_target_hash: FullHash | ShortHash,
     undo_owner: sublime.ViewId
 ) -> None:
     with ref_undo.record_tag_recreate_action(
         cmd,
         tag_name,
-        dereferenced_target_hash=dereferenced_target_hash,
         undo_owner=undo_owner
     ):
         cmd.git("tag", "-d", tag_name)

--- a/core/commands/log_graph_smart_copy.py
+++ b/core/commands/log_graph_smart_copy.py
@@ -227,7 +227,7 @@ class gs_log_graph_smart_paste(sublime_plugin.TextCommand):
                 "force": True
             })
         elif kind == "tag":
-            window.run_command("gs_tag_create", {
+            window.run_command("gs_create_tag", {
                 "target_commit": commit_hash.text,
                 "tag_name": ref,
             })

--- a/core/commands/log_graph_smart_copy.py
+++ b/core/commands/log_graph_smart_copy.py
@@ -230,6 +230,7 @@ class gs_log_graph_smart_paste(sublime_plugin.TextCommand):
             window.run_command("gs_create_tag", {
                 "target_commit": commit_hash.text,
                 "tag_name": ref,
+                "force": True
             })
 
 

--- a/core/commands/ref_undo.py
+++ b/core/commands/ref_undo.py
@@ -14,7 +14,7 @@ from sublime_plugin import EventListener
 from ...common import util
 from ..base_commands import GsTextCommand
 from ..git_command import GitCommand
-from ..types import FullHash, ShortHash
+from ..types import CommitHash, FullHash, ShortHash
 from ..ui__quick_panel import show_quick_panel
 
 
@@ -100,13 +100,9 @@ def add_branch_move_undo(
 def record_tag_recreate_action(
     cmd: GitCommand,
     tag_name: str,
-    tag_ref_hash: FullHash | ShortHash | None = None,
-    dereferenced_target_hash: FullHash | ShortHash | None = None,
     undo_owner: UndoOwner | None = None
 ) -> Iterator[None]:
-    ref = f"refs/tags/{tag_name}"
-    tag_ref_hash = tag_ref_hash or cmd.resolve(ref)
-    dereferenced_target_hash = dereferenced_target_hash or cmd.resolve(f"{ref}^{{}}")
+    tag_ref_hash, dereferenced_target_hash = cmd.resolve_tag(tag_name)
 
     yield
 
@@ -116,8 +112,8 @@ def record_tag_recreate_action(
 def add_tag_undo(
     cmd: GitCommand,
     tag_name: str,
-    tag_ref_hash: FullHash | ShortHash,
-    dereferenced_target_hash: FullHash | ShortHash,
+    tag_ref_hash: CommitHash,
+    dereferenced_target_hash: CommitHash,
     undo_owner: UndoOwner | None = None
 ) -> None:
     undo_owner = undo_owner or resolve_undo_owner(cmd)

--- a/core/commands/tag.py
+++ b/core/commands/tag.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 from sublime_plugin import TextCommand
 
@@ -5,18 +7,20 @@ from ...common import util
 from ..git_command import GitSavvyError
 from ..ui_mixins.quick_panel import PanelActionMixin
 from ..ui_mixins.input_panel import show_single_line_input_panel
-from GitSavvy.core.base_commands import GsTextCommand
+from GitSavvy.core.base_commands import (
+    call_with_wanted_args,
+    Args, GsCommand, GsWindowCommand, Kont)
 from ..ui__quick_panel import noop, show_actions_panel
-from GitSavvy.core.utils import uprint, yes_no_switch
+from GitSavvy.core.utils import just, uprint, yes_no_switch
 
 
 __all__ = (
-    "gs_tag_create",
+    "gs_create_tag",
     "gs_smart_tag",
 )
 
 
-from typing import Literal, Optional
+from typing import Callable, Literal, Optional
 ReleaseTypes = Literal[
     "patch",
     "minor",
@@ -88,78 +92,110 @@ def default_tag_message(message_template: str, tag_name: str) -> str:
     return message_template.format(tag_name=tag_name)
 
 
-class gs_tag_create(GsTextCommand):
+def ask_for_tag_name(
+    caption: str = TAG_CREATE_PROMPT,
+    initial_text: Callable[..., str] = just("")
+):
+    def handler(cmd: GsCommand, args: Args, done: Kont, initial_text_: str = "") -> None:
+        def on_done(tag_name):
+            if not tag_name:
+                return None
 
+            normalized_tag_name = normalize_tag_name(cmd, tag_name)
+            if not normalized_tag_name:
+                util.log.display_panel(
+                    cmd.window,
+                    "'{}' is not a valid tag name.".format(tag_name)
+                )
+                handler(cmd, args, done, initial_text_=tag_name)
+                return None
+
+            done(normalized_tag_name)
+
+        show_single_line_input_panel(
+            caption,
+            initial_text_ or call_with_wanted_args(initial_text, args),
+            on_done
+        )
+    return handler
+
+
+def ask_for_tag_message():
+    def handler(cmd: GsCommand, args: Args, done: Kont) -> None:
+        tag_name = args["tag_name"]
+        if should_ask_for_tag_message(cmd, tag_name):
+            show_single_line_input_panel(
+                TAG_CREATE_MESSAGE_PROMPT,
+                default_tag_message(cmd.savvy_settings.get("default_tag_message"), tag_name),
+                done
+            )
+        else:
+            done(None)
+    return handler
+
+
+def should_ask_for_tag_message(cmd: GsCommand, tag_name: str) -> bool:
+    return (
+        not cmd.savvy_settings.get("only_ask_to_annotate_versions")
+        or bool(MAYBE_SEMVER.search(tag_name))
+    )
+
+
+def normalize_tag_name(cmd: GsCommand, tag_name: str) -> str | None:
+    stdout = cmd.git(
+        "check-ref-format",
+        "--normalize",
+        "refs/tags/" + tag_name,
+        throw_on_error=False
+    )
+    return stdout.strip()[10:] if stdout else None
+
+
+class gs_create_tag(GsWindowCommand):
     """
     Through a series of panels, allow the user to add a tag and message.
     """
 
-    def run(self, edit, tag_name="", target_commit=None):
-        # type: (object, str, str) -> None
-        window = self.view.window()
-        if not window:
-            return
-        self.window = window
-        self.target_commit = target_commit
-        show_single_line_input_panel(TAG_CREATE_PROMPT, tag_name, self.on_entered_name)
+    defaults = {
+        "tag_name": ask_for_tag_name(
+            initial_text=lambda suggested_name="": suggested_name
+        ),
+        "tag_message": ask_for_tag_message(),
+    }
 
-    def on_entered_name(self, tag_name):
-        # type: (str) -> None
-        """
-        After the user has entered a tag name, validate the tag name and prompt for
-        a tag message.
-        """
-        if not tag_name:
-            return
-
-        stdout = self.git(
-            "check-ref-format",
-            "--normalize",
-            "refs/tags/" + tag_name,
-            throw_on_error=False
-        )
-
-        if not stdout:
-            util.log.display_panel(
-                self.window,
-                "'{}' is not a valid tag name.".format(tag_name)
-            )
-            return None
-
-        self.tag_name = stdout.strip()[10:]
-
-        if MAYBE_SEMVER.search(tag_name) and self.savvy_settings.get("only_ask_to_annotate_versions"):
-            show_single_line_input_panel(
-                TAG_CREATE_MESSAGE_PROMPT,
-                default_tag_message(self.savvy_settings.get("default_tag_message"), tag_name),
-                self.on_entered_message
-            )
-        else:
-            self.on_entered_message()
-
-    def on_entered_message(self, message=None, force=False):
-        # type: (str, bool) -> None
-        """
-        Create a tag with the specified tag name and message.
-        """
+    def run(
+        self,
+        tag_name: str,
+        tag_message: str | None,
+        target_commit: str | None = None,
+        force: bool = False,
+        suggested_name: str = "",
+    ) -> None:
         try:
-            if not message:
-                self.git_throwing_silently("tag", yes_no_switch("--force", force), self.tag_name, self.target_commit)
+            if not tag_message:
+                self.git_throwing_silently(
+                    "tag", yes_no_switch("--force", force), tag_name, target_commit)
             else:
                 self.git_throwing_silently(
-                    "tag", yes_no_switch("--force", force), self.tag_name, self.target_commit,
-                    "-F", "-", stdin=message)
+                    "tag", yes_no_switch("--force", force), tag_name, target_commit,
+                    "-F", "-", stdin=tag_message)
         except GitSavvyError as e:
-            if TAG_ALREADY_EXISTS_MESSAGE.format(self.tag_name) in e.stderr and not force:
+            if TAG_ALREADY_EXISTS_MESSAGE.format(tag_name) in e.stderr and not force:
                 def overwrite_action():
-                    old_hash = self.resolve(self.tag_name)
-                    uprint(RECREATE_TAG_UNDO_MESSAGE.format(self.tag_name, old_hash))
-                    self.on_entered_message(message, force=True)
+                    old_hash = self.resolve(tag_name)
+                    uprint(RECREATE_TAG_UNDO_MESSAGE.format(tag_name, old_hash))
+
+                    self.window.run_command("gs_create_tag", {
+                        "tag_name": tag_name,
+                        "tag_message": tag_message,
+                        "target_commit": target_commit,
+                        "force": True,
+                    })
 
                 show_actions_panel(self.window, [
-                    noop(f"Abort, a tag named '{self.tag_name}' already exists."),
+                    noop(f"Abort, a tag named '{tag_name}' already exists."),
                     (
-                        f'Re-create the tag at {self.target_commit}.',
+                        f'Re-create the tag at {target_commit or "HEAD"}.',
                         overwrite_action
                     )
                 ])
@@ -169,7 +205,7 @@ class gs_tag_create(GsTextCommand):
                 e.show_error_panel()
                 raise
 
-        self.window.status_message(TAG_CREATE_MESSAGE.format(self.tag_name))
+        self.window.status_message(TAG_CREATE_MESSAGE.format(tag_name))
         util.view.refresh_gitsavvy_interfaces(self.window)
 
 
@@ -190,8 +226,10 @@ class gs_smart_tag(PanelActionMixin, TextCommand):
         ["smart_tag", "premajor", ("premajor", )],
     ]
 
-    def smart_tag(self, release_type):
-        # type: (ReleaseTypes) -> None
+    def smart_tag(self, release_type: ReleaseTypes) -> None:
         last_tag_name = self.get_last_local_semver_tag() or VERSION_ZERO
         tag_name = smart_incremented_tag(last_tag_name, release_type) or last_tag_name
-        self.view.run_command("gs_tag_create", {"tag_name": tag_name})
+        window = self.view.window()
+        if not window:
+            return
+        window.run_command("gs_create_tag", {"suggested_name": tag_name})

--- a/core/commands/tag.py
+++ b/core/commands/tag.py
@@ -178,15 +178,7 @@ class gs_create_tag(GsWindowCommand):
         previous_hash: tuple[CommitHash, CommitHash] | None = None
     ) -> None:
         if force and previous_hash is None:
-            if previous_tag_ref_hash := self.resolve(
-                f"refs/tags/{tag_name}",
-                on_error="ignore"
-            ):
-                if previous_tag_deref_hash := self.resolve(
-                    f"refs/tags/{tag_name}^{{}}",
-                    on_error="ignore"
-                ):
-                    previous_hash = (previous_tag_ref_hash, previous_tag_deref_hash)
+            previous_hash = self.resolve_tag(tag_name, lenient=True)
 
         try:
             if not tag_message:
@@ -199,10 +191,7 @@ class gs_create_tag(GsWindowCommand):
         except GitSavvyError as e:
             if TAG_ALREADY_EXISTS_MESSAGE.format(tag_name) in e.stderr and not force:
                 def overwrite_action():
-                    previous_hash = (
-                        self.resolve(f"refs/tags/{tag_name}"),
-                        self.resolve(f"refs/tags/{tag_name}^{{}}")
-                    )
+                    previous_hash = self.resolve_tag(tag_name)
                     uprint(RECREATE_TAG_UNDO_MESSAGE.format(
                         tag_name,
                         previous_hash[1]

--- a/core/commands/tag.py
+++ b/core/commands/tag.py
@@ -1,17 +1,20 @@
 from __future__ import annotations
 
 import re
+import sublime
 from sublime_plugin import TextCommand
 
+from . import ref_undo
 from ...common import util
 from ..git_command import GitSavvyError
 from ..ui_mixins.quick_panel import PanelActionMixin
 from ..ui_mixins.input_panel import show_single_line_input_panel
 from GitSavvy.core.base_commands import (
     call_with_wanted_args,
-    Args, GsCommand, GsWindowCommand, Kont)
+    Args, GsCommand, GsWindowCommand, Kont, std_undo_owner)
 from ..ui__quick_panel import noop, show_actions_panel
 from GitSavvy.core.utils import just, uprint, yes_no_switch
+from GitSavvy.core.types import CommitHash
 
 
 __all__ = (
@@ -161,16 +164,30 @@ class gs_create_tag(GsWindowCommand):
             initial_text=lambda suggested_name="": suggested_name
         ),
         "tag_message": ask_for_tag_message(),
+        "undo_owner": std_undo_owner,
     }
 
     def run(
         self,
         tag_name: str,
         tag_message: str | None,
+        undo_owner: sublime.ViewId,
         target_commit: str | None = None,
         force: bool = False,
         suggested_name: str = "",
+        previous_hash: tuple[CommitHash, CommitHash] | None = None
     ) -> None:
+        if force and previous_hash is None:
+            if previous_tag_ref_hash := self.resolve(
+                f"refs/tags/{tag_name}",
+                on_error="ignore"
+            ):
+                if previous_tag_deref_hash := self.resolve(
+                    f"refs/tags/{tag_name}^{{}}",
+                    on_error="ignore"
+                ):
+                    previous_hash = (previous_tag_ref_hash, previous_tag_deref_hash)
+
         try:
             if not tag_message:
                 self.git_throwing_silently(
@@ -182,14 +199,22 @@ class gs_create_tag(GsWindowCommand):
         except GitSavvyError as e:
             if TAG_ALREADY_EXISTS_MESSAGE.format(tag_name) in e.stderr and not force:
                 def overwrite_action():
-                    old_hash = self.resolve(tag_name)
-                    uprint(RECREATE_TAG_UNDO_MESSAGE.format(tag_name, old_hash))
+                    previous_hash = (
+                        self.resolve(f"refs/tags/{tag_name}"),
+                        self.resolve(f"refs/tags/{tag_name}^{{}}")
+                    )
+                    uprint(RECREATE_TAG_UNDO_MESSAGE.format(
+                        tag_name,
+                        previous_hash[1]
+                    ))
 
                     self.window.run_command("gs_create_tag", {
                         "tag_name": tag_name,
                         "tag_message": tag_message,
                         "target_commit": target_commit,
                         "force": True,
+                        "previous_hash": previous_hash,
+                        "undo_owner": undo_owner,
                     })
 
                 show_actions_panel(self.window, [
@@ -204,6 +229,14 @@ class gs_create_tag(GsWindowCommand):
             else:
                 e.show_error_panel()
                 raise
+
+        if force and previous_hash:
+            ref_undo.add_tag_undo(
+                self,
+                tag_name,
+                *previous_hash,
+                undo_owner
+            )
 
         self.window.status_message(TAG_CREATE_MESSAGE.format(tag_name))
         util.view.refresh_gitsavvy_interfaces(self.window)

--- a/core/git_mixins/history.py
+++ b/core/git_mixins/history.py
@@ -11,7 +11,7 @@ from ...common import util
 from GitSavvy.core.fns import last, pairwise, take
 from GitSavvy.core.git_command import mixin_base
 from GitSavvy.core.caches import Cache, cached
-from GitSavvy.core.types import FullHash, FullPath, ShortHash, ShortPath
+from GitSavvy.core.types import CommitHash, FullHash, FullPath, ShortHash, ShortPath
 
 
 class LogEntry(NamedTuple):
@@ -276,6 +276,48 @@ class HistoryMixin(mixin_base):
 
     def resolve_commitish(self, ref: str) -> ShortHash:
         return self.resolve(ref, short=True)
+
+    @overload
+    def resolve_tag(
+        self,
+        tag_name: str,
+        *,
+        lenient: Literal[False] = False
+    ) -> tuple[CommitHash, CommitHash]: ...
+
+    @overload
+    def resolve_tag(
+        self,
+        tag_name: str,
+        *,
+        lenient: Literal[True]
+    ) -> tuple[CommitHash, CommitHash] | None: ...
+
+    def resolve_tag(self, tag_name: str, *, lenient: bool = False):
+        ref = tag_name if tag_name.startswith("refs/tags/") else f"refs/tags/{tag_name}"
+        output = self.git(
+            "show-ref",
+            "--dereference",
+            ref,
+            throw_on_error=not lenient,
+            show_panel_on_error=not lenient
+        ).strip()
+        if not output:
+            return None
+
+        tag_ref_hash = None
+        dereferenced_target_hash = None
+        for line in output.splitlines():
+            commit_hash, ref_name = line.split(" ", 1)
+            if ref_name == ref:
+                tag_ref_hash = FullHash(commit_hash)
+            elif ref_name == f"{ref}^{{}}":
+                dereferenced_target_hash = FullHash(commit_hash)
+
+        if not tag_ref_hash:
+            return None
+
+        return (tag_ref_hash, dereferenced_target_hash or tag_ref_hash)
 
     def to_short_hash(self, commit_hash: FullHash | ShortHash) -> ShortHash:
         short_hash_length = self.get_short_hash_length()

--- a/core/interfaces/status_main_actions.py
+++ b/core/interfaces/status_main_actions.py
@@ -166,4 +166,4 @@ class gs_status_action_menu(GsWindowCommand):
         open_folder_in_new_window(worktree_path, then=callback)
 
     def create_tag(self) -> None:
-        self.window.run_command("gs_tag_create")
+        self.window.run_command("gs_create_tag")

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -455,10 +455,9 @@ class gs_tags_delete(TagsInterfaceCommand):
     def delete_local(self):
         # type: () -> List[str]
         tags_to_delete = self.selected_local_tags()
-        tag_hashes = self.selected_local_commits()
-        for tag, tag_hash in zip(tags_to_delete, tag_hashes):
+        for tag in tags_to_delete:
             with ref_undo.record_tag_recreate_action(
-                self, tag, tag_hash, undo_owner=self.view.id()
+                self, tag, undo_owner=self.view.id()
             ):
                 rv = self.git("tag", "-d", tag)
 

--- a/core/utils.py
+++ b/core/utils.py
@@ -16,7 +16,8 @@ import sublime
 from . import runtime
 
 
-from typing import Callable, Iterator, Optional, Sequence, Type
+from typing import Callable, Iterator, Optional, Sequence, Type, TypeVar
+T = TypeVar("T")
 
 
 @contextmanager
@@ -136,6 +137,10 @@ def yes_no_switch(name, value):
     if value:
         return name
     return "--no-{}".format(name[2:])
+
+
+def just(value: T) -> Callable[..., T]:
+    return lambda: value
 
 
 def focus_view(view):


### PR DESCRIPTION
Rename the tag creation command to gs_create_tag and convert it to
use the command default-provider flow.

Add providers for tag names and messages, keep suggested names editable,
and support forced tag recreation while preserving explicit no-force flags.