### PR TITLE
Rework slow repo detection

### DIFF
--- a/core/git_mixins/branches.py
+++ b/core/git_mixins/branches.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 import re
+import threading
+import time
 
 from GitSavvy.core.git_command import mixin_base, NOT_SET
 from GitSavvy.core.fns import filter_
@@ -15,6 +17,8 @@ from typing import Dict, List, NamedTuple, Optional, Sequence
 BRANCH_DESCRIPTION_RE = re.compile(r"^branch\.(.*?)\.description (.*)$")
 FOR_EACH_REF_SUPPORTS_AHEAD_BEHIND = (2, 41, 0)
 FOR_EACH_REF_SUPPORTS_WORKTREEPATH = (2, 23, 0)
+COMMIT_GRAPH_WRITE_INTERVAL = 60 * 60  # [s]
+COMMIT_GRAPH_WRITE_LOCK = threading.Lock()
 
 
 class Upstream(NamedTuple):
@@ -155,6 +159,7 @@ class BranchesMixin(mixin_base):
                 )
             except GitSavvyError as e:
                 if probe_speed and "timed out after" in e.stderr:
+                    self.update_store({"slow_repo": True})
 
                     def run_commit_graph_write():
                         hprint(
@@ -166,7 +171,6 @@ class BranchesMixin(mixin_base):
                             self.git_throwing_silently("commit-graph", "write")
                         except GitSavvyError as err:
                             hprint(f"`git commit-graph write` raised: {err}")
-                            self.update_store({"slow_repo": True})
                             return
 
                         with measure_runtime() as ms:
@@ -177,12 +181,10 @@ class BranchesMixin(mixin_base):
                             f"After `git commit-graph write` the `git for-each-ref` call "
                             f"{'' if ok else 'still '}takes {elapsed}ms"
                         )
-                        if not ok:
-                            hprint("Disabling sections in the branches dashboard.")
 
-                        self.update_store({"slow_repo": True if not ok else False})
+                    if self._claim_commit_graph_write():
+                        run_on_new_thread(run_commit_graph_write)
 
-                    run_on_new_thread(run_commit_graph_write)
                     return get_branches__(False, False)
 
                 if "fatal: failed to find 'HEAD'" in e.stderr and supports_ahead_behind:
@@ -220,6 +222,16 @@ class BranchesMixin(mixin_base):
         )
         probe_speed = compute_ahead_behind and slow_repo is None
         return get_branches__(probe_speed, compute_ahead_behind)
+
+    def _claim_commit_graph_write(self) -> bool:
+        with COMMIT_GRAPH_WRITE_LOCK:
+            now = time.monotonic()
+            last_run = self.current_state().get("last_commit_graph_write", -COMMIT_GRAPH_WRITE_INTERVAL)
+            if now - last_run < COMMIT_GRAPH_WRITE_INTERVAL:
+                return False
+
+            self.update_store({"last_commit_graph_write": now})
+            return True
 
     def _cache_branches(self, branches, refs):
         # type: (List[Branch], Sequence[str]) -> None

--- a/core/git_mixins/branches.py
+++ b/core/git_mixins/branches.py
@@ -19,6 +19,7 @@ FOR_EACH_REF_SUPPORTS_AHEAD_BEHIND = (2, 41, 0)
 FOR_EACH_REF_SUPPORTS_WORKTREEPATH = (2, 23, 0)
 COMMIT_GRAPH_WRITE_INTERVAL = 60 * 60  # [s]
 COMMIT_GRAPH_WRITE_LOCK = threading.Lock()
+AHEAD_BEHIND_RETRY_DELAYS = (1, 10, 60, 10 * 60, 60 * 60)  # [s]
 
 
 class Upstream(NamedTuple):
@@ -128,9 +129,15 @@ class BranchesMixin(mixin_base):
         """
         Return a list of local and/or remote branches.
         """
+        supports_ahead_behind = self.git_version >= FOR_EACH_REF_SUPPORTS_AHEAD_BEHIND
         supports_worktreepath = self.git_version >= FOR_EACH_REF_SUPPORTS_WORKTREEPATH
 
-        def get_branches__(probe_speed: bool, supports_ahead_behind: bool) -> List[Branch]:
+        def get_branches__(
+            with_ahead_behind: bool,
+            *,
+            allow_slow_run: bool = False
+        ) -> List[Branch]:
+            probe_speed = with_ahead_behind and not allow_slow_run
             WAIT_TIME = 200  # [ms]
             try:
                 stdout: str = self.git_throwing_silently(
@@ -147,19 +154,19 @@ class BranchesMixin(mixin_base):
                             "%(committerdate:relative)",
                             "%(objectname)",
                             "%(contents:subject)",
-                            "%(ahead-behind:HEAD)" if supports_ahead_behind else "",
+                            "%(ahead-behind:HEAD)" if with_ahead_behind else "",
                             "%(worktreepath)" if supports_worktreepath else ""
                         ))
                     ),
                     *refs,
