### PR TITLE
Fix spacing in remotes dashboard

### DIFF
--- a/core/interfaces/remotes.py
+++ b/core/interfaces/remotes.py
@@ -124,13 +124,12 @@ class RemotesInterface(ui.ReactiveInterface):
     def render_remote_list(self, remote_info: RemoteInfoBlob) -> str:
         remote_infos = remote_info.remotes
         if not remote_infos:
-            return "\n  ** No remotes configured. **"
+            return "\n  ** No remotes configured. **\n"
 
         show_markers = len(remote_infos) > 1
         name_width = max(len(remote.name) for remote in remote_infos)
-
-        return "\n".join(
-            f"\n{rendered}\n" if "\n" in rendered else rendered
+        rendered_remotes = [
+            rendered
             for remote in remote_infos
             if (rendered := self.render_remote(
                 remote,
@@ -139,7 +138,13 @@ class RemotesInterface(ui.ReactiveInterface):
                 remote_info.integration_remote,
                 name_width
             ))
-        ).lstrip("\n")
+        ]
+
+        output = rendered_remotes[0]
+        for previous, rendered in zip(rendered_remotes, rendered_remotes[1:]):
+            separator = "\n\n" if "\n" in previous or "\n" in rendered else "\n"
+            output += separator + rendered
+        return output + "\n"
 
     @ui.section("help")
     def render_help(self, show_help: bool) -> str:

--- a/tests/test_remotes_dashboard.py
+++ b/tests/test_remotes_dashboard.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from unittesting import DeferrableTestCase
+
+from GitSavvy.core.git_mixins.active_branch import Commit
+from GitSavvy.core.git_mixins.remotes import ConfigEntry, RemoteInfo, RemoteInfoBlob
+from GitSavvy.core.interfaces.remotes import RemotesInterface
+from GitSavvy.core.types import ShortHash
+
+
+class TestRemotesDashboard(DeferrableTestCase):
+    def test_single_remote_with_config_has_one_blank_line_before_help(self) -> None:
+        output = render_dashboard([
+            remote("origin", "https://example.com/project.git", [
+                ConfigEntry("gh-resolved", "base")
+            ])
+        ])
+
+        self.assertEqual(output, """
+  ROOT:    /repo
+
+  BRANCH:  On branch `main`.
+  HEAD:    1234567 A commit
+
+  REMOTE:
+    origin  https://example.com/project.git
+      gh-resolved = base
+
+  #############
+""")
+
+    def test_detailed_remotes_have_one_blank_line_between_each_remote(self) -> None:
+        output = render_dashboard([
+            remote("origin", "https://example.com/origin.git", [
+                ConfigEntry("fetch", "^refs/heads/main")
+            ]),
+            remote("upstream", "https://example.com/upstream.git", [
+                ConfigEntry("push", "+refs/heads/*:refs/heads/*"),
+                ConfigEntry("tagopt", "--no-tags")
+            ])
+        ], integration_remote="origin")
+
+        self.assertEqual(output, """
+  ROOT:    /repo
+
+  BRANCH:  On branch `main`.
+  HEAD:    1234567 A commit
+
+  REMOTE:
+  * origin    https://example.com/origin.git
+      fetch = ^refs/heads/main
+
+    upstream  https://example.com/upstream.git
+      push = +refs/heads/*:refs/heads/*
+      tagopt = --no-tags
+
+  #############
+""")
+
+    def test_compact_remote_list_has_no_blank_lines_between_remotes(self) -> None:
+        output = render_dashboard([
+            remote("origin", "https://example.com/origin.git"),
+            remote("fork", "https://example.com/fork.git"),
+            remote("backup", "https://example.com/backup.git")
+        ], push_remote="fork", integration_remote="origin")
+
+        self.assertEqual(output, """
+  ROOT:    /repo
+
+  BRANCH:  On branch `main`.
+  HEAD:    1234567 A commit
+
+  REMOTE:
+  * origin  https://example.com/origin.git
+  ▸ fork    https://example.com/fork.git
+    backup  https://example.com/backup.git
+
+  #############
+""")
+
+
+def render_dashboard(
+    remotes: list[RemoteInfo],
+    *,
+    push_remote: str | None = None,
+    integration_remote: str | None = None
+) -> str:
+    interface = RemotesInterface.__new__(RemotesInterface)
+    interface.template_help = "\n  #############"
+    interface.state = {
+        "git_root": "/repo",
+        "long_status": "On branch `main`.",
+        "recent_commits": [Commit(ShortHash("1234567"), "", "A commit")],
+        "remote_info": RemoteInfoBlob(remotes, push_remote, integration_remote),
+        "show_help": True
+    }
+    output, _regions = interface._render_template()
+    return output
+
+
+def remote(
+    name: str,
+    url: str,
+    config: list[ConfigEntry] | None = None
+) -> RemoteInfo:
+    return RemoteInfo(name, url, config or [])


### PR DESCRIPTION
Normalize separators between detailed remote entries while keeping compact remote lists together. Add regression tests for both forms and for the boundary before the help section.