### PR TITLE
Abort commands from output panel

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1,5 +1,18 @@
 [
 
+    //////////////////
+    // OUTPUT PANEL //
+    //////////////////
+
+    {
+        "keys": ["ctrl+z"],
+        "command": "gs_abort_output_panel",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.output_panel", "operator": "equal", "operand": true }
+        ]
+    },
+
     //////////////////////
     // INLINE DIFF VIEW //
     //////////////////////

--- a/common/util/log.py
+++ b/common/util/log.py
@@ -1,63 +1,60 @@
 import re
+import subprocess
 import sublime
 
 from GitSavvy.core.view import replace_view_content
 
-from typing import Optional
+from typing import Dict, List, Optional
 
 
 PANEL_NAME = "GitSavvy"
+ABORT_HINT = "\n[ctrl+z to abort]"
 ANSI_ESCAPE_RE = re.compile(r'\x1B\[[0-?]*[ -/]*[@-~]')
+RUNNING_PROCESSES: Dict[int, List[subprocess.Popen]] = {}
 
 
-def normalize(string):
-    # type: (str) -> str
+def normalize(string: str) -> str:
     return ANSI_ESCAPE_RE.sub('', string.replace('\r\n', '\n').replace('\r', '\n'))
 
 
-def init_panel(window):
-    # type: (sublime.Window) -> sublime.View
+def init_panel(window: sublime.Window) -> sublime.View:
     panel_view = create_panel(window)
     show_panel(window)
     return panel_view
 
 
-def display_panel(window, message):
-    # type: (sublime.Window, str) -> sublime.View
+def display_panel(window: sublime.Window, message: str) -> sublime.View:
     panel_view = init_panel(window)
     append_to_panel(panel_view, message)
     panel_view.show(0)
     return panel_view
 
 
-def ensure_panel(window):
-    # type: (sublime.Window) -> sublime.View
+def ensure_panel(window: sublime.Window) -> sublime.View:
     return get_panel(window) or create_panel(window)
 
 
-def get_panel(window):
-    # type: (sublime.Window) -> Optional[sublime.View]
+def get_panel(window: sublime.Window) -> Optional[sublime.View]:
     return window.find_output_panel(PANEL_NAME)
 
 
-def create_panel(window):
-    # type: (sublime.Window) -> sublime.View
+def create_panel(window: sublime.Window) -> sublime.View:
     panel_view = window.create_output_panel(PANEL_NAME)
     panel_view.set_syntax_file("Packages/GitSavvy/syntax/output_panel.sublime-syntax")
+    panel_view.settings().set("git_savvy.output_panel", True)
     return panel_view
 
 
-def show_panel(window):
-    # type: (sublime.Window) -> None
+def show_panel(window: sublime.Window) -> None:
     window.run_command("show_panel", {"panel": "output.{}".format(PANEL_NAME)})
 
 
-def append_to_panel(panel, message):
-    # type: (sublime.View, str) -> None
+def append_to_panel(panel: sublime.View, message: str) -> None:
     # We support standard progress bars with "\r" line endings!
     # If we see such a line ending, we remember where we started
     # our write as `virtual_cursor` as this is where the next
     # write must begin.
+    _erase_abort_hint(panel)
     has_trailing_carriage_return = message.endswith("\r")
     message = normalize(message)
 
@@ -67,5 +64,64 @@ def append_to_panel(panel, message):
     replace_view_content(panel, message, region=region)
     panel.settings().set("virtual_cursor", cursor if has_trailing_carriage_return else None)
 
+    _ensure_abort_hint(panel)
     eof_after_append = panel.size()
     panel.show(eof_after_append)