-                    # If `supports_ahead_behind` we don't use the `--[no-]merged` argument
+                    # With ahead/behind data we don't use the `--[no-]merged` argument
                     # and instead filter here in Python land.
-                    yes_no_switch("--merged", merged) if not supports_ahead_behind else None,
+                    yes_no_switch("--merged", merged) if not with_ahead_behind else None,
                     timeout=WAIT_TIME / 1000 if probe_speed else NOT_SET
                 )
             except GitSavvyError as e:
                 if probe_speed and "timed out after" in e.stderr:
-                    self.update_store({"slow_repo": True})
+                    self._record_ahead_behind_timeout()
 
                     if self._claim_commit_graph_write():
                         def run_commit_graph_write():
@@ -175,7 +182,7 @@ class BranchesMixin(mixin_base):
                                 return
 
                             with measure_runtime() as ms:
-                                get_branches__(False, supports_ahead_behind)
+                                get_branches__(True, allow_slow_run=True)
                             elapsed = ms.get()
                             ok = elapsed < WAIT_TIME
                             hprint(
@@ -185,13 +192,16 @@ class BranchesMixin(mixin_base):
 
                         run_on_new_thread(run_commit_graph_write)
 
-                    return get_branches__(False, False)
+                    return get_branches__(False)
 
-                if "fatal: failed to find 'HEAD'" in e.stderr and supports_ahead_behind:
-                    return get_branches__(False, False)
+                if "fatal: failed to find 'HEAD'" in e.stderr and with_ahead_behind:
+                    return get_branches__(False)
 
                 e.show_error_panel()
                 raise
+
+            if probe_speed:
+                self._record_fast_ahead_behind_query()
 
             branches = [
                 branch
@@ -201,7 +211,7 @@ class BranchesMixin(mixin_base):
                 )
                 if branch.name != "HEAD"
             ]
-            if supports_ahead_behind:
+            if with_ahead_behind:
                 # Cache git's full output but return a filtered result if requested.
                 self._cache_branches(branches, refs)
                 if merged is True:
@@ -215,13 +225,24 @@ class BranchesMixin(mixin_base):
 
             return branches
 
-        slow_repo = self.current_state().get("slow_repo", None)
-        compute_ahead_behind = (
-            self.git_version >= FOR_EACH_REF_SUPPORTS_AHEAD_BEHIND
-            and not slow_repo
-        )
-        probe_speed = compute_ahead_behind and slow_repo is None
-        return get_branches__(probe_speed, compute_ahead_behind)
+        now = time.monotonic()
+        retry_at = self.current_state().get("ahead_behind_retry_at", now)
+        compute_ahead_behind = supports_ahead_behind and now >= retry_at
+        return get_branches__(compute_ahead_behind)
+
+    def _record_ahead_behind_timeout(self) -> None:
+        failures = self.current_state().get("ahead_behind_consecutive_failures", 0) + 1
+        delay = AHEAD_BEHIND_RETRY_DELAYS[
+            min(failures - 1, len(AHEAD_BEHIND_RETRY_DELAYS) - 1)
+        ]
+        self.update_store({
+            "ahead_behind_consecutive_failures": failures,
+            "ahead_behind_retry_at": time.monotonic() + delay
+        })
+
+    def _record_fast_ahead_behind_query(self) -> None:
+        if self.current_state().get("ahead_behind_consecutive_failures", 0):
+            self.update_store({"ahead_behind_consecutive_failures": 0})
 
     def _claim_commit_graph_write(self) -> bool:
         with COMMIT_GRAPH_WRITE_LOCK:

--- a/core/git_mixins/branches.py
+++ b/core/git_mixins/branches.py
@@ -161,28 +161,28 @@ class BranchesMixin(mixin_base):
                 if probe_speed and "timed out after" in e.stderr:
                     self.update_store({"slow_repo": True})
 
