### PR TITLE
Remove obsolete word-diff syntax

### DIFF
--- a/syntax/diff.sublime-syntax
+++ b/syntax/diff.sublime-syntax
@@ -128,20 +128,4 @@ contexts:
         1: punctuation.definition.deleted.diff
         2: markup.deleted.diff.content
 
-    - match: (\{\+)(.+?)(\+\})
-      comment: Add block/sections
-      scope: markup.inserted.git-savvy.add-block
-      captures:
-        1: punctuation.definition.inserted.diff
-        2: markup.inserted.git-savvy.add-block.content
-        3: punctuation.definition.inserted.diff
-
-    - match: (\[\-)(.+?)(\-\])
-      comment: Delete block/sections
-      scope: markup.deleted.git-savvy.delete-block
-      captures:
-        1: punctuation.definition.deleted.diff
-        2: markup.deleted.git-savvy.delete-block.content
-        3: punctuation.definition.deleted.diff
-
     - include: "scope:git-savvy.commit-diffstat"

--- a/syntax/test/syntax_test_diff.txt
+++ b/syntax/test/syntax_test_diff.txt
@@ -81,18 +81,5 @@ similarity index 59%
 #         ^ markup.inserted.diff.content
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.inserted.diff
 
-In the midlle {+inserted+} of the word
-#             ^ punctuation.definition.inserted.diff
-#              ^ punctuation.definition.inserted.diff
-#               ^^^^^^^^ markup.inserted.git-savvy.add-block.content
-#                       ^ punctuation.definition.inserted.diff
-#                        ^ punctuation.definition.inserted.diff
-#             ^^^^^^^^^^^^ markup.inserted.git-savvy.add-block
-
-In the midlle [-deleted-] of the word
-#             ^ punctuation.definition.deleted.diff
-#              ^ punctuation.definition.deleted.diff
-#               ^^^^^^^ markup.deleted.git-savvy.delete-block.content
-#                      ^ punctuation.definition.deleted.diff
-#                       ^ punctuation.definition.deleted.diff
-#             ^^^^^^^^^^^ markup.deleted.git-savvy.delete-block
+ const SEMVER_TAG_RE = /^v?\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/
+#                                          ^^^^^^^^^^^^^^^^^ - markup.deleted.git-savvy.delete-block


### PR DESCRIPTION
Word-diff support was removed after intra-line highlighting became the preferred implementation. Remove its leftover syntax rules so source text resembling word-diff markers is not marked as deleted.