+
+
+def start_abortable_command(panel: sublime.View, proc: subprocess.Popen) -> None:
+    processes = RUNNING_PROCESSES.setdefault(panel.buffer_id(), [])
+    processes.append(proc)
+    _ensure_abort_hint(panel)
+
+
+def finish_abortable_command(panel: sublime.View, proc: Optional[subprocess.Popen]) -> None:
+    if proc is None:
+        return
+
+    processes = RUNNING_PROCESSES.get(panel.buffer_id()) or []
+    try:
+        processes.remove(proc)
+    except ValueError:
+        pass
+    if not processes:
+        RUNNING_PROCESSES.pop(panel.buffer_id(), None)
+
+
+def append_done_message(panel: sublime.View, elapsed: float, status: str = "Done") -> None:
+    _erase_abort_hint(panel)
+    append_to_panel(panel, "\n[{} in {:.2f}s]".format(status, elapsed))
+
+
+def running_process_for_panel(panel: sublime.View) -> Optional[subprocess.Popen]:
+    processes = RUNNING_PROCESSES.get(panel.buffer_id()) or []
+    for proc in reversed(processes):
+        if proc.poll() is None:
+            return proc
+    return None
+
+
+def panel_can_abort(panel: sublime.View) -> bool:
+    return running_process_for_panel(panel) is not None
+
+
+def _ensure_abort_hint(panel: sublime.View) -> None:
+    if not panel_can_abort(panel) or _abort_hint_region(panel):
+        return
+
+    eof = panel.size()
+    replace_view_content(panel, ABORT_HINT, region=sublime.Region(eof, eof))
+
+
+def _erase_abort_hint(panel: sublime.View) -> None:
+    region = _abort_hint_region(panel)
+    if region is not None:
+        replace_view_content(panel, "", region=region)
+
+
+def _abort_hint_region(panel: sublime.View) -> Optional[sublime.Region]:
+    eof = panel.size()
+    start = eof - len(ABORT_HINT)
+    if start >= 0 and panel.substr(sublime.Region(start, eof)) == ABORT_HINT:
+        return sublime.Region(start, eof)
+    return None

--- a/core/commands/__init__.py
+++ b/core/commands/__init__.py
@@ -30,6 +30,7 @@ from .multi_selector import *
 from .mv import *
 from .navigate import *
 from .next_hunk import *
+from .output_panel import *
 from .pull import *
 from .push import *
 from .quick_commit import *

--- a/core/commands/output_panel.py
+++ b/core/commands/output_panel.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import sublime_plugin
+
+from GitSavvy.common import util
+from GitSavvy.core.utils import abort_proc, flash
+
+
+__all__ = (
+    "gs_abort_output_panel",
+)
+
+
+class gs_abort_output_panel(sublime_plugin.TextCommand):
+    def run(self, edit) -> None:
+        proc = util.log.running_process_for_panel(self.view)
+        if not proc:
+            flash(self.view, "No process is currently running")
+            return
+
+        abort_proc(proc)
+        flash(self.view, "Aborting git command…")

--- a/core/exceptions.py
+++ b/core/exceptions.py
@@ -24,6 +24,10 @@ class GitSavvyError(Exception):
         util.log.display_panel(self.window or sublime.active_window(), self.message)
 
 
+class AbortedGitCall(GitSavvyError):
+    pass
+
+
 class FailedGithubRequest(GitSavvyError):
     pass
 

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -22,7 +22,10 @@ import sublime
 
 from ..common import util
 from .settings import SettingsMixin
-from .utils import try_kill_proc, paths_upwards, proc_has_been_killed, resolve_path, STARTUPINFO
+from .utils import (
+    try_kill_proc, paths_upwards, proc_has_been_aborted_by_user,
+    proc_has_been_killed, resolve_path, STARTUPINFO
+)
 from GitSavvy.core import store
 from GitSavvy.core.fns import consume, filter_, pairwise
 from GitSavvy.core.runtime import auto_timeout, enqueue_on_worker, run_as_future
@@ -30,7 +33,7 @@ from GitSavvy.core.types import FullPath, ShortPath
 
 
 from typing import (
-    Callable, Deque, Dict, IO, Iterable, Iterator, List, Optional, Sequence,
+    Any, Callable, Deque, Dict, IO, Iterable, Iterator, List, Optional, Sequence,
     Tuple, TypeVar, Union)
 T = TypeVar("T")
 
@@ -366,6 +369,7 @@ class _GitCommand(SettingsMixin):
                 raise GitSavvyError(str(e), show_panel=show_panel_on_error, window=window)
 
         stdout, stderr = None, None
+        p = None
         vars_for_replace = ChainMap(
             custom_environ or {},
             window.extract_variables(),
@@ -381,6 +385,9 @@ class _GitCommand(SettingsMixin):
             savvy_env_expanded or {},
             os.environ
         )
+        popen_kwargs: Dict[str, Any] = {"startupinfo": STARTUPINFO}
+        if os.name != "nt":
+            popen_kwargs["start_new_session"] = True
         start = time.time()
         try:
             p = subprocess.Popen(
@@ -390,11 +397,14 @@ class _GitCommand(SettingsMixin):
                 stderr=subprocess.PIPE,
                 cwd=working_dir,
                 env=environ,
-                startupinfo=STARTUPINFO
+                **popen_kwargs
             )
 
             if just_the_proc:
                 return p
+
+            if log:
+                util.log.start_abortable_command(panel, p)
 
             if isinstance(stdin, str):
                 stdin = stdin.encode(encoding=stdin_encoding)