-                    def run_commit_graph_write():
-                        hprint(
-                            f"`git for-each-ref` took more than {WAIT_TIME}ms which is slow "
-                            "for our purpose. We now run `git commit-graph write` to see if "
-                            "it gets better."
-                        )
-                        try:
-                            self.git_throwing_silently("commit-graph", "write")
-                        except GitSavvyError as err:
-                            hprint(f"`git commit-graph write` raised: {err}")
-                            return
-
-                        with measure_runtime() as ms:
-                            get_branches__(False, supports_ahead_behind)
-                        elapsed = ms.get()
-                        ok = elapsed < WAIT_TIME
-                        hprint(
-                            f"After `git commit-graph write` the `git for-each-ref` call "
-                            f"{'' if ok else 'still '}takes {elapsed}ms"
-                        )
-
                     if self._claim_commit_graph_write():
+                        def run_commit_graph_write():
+                            hprint(
+                                f"`git for-each-ref` took more than {WAIT_TIME}ms which is slow "
+                                "for our purpose. We now run `git commit-graph write` to see if "
+                                "it gets better."
+                            )
+                            try:
+                                self.git_throwing_silently("commit-graph", "write")
+                            except GitSavvyError as err:
+                                hprint(f"`git commit-graph write` raised: {err}")
+                                return
+
+                            with measure_runtime() as ms:
+                                get_branches__(False, supports_ahead_behind)
+                            elapsed = ms.get()
+                            ok = elapsed < WAIT_TIME
+                            hprint(
+                                f"After `git commit-graph write` the `git for-each-ref` call "
+                                f"{'' if ok else 'still '}takes {elapsed}ms"
+                            )
+
                         run_on_new_thread(run_commit_graph_write)
 
                     return get_branches__(False, False)

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -50,7 +50,7 @@ __all__ = (
 )
 
 
-from typing import Dict, Iterable, Iterator, List, Optional, Tuple, TypedDict, NamedTuple
+from typing import cast, Dict, Iterable, Iterator, List, Optional, Tuple, TypedDict, NamedTuple, Protocol
 from ..git_mixins.active_branch import Commit
 from ..git_mixins.branches import Branch
 from ..git_mixins.worktrees import Worktree
@@ -77,7 +77,15 @@ class DetachedBranch(NamedTuple):
     worktree_path: str
 
 
-BranchWithWorktree = DetachedBranch
+class BranchWithWorktree(Protocol):
+    @property
+    def commit_hash(self) -> FullHash: ...
+
+    @property
+    def canonical_name(self) -> str: ...
+
+    @property
+    def worktree_path(self) -> str: ...
 
 
 class gs_show_branch(WindowCommand, GitCommand):
@@ -308,14 +316,30 @@ class BranchInterface(ui.ReactiveInterface, GitCommand):
         else:
             if sort_by_recent:
                 local_branches = sorted(local_branches, key=lambda branch: -branch.committerdate)
-            return self._render_branch_list(None, local_branches, descriptions)
+
+            worktree_branches = [
+                cast(BranchWithWorktree, branch)
+                for branch in local_branches
+                if branch.worktree_path and not branch.active
+            ]
+            local_branches = [
+                branch for branch in local_branches
+                if not branch.worktree_path or branch.active
+            ]
+            sections = [
+                self._render_detached_head(detached_head[0]) if detached_head else "",
+                self._render_branch_list(None, local_branches, descriptions),
+                self._render_worktree_branches(worktree_branches) if worktree_branches else "",
+                self._render_worktree_branches(detached_worktrees) if detached_worktrees else ""
+            ]
+            return "\n{}\n".format(" " * 60).join(filter_(sections))
 
     def _render_detached_head(self, worktree: DetachedBranch) -> str:
         return "  ▸ {hash} (DETACHED)".format(
             hash=self.to_short_hash(worktree.commit_hash),
         )
 
