### PR TITLE
Iter tags dashboard

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1764,7 +1764,7 @@
     },
     {
         "keys": ["s"],
-        "command": "gs_smart_tag",
+        "command": "gs_tags_smart_tag",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.tags_view", "operator": "equal", "operand": true }

--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -188,7 +188,7 @@
         {year}, {month}, {day}, {hour}, {minute}, and {second}; all numeric
         fields are zero-padded.
      */
-    "calendar_version_style": "{year}.{month}.{day}.{hour}.{minute}.{second}",
+    "calendar_version_style": "{year}.{month}.{day}",
 
     /*
         The filename for extra customized info to be displayed after the default

--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -183,6 +183,14 @@
     "only_ask_to_annotate_versions": true,
 
     /*
+        Format used by the smart tagger for repositories that use calendar
+        versioning instead of semantic versioning.  Available fields are
+        {year}, {month}, {day}, {hour}, {minute}, and {second}; all numeric
+        fields are zero-padded.
+     */
+    "calendar_version_style": "{year}.{month}.{day}.{hour}.{minute}.{second}",
+
+    /*
         The filename for extra customized info to be displayed after the default
         COMMIT_HELP_TEXT, such as commit message rules/tips/conventions.
         Place this file at the root of the repo, and it should be committed to the

--- a/core/commands/push.py
+++ b/core/commands/push.py
@@ -17,7 +17,7 @@ __all__ = (
 )
 
 
-from typing import Dict, Sequence, TypeVar
+from typing import TypeVar
 from GitSavvy.core.base_commands import Args, GsCommand, Kont
 T = TypeVar("T")
 
@@ -28,34 +28,6 @@ CONFIRM_FORCE_PUSH = ("You are about to `git push {}`. Would you  "
 
 
 class PushMixin(GsWindowCommand):
-    def guess_remote_to_push_to(self, available_remotes):
-        # type: (Sequence[str]) -> str
-        if len(available_remotes) == 0:
-            raise RuntimeError("")
-        if len(available_remotes) == 1:
-            return next(iter(available_remotes))
-
-        last_remote_used = self.current_state().get("last_remote_used_for_push")
-        if last_remote_used in available_remotes:
-            return last_remote_used  # type: ignore[return-value]
-
-        defaults = dict(
-            (key[:-12], val)  # strip trailing ".pushdefault" from key
-            for key, val in (
-                line.split()
-                for line in self.git(
-                    "config",
-                    "--get-regexp",
-                    r".*\.pushdefault",
-                    throw_on_error=False
-                ).splitlines()
-            )
-        )  # type: Dict[str, str]
-        for key in (defaults.get("gitsavvy"), defaults.get("remote"), "fork", "origin"):
-            if key in available_remotes:
-                return key  # type: ignore[return-value]
-        return next(iter(available_remotes))
-
     def do_push(
         self,
         remote,

--- a/core/commands/tag.py
+++ b/core/commands/tag.py
@@ -1,20 +1,19 @@
 from __future__ import annotations
 
 from datetime import datetime
+from functools import partial
 import re
 from string import Formatter
 import sublime
-from sublime_plugin import TextCommand
 
 from . import ref_undo
 from ...common import util
 from ..git_command import GitSavvyError
-from ..ui_mixins.quick_panel import PanelActionMixin
 from ..ui_mixins.input_panel import show_single_line_input_panel
 from GitSavvy.core.base_commands import (
     call_with_wanted_args,
     Args, GsCommand, GsWindowCommand, Kont, std_undo_owner)
-from ..ui__quick_panel import noop, show_actions_panel
+from ..ui__quick_panel import ActionType, noop, show_actions_panel
 from GitSavvy.core.utils import just, uprint, yes_no_switch
 from GitSavvy.core.types import CommitHash
 
@@ -236,34 +235,42 @@ class gs_create_tag(GsWindowCommand):
         util.view.refresh_gitsavvy_interfaces(self.window)
 
 
-class gs_smart_tag(PanelActionMixin, TextCommand):
+class gs_smart_tag(GsWindowCommand):
     """
     Displays a panel of possible smart tag options, based on the choice,
     tag the current commit with the corresponding tagname.
     """
 
-    async_action = True
-    default_actions = [
-        ["smart_tag", "patch", ("patch", )],
-        ["smart_tag", "minor", ("minor", )],
-        ["smart_tag", "major", ("major", )],
-        ["smart_tag", "prerelease", ("prerelease", )],
-        ["smart_tag", "prepatch", ("prepatch", )],
-        ["smart_tag", "preminor", ("preminor", )],
-        ["smart_tag", "premajor", ("premajor", )],
-    ]
+    def run(self, version_style: str | None = None) -> None:
+        if not version_style:
+            version_style = self.get_local_tags().version_style
 
-    def update_actions(self) -> None:
-        if self.get_local_tags().version_style == "calendar":
-            style = self.get_calendar_version_style()
-            primary, secondary = calendar_version_options(style)
-            self.actions = [
-                ["create_tag", "Create '{}'".format(primary), (primary, )],
-                ["create_tag", "Create '{}'".format(secondary), (secondary, )],
-                ["edit_tag_name", "Edit the tag name", (primary, )],
-            ]
-        else:
-            self.actions = self.default_actions[:]
+        actions = (
+            self.calendar_actions()
+            if version_style == "calendar" else
+            self.semver_actions()
+        )
+        show_actions_panel(self.window, actions)
+
+    def calendar_actions(self) -> list[ActionType]:
+        style = self.get_calendar_version_style()
+        primary, secondary = calendar_version_options(style)
+        return [
+            ("Create '{}'".format(primary), partial(self.create_tag, primary)),
+            ("Create '{}'".format(secondary), partial(self.create_tag, secondary)),
+            ("Edit the tag name", partial(self.edit_tag_name, primary)),
+        ]
+
+    def semver_actions(self) -> list[ActionType]:
+        return [
+            ("patch", partial(self.smart_tag, "patch")),
+            ("minor", partial(self.smart_tag, "minor")),
+            ("major", partial(self.smart_tag, "major")),
+            ("prerelease", partial(self.smart_tag, "prerelease")),
+            ("prepatch", partial(self.smart_tag, "prepatch")),
+            ("preminor", partial(self.smart_tag, "preminor")),
+            ("premajor", partial(self.smart_tag, "premajor")),
+        ]
 
     def get_calendar_version_style(self) -> str:
         style = self.savvy_settings.get("calendar_version_style")
@@ -281,16 +288,10 @@ class gs_smart_tag(PanelActionMixin, TextCommand):
         self.edit_tag_name(tag_name)
 
     def create_tag(self, tag_name: str) -> None:
-        window = self.view.window()
-        if not window:
-            return
-        window.run_command("gs_create_tag", {"tag_name": tag_name})
+        self.window.run_command("gs_create_tag", {"tag_name": tag_name})
 
     def edit_tag_name(self, suggested_name: str) -> None:
-        window = self.view.window()
-        if not window:
-            return
-        window.run_command("gs_create_tag", {"suggested_name": suggested_name})
+        self.window.run_command("gs_create_tag", {"suggested_name": suggested_name})
 
 
 def calendar_version_style_is_valid(style: object) -> bool:

--- a/core/commands/tag.py
+++ b/core/commands/tag.py
@@ -9,6 +9,7 @@ import sublime
 from . import ref_undo
 from ...common import util
 from ..git_command import GitSavvyError
+from ..git_mixins.tags import is_version_tag
 from ..ui_mixins.input_panel import show_single_line_input_panel
 from GitSavvy.core.base_commands import (
     call_with_wanted_args,
@@ -36,7 +37,6 @@ ReleaseTypes = Literal[
 
 
 RELEASE_REGEXP = re.compile(r"^([0-9A-Za-z-]*[A-Za-z-])?([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-\.]*?)?([0-9]+))?$")
-MAYBE_SEMVER = re.compile(r"\d+\.\d+(\.\d+)?")
 
 TAG_CREATE_PROMPT = "Enter tag:"
 TAG_CREATE_MESSAGE = "Tag \"{}\" created."
@@ -144,7 +144,7 @@ def ask_for_tag_message():
 def should_ask_for_tag_message(cmd: GsCommand, tag_name: str) -> bool:
     return (
         not cmd.savvy_settings.get("only_ask_to_annotate_versions")
-        or bool(MAYBE_SEMVER.search(tag_name))
+        or is_version_tag(tag_name)
     )
 
 

--- a/core/commands/tag.py
+++ b/core/commands/tag.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from datetime import datetime
 import re
+from string import Formatter
 import sublime
 from sublime_plugin import TextCommand
 
@@ -46,6 +48,9 @@ GitSavvy: Re-created tag '{0}', in case you want to undo, run:
   $ git tag --force {0} {1}
 """
 VERSION_ZERO = "v0.0.0"
+DEFAULT_CALENDAR_VERSION_STYLE = "{year}.{month}.{day}.{hour}.{minute}.{second}"
+SHORT_CALENDAR_VERSION_STYLE = "{year}.{month}.{day}"
+CALENDAR_VERSION_FIELDS = {"year", "month", "day", "hour", "minute", "second"}
 
 
 def smart_incremented_tag(tag, release_type):
@@ -248,10 +253,89 @@ class gs_smart_tag(PanelActionMixin, TextCommand):
         ["smart_tag", "premajor", ("premajor", )],
     ]
 
+    def update_actions(self) -> None:
+        if self.get_local_tags().version_style == "calendar":
+            style = self.get_calendar_version_style()
+            primary, secondary = calendar_version_options(style)
+            self.actions = [
+                ["create_tag", "Create '{}'".format(primary), (primary, )],
+                ["create_tag", "Create '{}'".format(secondary), (secondary, )],
+                ["edit_tag_name", "Edit the tag name", (primary, )],
+            ]
+        else:
+            self.actions = self.default_actions[:]
+
+    def get_calendar_version_style(self) -> str:
+        style = self.savvy_settings.get("calendar_version_style")
+        if not calendar_version_style_is_valid(style):
+            print(
+                f"calendar_version_style is invalid. "
+                f"falling back to '{DEFAULT_CALENDAR_VERSION_STYLE}'"
+            )
+            return DEFAULT_CALENDAR_VERSION_STYLE
+        return style
+
     def smart_tag(self, release_type: ReleaseTypes) -> None:
         last_tag_name = self.get_last_local_semver_tag() or VERSION_ZERO
         tag_name = smart_incremented_tag(last_tag_name, release_type) or last_tag_name
+        self.edit_tag_name(tag_name)
+
+    def create_tag(self, tag_name: str) -> None:
         window = self.view.window()
         if not window:
             return
-        window.run_command("gs_create_tag", {"suggested_name": tag_name})
+        window.run_command("gs_create_tag", {"tag_name": tag_name})
+
+    def edit_tag_name(self, suggested_name: str) -> None:
+        window = self.view.window()
+        if not window:
+            return
+        window.run_command("gs_create_tag", {"suggested_name": suggested_name})
+
+
+def calendar_version_style_is_valid(style: object) -> bool:
+    if not isinstance(style, str) or not style:
+        return False
+
+    try:
+        fields = [field for _, field, _, _ in Formatter().parse(style) if field]
+    except ValueError:
+        return False
+
+    if not fields or any(field not in CALENDAR_VERSION_FIELDS for field in fields):
+        return False
+
+    return True
+
+
+def calendar_version_options(
+    primary_style: str,
+    now: datetime | None = None
+) -> tuple[str, str]:
+    now = now or datetime.now()
+    primary = calendar_version(primary_style, now)
+    secondary_style = (
+        DEFAULT_CALENDAR_VERSION_STYLE
+        if primary_style == SHORT_CALENDAR_VERSION_STYLE
+        else SHORT_CALENDAR_VERSION_STYLE
+    )
+    return primary, calendar_version(secondary_style, now)
+
+
+def calendar_version(style: str, now: datetime | None = None) -> str:
+    now = now or datetime.now()
+    try:
+        return style.format(**calendar_version_fields(now))
+    except (AttributeError, IndexError, KeyError, ValueError):
+        return DEFAULT_CALENDAR_VERSION_STYLE.format(**calendar_version_fields(now))
+
+
+def calendar_version_fields(now: datetime) -> dict[str, str]:
+    return {
+        "year": f"{now.year:04}",
+        "month": f"{now.month:02}",
+        "day": f"{now.day:02}",
+        "hour": f"{now.hour:02}",
+        "minute": f"{now.minute:02}",
+        "second": f"{now.second:02}"
+    }

--- a/core/commands/tag.py
+++ b/core/commands/tag.py
@@ -8,6 +8,7 @@ import sublime
 
 from . import ref_undo
 from ...common import util
+from ..fns import unique
 from ..git_command import GitSavvyError
 from ..git_mixins.tags import is_version_tag
 from ..ui_mixins.input_panel import show_single_line_input_panel
@@ -281,10 +282,13 @@ class gs_smart_tag(GsWindowCommand):
 
     def calendar_actions(self) -> list[ActionType]:
         style = self.get_calendar_version_style()
-        primary, secondary = calendar_version_options(style)
+        versions = calendar_version_options(style)
+        primary = versions[0]
         return [
-            ("Create '{}'".format(primary), partial(self.create_tag, primary)),
-            ("Create '{}'".format(secondary), partial(self.create_tag, secondary)),
+            *(
+                ("Create '{}'".format(version), partial(self.create_tag, version))
+                for version in versions
+            ),
             ("Edit the tag name", partial(self.edit_tag_name, primary)),
         ]
 
@@ -339,15 +343,16 @@ def calendar_version_style_is_valid(style: object) -> bool:
 def calendar_version_options(
     primary_style: str,
     now: datetime | None = None
-) -> tuple[str, str]:
+) -> list[str]:
     now = now or datetime.now()
-    primary = calendar_version(primary_style, now)
-    secondary_style = (
-        LONG_CALENDAR_VERSION_STYLE
-        if primary_style == DEFAULT_CALENDAR_VERSION_STYLE
-        else DEFAULT_CALENDAR_VERSION_STYLE
-    )
-    return primary, calendar_version(secondary_style, now)
+    return list(unique(
+        calendar_version(style, now)
+        for style in (
+            primary_style,
+            DEFAULT_CALENDAR_VERSION_STYLE,
+            LONG_CALENDAR_VERSION_STYLE
+        )
+    ))
 
 
 def calendar_version(style: str, now: datetime | None = None) -> str:

--- a/core/commands/tag.py
+++ b/core/commands/tag.py
@@ -47,8 +47,8 @@ GitSavvy: Re-created tag '{0}', in case you want to undo, run:
   $ git tag --force {0} {1}
 """
 VERSION_ZERO = "v0.0.0"
-DEFAULT_CALENDAR_VERSION_STYLE = "{year}.{month}.{day}.{hour}.{minute}.{second}"
-SHORT_CALENDAR_VERSION_STYLE = "{year}.{month}.{day}"
+DEFAULT_CALENDAR_VERSION_STYLE = "{year}.{month}.{day}"
+LONG_CALENDAR_VERSION_STYLE = "{year}.{month}.{day}.{hour}.{minute}"
 CALENDAR_VERSION_FIELDS = {"year", "month", "day", "hour", "minute", "second"}
 
 
@@ -343,9 +343,9 @@ def calendar_version_options(
     now = now or datetime.now()
     primary = calendar_version(primary_style, now)
     secondary_style = (
-        DEFAULT_CALENDAR_VERSION_STYLE
-        if primary_style == SHORT_CALENDAR_VERSION_STYLE
-        else SHORT_CALENDAR_VERSION_STYLE
+        LONG_CALENDAR_VERSION_STYLE
+        if primary_style == DEFAULT_CALENDAR_VERSION_STYLE
+        else DEFAULT_CALENDAR_VERSION_STYLE
     )
     return primary, calendar_version(secondary_style, now)
 

--- a/core/commands/tag.py
+++ b/core/commands/tag.py
@@ -240,6 +240,7 @@ class gs_smart_tag(GsWindowCommand):
     Displays a panel of possible smart tag options, based on the choice,
     tag the current commit with the corresponding tagname.
     """
+    last_selected_items: dict[str, int] = {}
 
     def run(self, version_style: str | None = None) -> None:
         if not version_style:
@@ -250,7 +251,33 @@ class gs_smart_tag(GsWindowCommand):
             if version_style == "calendar" else
             self.semver_actions()
         )
-        show_actions_panel(self.window, actions)
+        show_actions_panel(
+            self.window,
+            self.with_selection_storage(version_style, actions),
+            select=self.last_selected_item(version_style, actions)
+        )
+
+    def with_selection_storage(
+        self,
+        version_style: str,
+        actions: list[ActionType]
+    ) -> list[ActionType]:
+        return [
+            (description, partial(self.run_and_remember, version_style, idx, action))
+            for idx, (description, action) in enumerate(actions)
+        ]
+
+    def last_selected_item(self, version_style: str, actions: list[ActionType]) -> int:
+        return min(self.last_selected_items.get(version_style, -1), len(actions) - 1)
+
+    def run_and_remember(
+        self,
+        version_style: str,
+        idx: int,
+        action: Callable[[], None]
+    ) -> None:
+        self.last_selected_items[version_style] = idx
+        action()
 
     def calendar_actions(self) -> list[ActionType]:
         style = self.get_calendar_version_style()

--- a/core/git_mixins/remotes.py
+++ b/core/git_mixins/remotes.py
@@ -6,7 +6,7 @@ from GitSavvy.core.caches import cache_in_store_as
 from GitSavvy.core.utils import yes_no_switch
 
 
-from typing import Dict, TYPE_CHECKING
+from typing import Dict, Sequence, TYPE_CHECKING
 name = str
 url = str
 
@@ -101,6 +101,33 @@ class RemotesMixin(mixin_base):
             remote,
             branch if not remote_branch else "{}:{}".format(branch, remote_branch)
         )
+
+    def guess_remote_to_push_to(self, available_remotes: Sequence[str]) -> str:
+        if len(available_remotes) == 0:
+            raise RuntimeError("")
+        if len(available_remotes) == 1:
+            return next(iter(available_remotes))
+
+        last_remote_used = self.current_state().get("last_remote_used_for_push")
+        if last_remote_used in available_remotes:
+            return last_remote_used  # type: ignore[return-value]
+
+        defaults = dict(
+            (key[:-12], val)  # strip trailing ".pushdefault" from key
+            for key, val in (
+                line.split()
+                for line in self.git(
+                    "config",
+                    "--get-regexp",
+                    r".*\.pushdefault",
+                    throw_on_error=False
+                ).splitlines()
+            )
+        )  # type: Dict[str, str]
+        for key in (defaults.get("gitsavvy"), defaults.get("remote"), "fork", "origin"):
+            if key in available_remotes:
+                return key  # type: ignore[return-value]
+        return next(iter(available_remotes))
 
     def username_from_url(self, input_url):
         # URLs can come in one of following formats format

--- a/core/git_mixins/tags.py
+++ b/core/git_mixins/tags.py
@@ -29,7 +29,6 @@ class TagList(NamedTuple):
         return chain(self.regular, self.versions)
 
 
-SEMVER_TEST = re.compile(r'\d+\.\d+\.?\d*')
 SEMVER_TAG_RE = re.compile(
     r"^v?"
     r"\d+\.\d+\.\d+"
@@ -134,14 +133,14 @@ class TagsMixin(mixin_base):
         if semver_entries:
             return TagList(
                 [entry for entry in entries if entry not in semver_entries],
-                sort_version_tags(semver_entries),
+                sort_semver_tags(semver_entries),
                 "semver"
             )
 
         calendar_entries = [entry for entry in entries if is_calendar_version_tag(entry.tag)]
         return TagList(
             [entry for entry in entries if entry not in calendar_entries],
-            sort_version_tags(calendar_entries),
+            sort_calendar_version_tags(calendar_entries),
             "calendar"
         )
 
@@ -155,33 +154,38 @@ def is_calendar_version_tag(tag: str) -> bool:
     return bool(CALENDAR_VERSION_TAG_RE.match(tag))
 
 
-def sort_version_tags(entries: List[TagDetails]) -> List[TagDetails]:
-    if not entries:
-        return entries
-
-    try:
-        return sorted(
-            entries,
-            key=lambda entry: parse_version(entry.tag),
-            reverse=True
-        )
-    except Exception:
-        # The error might be caused by having tags like 1.2.3.1 and 1.2.3.beta.
-        # Exception thrown is "can't convert str to int" as it is comparing
-        # 'beta' with 1.
-        # Fallback and take only the numbers as sorting key.
-        return sorted(
-            entries,
-            key=lambda entry: parse_version(
-                SEMVER_TEST.search(entry.tag).group()  # type: ignore[union-attr]
-            ),
-            reverse=True
-        )
+def sort_semver_tags(entries: List[TagDetails]) -> List[TagDetails]:
+    return sorted(
+        entries,
+        key=lambda entry: semver_sort_key(entry.tag),
+        reverse=True
+    )
 
 
-def parse_version(version_str: str) -> tuple[str | int, ...]:
+def sort_calendar_version_tags(entries: List[TagDetails]) -> List[TagDetails]:
+    return sorted(
+        entries,
+        key=lambda entry: natural_version_key(entry.tag),
+        reverse=True
+    )
+
+
+def semver_sort_key(version_str: str) -> tuple[tuple[int, object], ...]:
+    base, separator, prerelease = strip_v_prefix(version_str).partition("-")
+    return (
+        natural_version_key(base)
+        + ((2, 0 if separator else 1),)
+        + natural_version_key(prerelease)
+    )
+
+
+def natural_version_key(version_str: str) -> tuple[tuple[int, object], ...]:
     return tuple(
-        int(part) if part.isdigit() else part
+        (0, int(part)) if part.isdigit() else (1, part)
         for part in re.split(r'[.-]', version_str)
         if part
     )
+
+
+def strip_v_prefix(version_str: str) -> str:
+    return version_str[1:] if version_str.startswith("v") else version_str

--- a/core/git_mixins/tags.py
+++ b/core/git_mixins/tags.py
@@ -6,7 +6,10 @@ from GitSavvy.core.git_command import mixin_base
 from GitSavvy.core.caches import cache_in_store_as
 from GitSavvy.core.types import FullHash
 
-from typing import Iterable, List, NamedTuple, Optional, Set
+from typing import Iterable, List, Literal, NamedTuple, Optional, Set
+
+
+VersionStyle = Literal["calendar", "semver"]
 
 
 class TagDetails(NamedTuple):
@@ -19,13 +22,32 @@ class TagDetails(NamedTuple):
 class TagList(NamedTuple):
     regular: List[TagDetails]
     versions: List[TagDetails]
+    version_style: VersionStyle = "semver"
 
     @property
     def all(self):
-        return chain(*self)
+        return chain(self.regular, self.versions)
 
 
 SEMVER_TEST = re.compile(r'\d+\.\d+\.?\d*')
+SEMVER_TAG_RE = re.compile(
+    r"^v?"
+    r"\d+\.\d+\.\d+"
+    r"(?:-[0-9A-Za-z-.]+)?"
+    r"$"
+)
+CALENDAR_VERSION_TAG_RE = re.compile(
+    r"^v?"
+    r"(?:19\d{2}|20\d{2})"
+    r"\.(?:0?[1-9]|1[0-2])"
+    r"\.(?:0?[1-9]|[12]\d|3[01])"
+    r"(?:\.(?:[01]?\d|2[0-3])"
+    r"(?:\.(?:[0-5]?\d)"
+    r"(?:\.(?:[0-5]?\d))?"
+    r")?"
+    r")?"
+    r"$"
+)
 REMOTE_TAGOPT_RE = re.compile(r"^remote\.(?P<branch_name>.+?)\.tagopt (?P<options>.+)$")
 
 
@@ -64,9 +86,11 @@ class TagsMixin(mixin_base):
         )
         porcelain_entries = stdout.splitlines()
         entries = (
-            TagDetails(entry[:40], entry[51:], "", "")
+            TagDetails(entry[:40], tag_name, "", "")
             for entry in reversed(porcelain_entries)
             if entry
+            if (tag_name := entry[51:])
+            if not tag_name.endswith("^{}")
         )
         return self.handle_semver_tags(entries)
 
@@ -90,47 +114,69 @@ class TagsMixin(mixin_base):
         """
         Return the last tag of the current branch. get_tags() fails to return an ordered list.
         """
-        _, tags = self.get_local_tags()
+        tag_list = self.get_local_tags()
+        if tag_list.version_style != "semver":
+            return None
+
+        tags = tag_list.versions
         return tags[0].tag if tags else None
 
     def handle_semver_tags(self, entries):
         # type: (Iterable[TagDetails]) -> TagList
         """
-        Split list into semantic versions and "other" tags.
-        Also sort the semantic versions.
-        """
-        semver_entries, regular_entries = [], []
-        for entry in entries:
-            if SEMVER_TEST.search(entry.tag):
-                semver_entries.append(entry)
-            else:
-                regular_entries.append(entry)
-        if len(semver_entries):
-            try:
-                semver_entries = sorted(
-                    semver_entries,
-                    key=lambda entry: parse_version(remove_suffix("^{}", entry.tag)),
-                    reverse=True
-                )
-            except Exception:
-                # The error might me caused of having tags like 1.2.3.1 and 1.2.3.beta.
-                # Exception thrown is "can't convert str to int" as it is comparing
-                # 'beta' with 1.
-                # Fallback and take only the numbers as sorting key.
-                semver_entries = sorted(
-                    semver_entries,
-                    key=lambda entry: parse_version(
-                        SEMVER_TEST.search(entry.tag).group()  # type: ignore[union-attr]
-                    ),
-                    reverse=True
-                )
+        Split list into version and "other" tags, and sort versions.
 
-        return TagList(regular_entries, semver_entries)
+        Prefer semantic versions if any are present.  Otherwise, treat calendar
+        versions as the repository's version style.
+        """
+        entries = list(entries)
+        semver_entries = [entry for entry in entries if is_semver_tag(entry.tag)]
+        if semver_entries:
+            return TagList(
+                [entry for entry in entries if entry not in semver_entries],
+                sort_version_tags(semver_entries),
+                "semver"
+            )
+
+        calendar_entries = [entry for entry in entries if is_calendar_version_tag(entry.tag)]
+        return TagList(
+            [entry for entry in entries if entry not in calendar_entries],
+            sort_version_tags(calendar_entries),
+            "calendar"
+        )
 
 
 def is_semver_tag(tag):
     # type: (str) -> bool
-    return bool(SEMVER_TEST.search(tag))
+    return bool(SEMVER_TAG_RE.match(tag)) and not is_calendar_version_tag(tag)
+
+
+def is_calendar_version_tag(tag: str) -> bool:
+    return bool(CALENDAR_VERSION_TAG_RE.match(tag))
+
+
+def sort_version_tags(entries: List[TagDetails]) -> List[TagDetails]:
+    if not entries:
+        return entries
+
+    try:
+        return sorted(
+            entries,
+            key=lambda entry: parse_version(entry.tag),
+            reverse=True
+        )
+    except Exception:
+        # The error might be caused by having tags like 1.2.3.1 and 1.2.3.beta.
+        # Exception thrown is "can't convert str to int" as it is comparing
+        # 'beta' with 1.
+        # Fallback and take only the numbers as sorting key.
+        return sorted(
+            entries,
+            key=lambda entry: parse_version(
+                SEMVER_TEST.search(entry.tag).group()  # type: ignore[union-attr]
+            ),
+            reverse=True
+        )
 
 
 def parse_version(version_str: str) -> tuple[str | int, ...]:
@@ -139,7 +185,3 @@ def parse_version(version_str: str) -> tuple[str | int, ...]:
         for part in re.split(r'[.-]', version_str)
         if part
     )
-
-
-def remove_suffix(suffix: str, s: str) -> str:
-    return s[:-len(suffix)] if suffix and s.endswith(suffix) else s

--- a/core/git_mixins/tags.py
+++ b/core/git_mixins/tags.py
@@ -145,6 +145,10 @@ class TagsMixin(mixin_base):
         )
 
 
+def is_version_tag(tag: str) -> bool:
+    return bool(SEMVER_TAG_RE.match(tag) or CALENDAR_VERSION_TAG_RE.match(tag))
+
+
 def is_semver_tag(tag):
     # type: (str) -> bool
     return bool(SEMVER_TAG_RE.match(tag)) and not is_calendar_version_tag(tag)

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -279,17 +279,15 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
                     "   {}{} {}".format(
                         maybe_mark(tag) if is_short_version_tag(tag.tag) else " ",
                         self.to_short_hash(tag.sha),
-                        tag.tag,
+                        tag_with_date(tag, is_short_version_tag(tag.tag)),
                     )
                     for tag in local_tags.regular[:max_items]
                 ),
                 "\n".join(
-                    "   {}{} {:<10} {}{}".format(
+                    "   {}{} {}".format(
                         maybe_mark(tag),
                         self.to_short_hash(tag.sha),
-                        tag.tag,
-                        tag.human_date,
-                        " ({})".format(tag.relative_date) if tag.relative_date != tag.human_date else ""
+                        tag_with_date(tag, True)
                     )
                     for tag in local_tags.versions[:max_items]
                 )
@@ -594,6 +592,17 @@ TAG_ALREADY_EXISTS_ON_REMOTE_RE = re.compile(
     r"^\s*!\s+\[rejected\]\s+(?P<tag>\S+)\s+->\s+\S+\s+\(already exists\)$",
     re.MULTILINE
 )
+
+
+def tag_with_date(tag: TagDetails, show_date: bool) -> str:
+    if not show_date or not tag.human_date:
+        return tag.tag
+
+    return "{:<10} {}{}".format(
+        tag.tag,
+        tag.human_date,
+        " ({})".format(tag.relative_date) if tag.relative_date != tag.human_date else ""
+    )
 
 
 def is_short_version_tag(tag: str) -> bool:

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -263,9 +263,9 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
 
             def maybe_mark(tag):
                 if tag.tag not in remote_tag_names:
-                    return "*"  # denote new semver
+                    return "*"  # denote new version tag
                 if (tag.sha, tag.tag) not in remote_tags:
-                    return "!"  # denote known semver on a different hash
+                    return "!"  # denote known version tag on a different hash
                 return " "
 
         else:
@@ -338,7 +338,7 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
                 tags_list = [
                     tag
                     for tag in remote_info["tags"]
-                    if tag.tag[-3:] != "^{}" and (tag.sha, tag.tag) not in seen
+                    if (tag.sha, tag.tag) not in seen
                 ]
                 msg = "\n".join(
                     "    {} {}".format(self.to_short_hash(tag.sha), tag.tag)

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -85,6 +85,7 @@ LOADING_TAGS_MESSAGE = "    Loading tags from remote..."
 START_PUSH_MESSAGE = "Pushing tag..."
 END_PUSH_MESSAGE = "Push complete."
 TAG_DELETE_MESSAGE = "Tag(s) deleted."
+SHORT_VERSION_TAG_RE = re.compile(r"^v\d+(?:\.\d+)?$")
 
 
 class gs_show_tags(WindowCommand, GitCommand):
@@ -275,7 +276,8 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
                                                 # the syntax expects the remote section begins
             filter_((
                 "\n".join(
-                    "    {} {}".format(
+                    "   {}{} {}".format(
+                        maybe_mark(tag) if is_short_version_tag(tag.tag) else " ",
                         self.to_short_hash(tag.sha),
                         tag.tag,
                     )
@@ -592,6 +594,10 @@ TAG_ALREADY_EXISTS_ON_REMOTE_RE = re.compile(
     r"^\s*!\s+\[rejected\]\s+(?P<tag>\S+)\s+->\s+\S+\s+\(already exists\)$",
     re.MULTILINE
 )
+
+
+def is_short_version_tag(tag: str) -> bool:
+    return bool(SHORT_VERSION_TAG_RE.match(tag))
 
 
 def tags_that_already_exist_on_remote(stderr: str, tags: List[str]) -> List[str]:

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -18,7 +18,7 @@ from GitSavvy.core.fns import filter_
 from GitSavvy.core.runtime import enqueue_on_worker, on_worker, run_on_new_thread
 from GitSavvy.core.types import ShortHash
 from GitSavvy.core.utils import flash, uprint
-from GitSavvy.core.ui_mixins.quick_panel import show_remote_panel
+from GitSavvy.core.ui_mixins.quick_panel import NO_REMOTES_MESSAGE
 from ..ui__quick_panel import noop, show_actions_panel
 from GitSavvy.github import github
 from GitSavvy.github.git_mixins import GithubRemotesMixin
@@ -500,16 +500,63 @@ class gs_tags_push(TagsInterfaceCommand):
             if name in actual_remotes_to_fetch
         }
         tags_to_push = self.selected_local_tags()
-        kont = partial(self.push_selected, tags_to_push=tags_to_push)
-        show_remote_panel(kont, remotes=remote_candidates, allow_direct=True)
+
+        if not remote_candidates:
+            show_actions_panel(self.window, [noop(NO_REMOTES_MESSAGE)])
+            return
+
+        if len(remote_candidates) == 1:
+            self.push_selected(next(iter(remote_candidates)), tags_to_push)
+            return
+
+        remote = self.guess_remote_to_push_to(list(remote_candidates))
+        show_actions_panel(self.window, [
+            (
+                "Push to '{}'".format(remote),
+                partial(self.push_selected, remote, tags_to_push)
+            ),
+            (
+                "Choose where to push to...",
+                partial(self.ask_which_remote_to_push_to, remote_candidates, remote, tags_to_push)
+            )
+        ])
+
+    def ask_which_remote_to_push_to(
+        self,
+        remote_candidates: Dict[str, str],
+        selected_remote: str,
+        tags_to_push: List[str]
+    ) -> None:
+        available_remotes = list(remote_candidates)
+        show_actions_panel(
+            self.window,
+            [
+                (
+                    remote,
+                    partial(
+                        self.push_selected,
+                        remote,
+                        tags_to_push,
+                        remember_used_remote=True
+                    )
+                )
+                for remote in available_remotes
+            ],
+            select=available_remotes.index(selected_remote)
+        )
 
     @on_worker
     def push_selected(
         self,
         remote: str,
         tags_to_push: List[str],
-        force: bool = False
+        force: bool = False,
+        remember_used_remote: bool = False
     ) -> None:
+        if remember_used_remote:
+            run_on_new_thread(self.git, "config", "--local", "gitsavvy.pushdefault", remote)
+            self.update_store({"last_remote_used_for_push": remote})
+
         flash(self.view, START_PUSH_MESSAGE)
         try:
             self.git_throwing_silently(

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -29,6 +29,7 @@ __all__ = (
     "gs_tags_toggle_remotes",
     "gs_tags_refresh",
     "gs_tags_delete",
+    "gs_tags_smart_tag",
     "gs_tags_push",
     "gs_tags_show_commit",
     "gs_tags_open_on_github",
@@ -426,6 +427,18 @@ class gs_tags_refresh(TagsInterfaceCommand):
             interface.state["remote_tags_info"] = {}
 
         util.view.refresh_gitsavvy(self.view)
+
+
+class gs_tags_smart_tag(TagsInterfaceCommand):
+    """
+    Open the smart tag panel using the dashboard's known tag style.
+    """
+
+    def run(self, edit) -> None:
+        local_tags = self.interface.state.get("local_tags")
+        self.window.run_command("gs_smart_tag", {
+            "version_style": local_tags.version_style if local_tags else "semver"
+        })
 
 
 DELETE_UNDO_MESSAGE = """\

--- a/tests/test_smart_tag.py
+++ b/tests/test_smart_tag.py
@@ -21,12 +21,16 @@ class TestSmartTag(unittest.TestCase):
     def test_calendar_version_options(self):
         now = datetime(2026, 5, 29, 12, 34, 56)
         self.assertEqual(
+            calendar_version_options("{year}.{month}", now),
+            ["2026.05", "2026.05.29", "2026.05.29.12.34"]
+        )
+        self.assertEqual(
             calendar_version_options("{year}.{month}.{day}", now),
-            ("2026.05.29", "2026.05.29.12.34")
+            ["2026.05.29", "2026.05.29.12.34"]
         )
         self.assertEqual(
             calendar_version_options("{year}.{month}.{day}.{hour}.{minute}", now),
-            ("2026.05.29.12.34", "2026.05.29")
+            ["2026.05.29.12.34", "2026.05.29"]
         )
 
     def test_calendar_version_style_is_valid_rejects_invalid_settings(self):

--- a/tests/test_smart_tag.py
+++ b/tests/test_smart_tag.py
@@ -1,9 +1,40 @@
-from GitSavvy.core.commands.tag import default_tag_message, smart_incremented_tag
-
+from datetime import datetime
 import unittest
+
+from GitSavvy.core.commands.tag import (
+    calendar_version,
+    calendar_version_options,
+    calendar_version_style_is_valid,
+    default_tag_message,
+    smart_incremented_tag,
+)
 
 
 class TestSmartTag(unittest.TestCase):
+    def test_calendar_version(self):
+        now = datetime(2026, 5, 29, 12, 34, 56)
+        self.assertEqual(
+            calendar_version("{year}.{month}.{day}.{hour}.{minute}.{second}", now),
+            "2026.05.29.12.34.56"
+        )
+
+    def test_calendar_version_options(self):
+        now = datetime(2026, 5, 29, 12, 34, 56)
+        self.assertEqual(
+            calendar_version_options("{year}.{month}.{day}.{hour}.{minute}.{second}", now),
+            ("2026.05.29.12.34.56", "2026.05.29")
+        )
+        self.assertEqual(
+            calendar_version_options("{year}.{month}.{day}", now),
+            ("2026.05.29", "2026.05.29.12.34.56")
+        )
+
+    def test_calendar_version_style_is_valid_rejects_invalid_settings(self):
+        invalid_settings = [None, "", "{year}.{unknown}", "{year.foo}", "{"]
+        for setting in invalid_settings:
+            with self.subTest(setting=setting):
+                self.assertFalse(calendar_version_style_is_valid(setting))
+
     def test_default_tag_message(self):
         self.assertEqual(default_tag_message('v{tag_name}', '2.1.0'), 'v2.1.0')
         self.assertEqual(default_tag_message('v{tag_name}', 'v2.1.0'), 'v2.1.0')

--- a/tests/test_smart_tag.py
+++ b/tests/test_smart_tag.py
@@ -21,12 +21,12 @@ class TestSmartTag(unittest.TestCase):
     def test_calendar_version_options(self):
         now = datetime(2026, 5, 29, 12, 34, 56)
         self.assertEqual(
-            calendar_version_options("{year}.{month}.{day}.{hour}.{minute}.{second}", now),
-            ("2026.05.29.12.34.56", "2026.05.29")
+            calendar_version_options("{year}.{month}.{day}", now),
+            ("2026.05.29", "2026.05.29.12.34")
         )
         self.assertEqual(
-            calendar_version_options("{year}.{month}.{day}", now),
-            ("2026.05.29", "2026.05.29.12.34.56")
+            calendar_version_options("{year}.{month}.{day}.{hour}.{minute}", now),
+            ("2026.05.29.12.34", "2026.05.29")
         )
 
     def test_calendar_version_style_is_valid_rejects_invalid_settings(self):

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,6 +1,6 @@
 import unittest
 
-from GitSavvy.core.git_mixins.tags import TagDetails, TagsMixin, is_semver_tag
+from GitSavvy.core.git_mixins.tags import TagDetails, TagsMixin, is_semver_tag, is_version_tag
 from GitSavvy.core.interfaces.tags import (
     is_short_version_tag,
     remote_tag_conflict_message,
@@ -24,6 +24,13 @@ class TestTags(unittest.TestCase):
         self.assertFalse(is_semver_tag("release-1.2.3"))
         self.assertFalse(is_semver_tag("2026.05.29"))
         self.assertFalse(is_semver_tag("v2026.05.29"))
+
+    def test_is_version_tag(self):
+        self.assertTrue(is_version_tag("v1.2.3"))
+        self.assertTrue(is_version_tag("2026.05.29"))
+        self.assertTrue(is_version_tag("2026.05.29.12.34.56"))
+        self.assertFalse(is_version_tag("v1"))
+        self.assertFalse(is_version_tag("private"))
 
     def test_get_remote_tags_skips_peeled_annotated_tags(self):
         tag_list = RemoteTagsRepo("""\

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,8 +1,10 @@
 import unittest
 
+from GitSavvy.core.git_mixins.tags import TagDetails
 from GitSavvy.core.interfaces.tags import (
     is_short_version_tag,
     remote_tag_conflict_message,
+    tag_with_date,
     tags_that_already_exist_on_remote,
 )
 
@@ -14,6 +16,11 @@ class TestTags(unittest.TestCase):
         self.assertFalse(is_short_version_tag("1"))
         self.assertFalse(is_short_version_tag("v1.2.3"))
         self.assertFalse(is_short_version_tag("version-1"))
+
+    def test_tag_with_date(self):
+        tag = TagDetails("abc", "v1", "25 May 2026", "4 minutes ago")
+        self.assertEqual(tag_with_date(tag, True), "v1         25 May 2026 (4 minutes ago)")
+        self.assertEqual(tag_with_date(tag, False), "v1")
 
     def test_remote_tag_conflict_message(self):
         self.assertEqual(

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,6 +1,6 @@
 import unittest
 
-from GitSavvy.core.git_mixins.tags import TagDetails
+from GitSavvy.core.git_mixins.tags import TagDetails, TagsMixin, is_semver_tag
 from GitSavvy.core.interfaces.tags import (
     is_short_version_tag,
     remote_tag_conflict_message,
@@ -9,7 +9,57 @@ from GitSavvy.core.interfaces.tags import (
 )
 
 
+class RemoteTagsRepo(TagsMixin):
+    def __init__(self, stdout):
+        self.stdout = stdout
+
+    def git_throwing_silently(self, *args, **kwargs):
+        return self.stdout
+
+
 class TestTags(unittest.TestCase):
+    def test_is_semver_tag(self):
+        self.assertTrue(is_semver_tag("1.2.3"))
+        self.assertTrue(is_semver_tag("v1.2.3"))
+        self.assertFalse(is_semver_tag("release-1.2.3"))
+        self.assertFalse(is_semver_tag("2026.05.29"))
+        self.assertFalse(is_semver_tag("v2026.05.29"))
+
+    def test_get_remote_tags_skips_peeled_annotated_tags(self):
+        tag_list = RemoteTagsRepo("""\
+1111111111111111111111111111111111111111\trefs/tags/v1.2.3
+2222222222222222222222222222222222222222\trefs/tags/v1.2.3^{}
+3333333333333333333333333333333333333333\trefs/tags/v1.2.4
+""").get_remote_tags("origin")
+        self.assertEqual([tag.tag for tag in tag_list.versions], ["v1.2.4", "v1.2.3"])
+
+    def test_handle_tags_prefers_semver(self):
+        tag_list = TagsMixin().handle_semver_tags([
+            TagDetails("abc", "2026.05.29", "", ""),
+            TagDetails("def", "v1.2.3", "", ""),
+            TagDetails("ghi", "private", "", "")
+        ])
+        self.assertEqual(tag_list.version_style, "semver")
+        self.assertEqual([tag.tag for tag in tag_list.versions], ["v1.2.3"])
+        self.assertEqual([tag.tag for tag in tag_list.regular], ["2026.05.29", "private"])
+        self.assertEqual(
+            [tag.tag for tag in tag_list.all],
+            ["2026.05.29", "private", "v1.2.3"]
+        )
+
+    def test_handle_tags_detects_calendar_versions(self):
+        tag_list = TagsMixin().handle_semver_tags([
+            TagDetails("abc", "2026.05.29", "", ""),
+            TagDetails("def", "2026.05.29.12.34", "", ""),
+            TagDetails("ghi", "private", "", "")
+        ])
+        self.assertEqual(tag_list.version_style, "calendar")
+        self.assertEqual(
+            [tag.tag for tag in tag_list.versions],
+            ["2026.05.29.12.34", "2026.05.29"]
+        )
+        self.assertEqual([tag.tag for tag in tag_list.regular], ["private"])
+
     def test_is_short_version_tag(self):
         self.assertTrue(is_short_version_tag("v1"))
         self.assertTrue(is_short_version_tag("v1.2"))

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,9 +1,20 @@
 import unittest
 
-from GitSavvy.core.interfaces.tags import remote_tag_conflict_message, tags_that_already_exist_on_remote
+from GitSavvy.core.interfaces.tags import (
+    is_short_version_tag,
+    remote_tag_conflict_message,
+    tags_that_already_exist_on_remote,
+)
 
 
 class TestTags(unittest.TestCase):
+    def test_is_short_version_tag(self):
+        self.assertTrue(is_short_version_tag("v1"))
+        self.assertTrue(is_short_version_tag("v1.2"))
+        self.assertFalse(is_short_version_tag("1"))
+        self.assertFalse(is_short_version_tag("v1.2.3"))
+        self.assertFalse(is_short_version_tag("version-1"))
+
     def test_remote_tag_conflict_message(self):
         self.assertEqual(
             remote_tag_conflict_message(["a", "b", "c"]),

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -47,6 +47,17 @@ class TestTags(unittest.TestCase):
             ["2026.05.29", "private", "v1.2.3"]
         )
 
+    def test_handle_tags_sorts_semver_naturally(self):
+        tag_list = TagsMixin().handle_semver_tags([
+            TagDetails("abc", "v2.0.0", "", ""),
+            TagDetails("def", "v10.0.0", "", ""),
+            TagDetails("ghi", "v10.0.0-rc.1", "", "")
+        ])
+        self.assertEqual(
+            [tag.tag for tag in tag_list.versions],
+            ["v10.0.0", "v10.0.0-rc.1", "v2.0.0"]
+        )
+
     def test_handle_tags_detects_calendar_versions(self):
         tag_list = TagsMixin().handle_semver_tags([
             TagDetails("abc", "2026.05.29", "", ""),


### PR DESCRIPTION
- Support calendar versions and short versions (like just `v1`).
- Honor pushDefault for tags as well. Fixes #2012