@@ -433,7 +443,13 @@ class _GitCommand(SettingsMixin):
                 end = time.time()
                 util.debug.log_git(final_args, working_dir, stdin, stdout, stderr, end - start)
                 if log:
-                    log("\n[Done in {:.2f}s]".format(end - start))
+                    aborted = proc_has_been_aborted_by_user(p) if p else False
+                    util.log.finish_abortable_command(panel, p)
+                    util.log.append_done_message(
+                        panel,
+                        end - start,
+                        "Aborted" if aborted else "Done"
+                    )
 
         if decode:
             try:
@@ -454,6 +470,18 @@ class _GitCommand(SettingsMixin):
                     show_panel=show_panel_on_error,
                     window=window
                 )
+
+        assert p is not None
+        if proc_has_been_aborted_by_user(p):
+            stdout_s, stderr_s = self.ensure_decoded(stdout), self.ensure_decoded(stderr)
+            raise AbortedGitCall(
+                "$ {}\n\nAborted by user.".format(command_str),
+                cmd=command,
+                stdout=stdout_s,
+                stderr=stderr_s,
+                show_panel=False,
+                window=window
+            )
 
         if throw_on_error and not p.returncode == 0:
             stdout_s, stderr_s = self.ensure_decoded(stdout), self.ensure_decoded(stderr)
@@ -852,7 +880,7 @@ from .git_mixins.tags import TagsMixin  # noqa: E402
 from .git_mixins.history import HistoryMixin  # noqa: E402
 from .git_mixins.rewrite import RewriteMixin  # noqa: E402
 from .git_mixins.merge import MergeMixin  # noqa: E402
-from .exceptions import DetachedView, GitSavvyError  # noqa: E402
+from .exceptions import AbortedGitCall, DetachedView, GitSavvyError  # noqa: E402
 
 
 class GitCommand(

--- a/core/utils.py
+++ b/core/utils.py
@@ -218,6 +218,12 @@ def kill_proc(proc: subprocess.Popen) -> None:
         proc.terminate()
 
 
+def abort_proc(proc: Optional[subprocess.Popen]) -> None:
+    if proc:
+        proc.aborted_by_user = True  # type: ignore[attr-defined]
+    try_kill_proc(proc)
+
+
 def try_kill_proc(proc: Optional[subprocess.Popen]) -> None:
     if proc:
         try:
@@ -229,6 +235,10 @@ def try_kill_proc(proc: Optional[subprocess.Popen]) -> None:
 
 def proc_has_been_killed(proc: subprocess.Popen) -> bool:
     return getattr(proc, "got_killed", False)
+
+
+def proc_has_been_aborted_by_user(proc: subprocess.Popen) -> bool:
+    return getattr(proc, "aborted_by_user", False)
 
 
 # `realpath` also supports `bytes` and we don't, hence the indirection

--- a/syntax/output_panel.sublime-syntax
+++ b/syntax/output_panel.sublime-syntax
@@ -12,8 +12,11 @@ contexts:
       captures:
         1: markup.heading entity.name.section
 
-    - match: ^\[Done.*\]$
-      scope: string.other
+    - match: ^\[(?:Done|Aborted).*\]$
+      scope: string.other.git-savvy
+
+    - match: ^\[ctrl\+z to abort\]$
+      scope: comment.string.other.hint.git-savvy
 
     - match: (\b{{sha}}\^?)
       comment: SHA

--- a/syntax/test/syntax_test_output_panel.txt
+++ b/syntax/test/syntax_test_output_panel.txt
@@ -32,6 +32,9 @@ To https://github.com/timbrel/GitSavvy
 $ git rebase --interactive --autostash --no-autosquash 87e57b9d^
 # <- markup.heading entity.name.section
 #                                                      ^^^^^^^^^ constant.numeric.graph.commit-hash.git-savvy
+[ctrl+z to abort]
+# <- comment.string.other.hint.git-savvy
+#^^^^^^^^^^^^^^^^ comment.string.other.hint.git-savvy
 [detached HEAD at 87e57b9d]
 #                 ^^^^^^^^ constant.numeric.graph.commit-hash.git-savvy
 Rebasing (2/3)


### PR DESCRIPTION
Allow the GitSavvy output panel to abort its displayed running git command with ctrl+z.  While a command is active, keep an abort hint at the end of the panel and remove it before writing the final status line.

Mark user-requested aborts separately from internal process kills so callers stop follow-up work via AbortedGitCall without showing a second error panel.

Fixes #1184