-    def _render_worktree_branches(self, branches: List[BranchWithWorktree | DetachedBranch]) -> str:
+    def _render_worktree_branches(self, branches: Iterable[BranchWithWorktree]) -> str:
         return "\n{}\n".format(" " * 60).join(
             "   <{hash}> {name}\n"
             "      \\ checked out at: {path}"

--- a/core/store.py
+++ b/core/store.py
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
         short_hash_length: int
         skipped_files: List[str]
         slow_repo: bool
+        last_commit_graph_write: float
         stashes: List[Stash]
         recent_commits: List[Commit]
         descriptions: Dict[str, str]

--- a/core/store.py
+++ b/core/store.py
@@ -40,7 +40,8 @@ if TYPE_CHECKING:
         last_reset_mode_used: Optional[str]
         short_hash_length: int
         skipped_files: List[str]
-        slow_repo: bool
+        ahead_behind_consecutive_failures: int
+        ahead_behind_retry_at: float
         last_commit_graph_write: float
         stashes: List[Stash]
         recent_commits: List[Commit]

--- a/tests/test_branch_dashboard.py
+++ b/tests/test_branch_dashboard.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from unittesting import DeferrableTestCase
+
+from GitSavvy.core.git_mixins.branches import Branch
+from GitSavvy.core.git_mixins.worktrees import Worktree
+from GitSavvy.core.interfaces.branch import BranchInterface
+from GitSavvy.core.types import FullHash, ShortHash
+
+
+class TestBranchDashboard(DeferrableTestCase):
+    def test_worktrees_render_without_ahead_behind_information(self) -> None:
+        interface = BranchRenderer.__new__(BranchRenderer)
+        interface.state = {
+            "descriptions": {},
+            "worktree_deletions_in_progress": set()
+        }
+        branches = [
+            branch("main", "a", active=True, worktree_path="/repo"),
+            branch("feature", "b", worktree_path="/repo-feature")
+        ]
+        worktrees = [
+            Worktree(
+                "/repo-detached", FullHash("c" * 40), None,
+                False, False, False
+            )
+        ]
+
+        output = interface.render_branch_list(
+            branches, worktrees, sort_by_recent=False,
+            group_by_distance_to_head=True
+        )
+
+        self.assertIn("▸ aaaaaaa main", output)
+        self.assertIn("<bbbbbbb> feature", output)
+        self.assertIn("checked out at: /repo-feature", output)
+        self.assertIn("<ccccccc> (DETACHED)", output)
+        self.assertIn("checked out at: /repo-detached", output)
+
+
+class BranchRenderer(BranchInterface):
+    def to_short_hash(self, commit_hash: FullHash | ShortHash) -> ShortHash:
+        return ShortHash(commit_hash[:7])
+
+    def nice_path(self, path: str) -> str:
+        return path
+
+
+def branch(
+    name: str,
+    hash_char: str,
+    *,
+    active: bool = False,
+    worktree_path: str | None = None
+) -> Branch:
+    return Branch(
+        name=name,
+        remote=None,
+        canonical_name=name,
+        commit_hash=FullHash(hash_char * 40),
+        commit_msg="",
+        active=active,
+        is_remote=False,
+        committerdate=0,
+        human_committerdate="now",
+        relative_committerdate="now",
+        upstream=None,
+        distance_to_head=None,
+        worktree_path=worktree_path
+    )

--- a/tests/test_git_mixins.py
+++ b/tests/test_git_mixins.py
@@ -2,6 +2,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import time
 
 import sublime
 
@@ -10,6 +11,7 @@ from GitSavvy.tests.mockito import unstub, when
 from GitSavvy.tests.parameterized import parameterized as p, param
 
 from GitSavvy.core.git_command import GitCommand
+from GitSavvy.core.exceptions import GitSavvyError
 from GitSavvy.core import git_mixins
 from GitSavvy.core.git_mixins.worktrees import Worktree, WorktreesMixin
 from GitSavvy.core.utils import resolve_path
@@ -234,6 +236,58 @@ class TestGetBranchesParsing(TestGitMixinsUsage):
                 None
             )
         ])
+
+
+class TestCommitGraphWrite(TestGitMixinsUsage):
+    def test_diagnostic_result_does_not_change_slow_repo_detection(self):
+        repo = SlowBranchesRepo()
+
+        when(git_mixins.branches).run_on_new_thread(...).thenAnswer(lambda fn: fn())
+        repo.get_branches()
+
+        self.assertTrue(repo.state["slow_repo"])
+        self.assertEqual(repo.commit_graph_writes, 1)
+        self.assertEqual(repo.ahead_behind_queries, 2)
+
+    def test_commit_graph_write_is_rate_limited(self):
+        repo = SlowBranchesRepo({"last_commit_graph_write": time.monotonic()})
+
+        repo.get_branches()
+
+        self.assertTrue(repo.state["slow_repo"])
+        self.assertEqual(repo.commit_graph_writes, 0)
+        self.assertEqual(repo.ahead_behind_queries, 1)
+
+
+class SlowBranchesRepo(git_mixins.branches.BranchesMixin):
+    def __init__(self, state=None):
+        self.state = state or {}
+        self.ahead_behind_queries = 0
+        self.commit_graph_writes = 0
+
+    @property
+    def git_version(self):
+        return (2, 41, 0)
+
+    def current_state(self):
+        return self.state
+
+    def update_store(self, partial_state):
+        self.state.update(partial_state)
+
+    def git_throwing_silently(self, command, *args, **kwargs):
+        if command == "commit-graph":
+            self.commit_graph_writes += 1
+            return ""
+
+        if any("%(ahead-behind:HEAD)" in str(arg) for arg in args):
+            self.ahead_behind_queries += 1
+            if self.ahead_behind_queries == 1:
+                raise GitSavvyError(
+                    "", stderr="timed out after 0.2 seconds", show_panel=False
+                )
+
+        return ""
 
 
 class TestGetWorktreesParsing(TestGitMixinsUsage):

--- a/tests/test_git_mixins.py
+++ b/tests/test_git_mixins.py
@@ -238,14 +238,16 @@ class TestGetBranchesParsing(TestGitMixinsUsage):
         ])
 
 
-class TestCommitGraphWrite(TestGitMixinsUsage):
-    def test_diagnostic_result_does_not_change_slow_repo_detection(self):
+class TestAheadBehindCircuitBreaker(TestGitMixinsUsage):
+    def test_diagnostic_result_does_not_reset_timeout_state(self):
+        now = time.monotonic()
         repo = SlowBranchesRepo()
 
         when(git_mixins.branches).run_on_new_thread(...).thenAnswer(lambda fn: fn())
         repo.get_branches()
 
-        self.assertTrue(repo.state["slow_repo"])
+        self.assertEqual(repo.state["ahead_behind_consecutive_failures"], 1)
+        self.assertGreaterEqual(repo.state["ahead_behind_retry_at"], now + 1)
         self.assertEqual(repo.commit_graph_writes, 1)
         self.assertEqual(repo.ahead_behind_queries, 2)
 
@@ -254,14 +256,52 @@ class TestCommitGraphWrite(TestGitMixinsUsage):
 
         repo.get_branches()
 
-        self.assertTrue(repo.state["slow_repo"])
+        self.assertEqual(repo.state["ahead_behind_consecutive_failures"], 1)
         self.assertEqual(repo.commit_graph_writes, 0)
         self.assertEqual(repo.ahead_behind_queries, 1)
 
+    def test_queries_without_ahead_behind_before_retry_time(self):
+        repo = SlowBranchesRepo({
+            "ahead_behind_consecutive_failures": 1,
+            "ahead_behind_retry_at": time.monotonic() + 60
+        })
+
+        repo.get_branches()
+
+        self.assertEqual(repo.ahead_behind_queries, 0)
+        self.assertEqual(repo.state["ahead_behind_consecutive_failures"], 1)
+
+    def test_fast_retry_immediately_resets_failures(self):
+        retry_at = time.monotonic() - 1
+        repo = SlowBranchesRepo({
+            "ahead_behind_consecutive_failures": 3,
+            "ahead_behind_retry_at": retry_at
+        }, timeouts=0)
+
+        repo.get_branches()
+
+        self.assertEqual(repo.ahead_behind_queries, 1)
+        self.assertEqual(repo.state["ahead_behind_consecutive_failures"], 0)
+        self.assertEqual(repo.state["ahead_behind_retry_at"], retry_at)
+
+    def test_repeated_timeout_increases_retry_delay(self):
+        now = time.monotonic()
+        repo = SlowBranchesRepo({
+            "ahead_behind_consecutive_failures": 2,
+            "ahead_behind_retry_at": now,
+            "last_commit_graph_write": now
+        })
+
+        repo.get_branches()
+
+        self.assertEqual(repo.state["ahead_behind_consecutive_failures"], 3)
+        self.assertGreaterEqual(repo.state["ahead_behind_retry_at"], now + 60)
+
 
 class SlowBranchesRepo(git_mixins.branches.BranchesMixin):
-    def __init__(self, state=None):
+    def __init__(self, state=None, *, timeouts=1):
         self.state = state or {}
+        self.timeouts = timeouts
         self.ahead_behind_queries = 0
         self.commit_graph_writes = 0
 
@@ -282,7 +322,7 @@ class SlowBranchesRepo(git_mixins.branches.BranchesMixin):
 
         if any("%(ahead-behind:HEAD)" in str(arg) for arg in args):
             self.ahead_behind_queries += 1
-            if self.ahead_behind_queries == 1:
+            if self.ahead_behind_queries <= self.timeouts:
                 raise GitSavvyError(
                     "", stderr="timed out after 0.2 seconds", show_panel=False
                 )


### PR DESCRIPTION
* Showing worktree info has nothing to do with slow_repo, so decouple that!
* Instead of probing once and set-in-stone-until-reload, probe often.  Very hard PR/state machine. 