### PR TITLE
Worktree support iteration

### DIFF
--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -42,6 +42,21 @@
     "users_home": "~",
 
     /*
+        When set to `true`, GitSavvy will copy the active project file into a
+        newly created worktree.
+
+        BETA/restrictions/dragons:
+        - Only project files stored in the repository root are considered.
+        - Absolute folder paths pointing to the original repository are
+          rewritten to ".".
+        - Tracked project files are left entirely to Git and are not copied.
+
+        Integrates with:
+        https://github.com/kaste/OpenTheProject
+    */
+    "copy_active_project_file_to_new_worktrees": true,
+
+    /*
         Enter your GitHub/GitLab API key(s) in the field below.
         To interact with enterprise/self-hosted instances, add a field with
         the FQDN as the key and the API key as the value.

--- a/core/commands/log_graph_main_actions.py
+++ b/core/commands/log_graph_main_actions.py
@@ -15,7 +15,7 @@ from ..git_mixins.branches import Branch
 from ..text_helper import line_from_pt
 from ..types import FullPath
 from ..ui__quick_panel import ActionType, SEPARATOR, show_actions_panel, show_quick_panel
-from ..utils import open_folder_in_new_window
+from ..utils import open_worktree_in_new_window
 from . import multi_selector
 from . import ref_undo
 from . import log_graph_colorizer as colorizer
@@ -655,7 +655,7 @@ class gs_log_graph_action(WindowCommand, GitCommand):
                 w.run_command("gs_graph")
 
         worktree_path = self.create_new_worktree(commit_hash)
-        open_folder_in_new_window(worktree_path, then=callback)
+        open_worktree_in_new_window(worktree_path, then=callback)
 
     def create_branch(self, commit_hash):
         self.window.run_command("gs_create_branch", {"start_point": commit_hash})

--- a/core/git_mixins/worktrees.py
+++ b/core/git_mixins/worktrees.py
@@ -116,6 +116,9 @@ class WorktreesMixin(mixin_base):
         self.git("worktree", "add", worktree_path, start_point)
         return worktree_path
 
+    def move_worktree(self, path: str, new_path: str) -> None:
+        self.git("worktree", "move", path, new_path)
+
     def remove_worktree(self, path: str, *, force: bool = False):
         self.git("worktree", "remove", "-f" if force else None, path)
 

--- a/core/git_mixins/worktrees.py
+++ b/core/git_mixins/worktrees.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from copy import deepcopy
 from itertools import count
 import os
 
@@ -95,9 +96,16 @@ class WorktreesMixin(mixin_base):
         commit_current(current)
         return worktrees
 
-    def create_new_worktree(self, start_point: ShortHash, worktree_path: str = None) -> str:
+    def create_new_worktree(
+        self, start_point: ShortHash, worktree_path: str | None = None
+    ) -> str:
         # Note: `start_point: ShortHash` is a shortcut for the automatic `worktree_path`
         #       computation.  Change when needed.
+        project = (
+            self._project_for_new_worktree()
+            if self.savvy_settings.get("copy_active_project_file_to_new_worktrees", True)
+            else None
+        )
         if not worktree_path:
             if self.repo_path.startswith(sublime.packages_path()):
                 base = self.default_project_root()
@@ -114,6 +122,8 @@ class WorktreesMixin(mixin_base):
                     break
 
         self.git("worktree", "add", worktree_path, start_point)
+        if project:
+            self._copy_project_to_worktree(project, worktree_path)
         return worktree_path
 
     def move_worktree(self, path: str, new_path: str) -> None:
@@ -122,9 +132,53 @@ class WorktreesMixin(mixin_base):
     def remove_worktree(self, path: str, *, force: bool = False):
         self.git("worktree", "remove", "-f" if force else None, path)
 
+    def _project_for_new_worktree(self) -> tuple[str, dict] | None:
+        window = self.some_window()
+        project_file = window.project_file_name()
+        if (
+            not project_file
+            or not project_file.endswith(".sublime-project")
+            or not _paths_are_equal(os.path.dirname(project_file), self.repo_path)
+        ):
+            return None
+
+        filename = os.path.basename(project_file)
+        if self.git("ls-files", "-z", "--", filename):
+            return None
+
+        project_data = window.project_data()
+        if project_data is None:
+            return None
+        return filename, project_data
+
+    def _copy_project_to_worktree(
+        self, project: tuple[str, dict], worktree_path: str
+    ) -> None:
+        filename, source_data = project
+        destination = os.path.join(worktree_path, filename)
+        if os.path.exists(destination):
+            return
+
+        project_data = deepcopy(source_data)
+        for folder in project_data.get("folders", []):
+            path = folder.get("path")
+            if path and os.path.isabs(path) and _paths_are_equal(path, self.repo_path):
+                folder["path"] = "."
+
+        with open(destination, "w", encoding="utf-8", newline="\n") as file:
+            file.write(sublime.encode_value(project_data, pretty=True))
+            file.write("\n")
+
 
 def _looks_malformed_non_z_field(field: str) -> bool:
     return (
         field.startswith('worktree "')
         or not field.startswith(WORKTREE_LIST_PORCELAIN_FIELD_PREFIXES)
+    )
+
+
+def _paths_are_equal(path_a: str, path_b: str) -> bool:
+    return (
+        os.path.normcase(os.path.realpath(path_a))
+        == os.path.normcase(os.path.realpath(path_b))
     )

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -836,6 +836,8 @@ class gs_branches_rename(CommandForSingleItem):
             )
         elif self.selected_item.is_remote:
             flash(self.view, "Cannot rename remote branches.")
+        elif self.selected_item.is_detached:
+            flash(self.view, "Cannot rename a detached HEAD.")
         else:
             self.window.run_command("gs_rename_branch", {
                 "branch": self.selected_item.branch_name

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -17,7 +17,7 @@ from ..git_command import GitCommand, GitSavvyError
 from ..ui__busy_spinner import busy_indicator
 from ..ui_mixins.quick_panel import show_remote_panel, show_branch_panel
 from ..ui_mixins.input_panel import show_single_line_input_panel
-from ..utils import open_folder_in_new_window
+from ..utils import open_worktree_in_new_window
 from GitSavvy.core import app_state
 from GitSavvy.core.fns import chain, filter_, pairwise
 from GitSavvy.core.utils import flash, is_younger_than
@@ -650,7 +650,7 @@ class gs_branches_checkout(CommandForSingleItem):
                     w.run_command("gs_show_branch")
 
             worktree_path = self.selected_item.worktree.replace("/", os.path.sep)
-            open_folder_in_new_window(worktree_path, then=callback)
+            open_worktree_in_new_window(worktree_path, then=callback)
 
         else:
             self.window.run_command("gs_checkout_branch", {

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -133,7 +133,7 @@ class BranchInterface(ui.ReactiveInterface, GitCommand):
       [w] create ad-hoc worktree from selected
       [d] delete                                    [h] fetch remote branches
       [D] delete (force)                            [m] merge selected into active branch
-      [R] rename (local)                            [M] fetch and merge into active branch
+      [R] rename branch / worktree directory        [M] fetch and merge into active branch
       [t] configure tracking                        [u] unset upstream on selected branch
 
       [f] open diff                                 [l] show log in a quick panel
@@ -820,18 +820,34 @@ def record_deleted_branch_undos(
             ref_undo.add_branch_undo(cmd, branch_name, ShortHash(commit_hash), undo_owner)
 
 
-class gs_branches_rename(CommandForSingleBranch):
+class gs_branches_rename(CommandForSingleItem):
 
     """
-    Rename selected branch.
+    Rename the selected branch or worktree directory.
     """
 
     def run(self, edit):
-        if self.selected_branch.is_remote:
+        if worktree_path := self.selected_item.worktree:
+            show_single_line_input_panel(
+                "Rename worktree directory:",
+                worktree_path,
+                partial(self.rename_worktree, worktree_path),
+                select_text=False
+            )
+        elif self.selected_item.is_remote:
             flash(self.view, "Cannot rename remote branches.")
+        else:
+            self.window.run_command("gs_rename_branch", {
+                "branch": self.selected_item.branch_name
+            })
+
+    @on_worker
+    def rename_worktree(self, current_path: str, new_path: str) -> None:
+        if not new_path or new_path == current_path:
             return
 
-        self.window.run_command("gs_rename_branch", {"branch": self.selected_branch.name})
+        self.move_worktree(current_path, new_path)
+        util.view.refresh_gitsavvy(self.view)
 
 
 class gs_branches_configure_tracking(CommandForSingleBranch):

--- a/core/interfaces/status_main_actions.py
+++ b/core/interfaces/status_main_actions.py
@@ -7,7 +7,7 @@ import sublime
 
 from ..base_commands import GsWindowCommand
 from ..ui__quick_panel import SEPARATOR, show_quick_panel
-from ..utils import open_folder_in_new_window
+from ..utils import open_worktree_in_new_window
 
 
 __all__ = (
@@ -163,7 +163,7 @@ class gs_status_action_menu(GsWindowCommand):
 
         commit_hash = self.resolve("HEAD", short=True)
         worktree_path = self.create_new_worktree(commit_hash)
-        open_folder_in_new_window(worktree_path, then=callback)
+        open_worktree_in_new_window(worktree_path, then=callback)
 
     def create_tag(self) -> None:
         self.window.run_command("gs_create_tag")

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from contextlib import contextmanager
 import datetime
+from glob import glob
 from itertools import count
 import os
 import signal
@@ -178,7 +179,42 @@ if sys.platform == "win32":
     STARTUPINFO.dwFlags |= subprocess.STARTF_USESHOWWINDOW
 
 
-def open_folder_in_new_window(path: str, *, then: Callable[[sublime.Window], None] = None):
+def open_worktree_in_new_window(
+    path: str, *, then: Callable[[sublime.Window], None] | None = None
+) -> None:
+    project_files = glob(os.path.join(path, "*.sublime-project"))
+    if len(project_files) != 1:
+        open_folder_in_new_window(path, then=then)
+        return
+
+    project_file = project_files[0]
+    current_windows = set(sublime.windows())
+    sublime.active_window().run_command("open_project_or_workspace", {
+        "file": project_file,
+        "new_window": True
+    })
+    if then:
+        @runtime.on_worker
+        def search_for_new_window(_tries=5):
+            for window in set(sublime.windows()) - current_windows:
+                candidate = window.project_file_name()
+                if (
+                    candidate
+                    and os.path.normcase(candidate) == os.path.normcase(project_file)
+                ):
+                    then(window)
+                    return
+
+            if _tries:
+                sublime.set_timeout(lambda: search_for_new_window(_tries - 1), 10)
+
+        search_for_new_window()
+
+
+def open_folder_in_new_window(
+    path: str, *, then: Callable[[sublime.Window], None] | None = None
+) -> None:
+    current_windows = set(sublime.windows())
     bin = get_sublime_executable()
     cmd = [bin, path]
     subprocess.Popen(cmd, startupinfo=STARTUPINFO)
@@ -186,11 +222,12 @@ def open_folder_in_new_window(path: str, *, then: Callable[[sublime.Window], Non
     if then:
         @runtime.on_worker
         def search_for_new_window(_tries=5):
-            for w in sublime.windows():
+            for w in set(sublime.windows()) - current_windows:
                 if path in w.folders():
                     then(w)
                     return
-            sublime.set_timeout(lambda: search_for_new_window(_tries - 1), 10)
+            if _tries:
+                sublime.set_timeout(lambda: search_for_new_window(_tries - 1), 10)
 
         search_for_new_window()
 

--- a/core/utils.py
+++ b/core/utils.py
@@ -194,21 +194,13 @@ def open_worktree_in_new_window(
         "new_window": True
     })
     if then:
-        @runtime.on_worker
-        def search_for_new_window(_tries=5):
-            for window in set(sublime.windows()) - current_windows:
-                candidate = window.project_file_name()
-                if (
-                    candidate
-                    and os.path.normcase(candidate) == os.path.normcase(project_file)
-                ):
-                    then(window)
-                    return
+        def is_project_window(window: sublime.Window) -> bool:
+            return bool(
+                (candidate := window.project_file_name())
+                and os.path.normcase(candidate) == os.path.normcase(project_file)
+            )
 
-            if _tries:
-                sublime.set_timeout(lambda: search_for_new_window(_tries - 1), 10)
-
-        search_for_new_window()
+        wait_for_new_window(current_windows, is_project_window, then)
 
 
 def open_folder_in_new_window(
@@ -220,16 +212,29 @@ def open_folder_in_new_window(
     subprocess.Popen(cmd, startupinfo=STARTUPINFO)
 
     if then:
-        @runtime.on_worker
-        def search_for_new_window(_tries=5):
-            for w in set(sublime.windows()) - current_windows:
-                if path in w.folders():
-                    then(w)
-                    return
-            if _tries:
-                sublime.set_timeout(lambda: search_for_new_window(_tries - 1), 10)
+        wait_for_new_window(
+            current_windows,
+            lambda window: path in window.folders(),
+            then
+        )
 
-        search_for_new_window()
+
+def wait_for_new_window(
+    current_windows: set[sublime.Window],
+    predicate: Callable[[sublime.Window], bool],
+    kont: Callable[[sublime.Window], None]
+) -> None:
+    @runtime.on_worker
+    def search(tries=5):
+        for window in set(sublime.windows()) - current_windows:
+            if predicate(window):
+                kont(window)
+                return
+
+        if tries:
+            sublime.set_timeout(lambda: search(tries - 1), 10)
+
+    search()
 
 
 def get_sublime_executable() -> str:

--- a/tests/test_git_mixins.py
+++ b/tests/test_git_mixins.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 import subprocess
 import sys
@@ -401,6 +402,134 @@ class TestGetWorktreesParsing(TestGitMixinsUsage):
         actual = repo.get_worktrees()
 
         self.assertEqual(actual, [])
+
+
+class TestCreateNewWorktreeProject(TestGitMixinsUsage):
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp(prefix=TMPDIR_PREFIX)
+        self.addCleanup(lambda: rmdir(self.tmp_dir))
+        self.repo_path = os.path.join(self.tmp_dir, "repo")
+        os.makedirs(self.repo_path)
+        self.project_file = os.path.join(self.repo_path, "repo.sublime-project")
+        self.project_data = {
+            "folders": [
+                {"path": self.repo_path},
+                {"path": ".", "folder_exclude_patterns": [".git"]}
+            ]
+        }
+
+    def test_copies_an_untracked_local_project(self):
+        repo = WorktreeCreationTestRepo(
+            self.repo_path, self.project_file, self.project_data
+        )
+        worktree_path = os.path.join(self.tmp_dir, "worktree")
+
+        repo.create_new_worktree("abc123", worktree_path)
+
+        with open(os.path.join(worktree_path, "repo.sublime-project"), encoding="utf-8") as file:
+            copied_data = sublime.decode_value(file.read())
+        self.assertEqual(copied_data, {
+            "folders": [
+                {"path": "."},
+                {"path": ".", "folder_exclude_patterns": [".git"]}
+            ]
+        })
+        self.assertEqual(self.project_data["folders"][0]["path"], self.repo_path)
+
+    def test_respects_the_copy_project_setting(self):
+        repo = WorktreeCreationTestRepo(
+            self.repo_path, self.project_file, self.project_data,
+            copy_project=False
+        )
+        worktree_path = os.path.join(self.tmp_dir, "worktree")
+
+        repo.create_new_worktree("abc123", worktree_path)
+
+        self.assertFalse(os.path.exists(os.path.join(worktree_path, "repo.sublime-project")))
+
+    def test_does_not_copy_a_non_local_project(self):
+        repo = WorktreeCreationTestRepo(
+            self.repo_path,
+            os.path.join(self.tmp_dir, "another-repo", "repo.sublime-project"),
+            self.project_data
+        )
+        worktree_path = os.path.join(self.tmp_dir, "worktree")
+
+        repo.create_new_worktree("abc123", worktree_path)
+
+        self.assertFalse(os.path.exists(os.path.join(worktree_path, "repo.sublime-project")))
+
+    def test_does_not_copy_a_tracked_project(self):
+        repo = WorktreeCreationTestRepo(
+            self.repo_path, self.project_file, self.project_data,
+            tracked=True
+        )
+        worktree_path = os.path.join(self.tmp_dir, "worktree")
+
+        repo.create_new_worktree("abc123", worktree_path)
+
+        self.assertFalse(os.path.exists(os.path.join(worktree_path, "repo.sublime-project")))
+
+    def test_does_not_overwrite_a_project_from_the_start_point(self):
+        repo = WorktreeCreationTestRepo(
+            self.repo_path, self.project_file, self.project_data,
+            checked_out_project="from the start point"
+        )
+        worktree_path = os.path.join(self.tmp_dir, "worktree")
+
+        repo.create_new_worktree("abc123", worktree_path)
+
+        with open(os.path.join(worktree_path, "repo.sublime-project"), encoding="utf-8") as file:
+            self.assertEqual(file.read(), "from the start point")
+
+
+class WorktreeCreationTestRepo(WorktreesMixin):
+    def __init__(
+        self,
+        repo_path,
+        project_file,
+        project_data,
+        *,
+        tracked=False,
+        checked_out_project=None,
+        copy_project=True
+    ):
+        self._repo_path = repo_path
+        self._savvy_settings = {
+            "copy_active_project_file_to_new_worktrees": copy_project
+        }
+        self.window = WorktreeCreationTestWindow(project_file, project_data)
+        self.tracked = tracked
+        self.checked_out_project = checked_out_project
+
+    @property
+    def repo_path(self):
+        return self._repo_path
+
+    def git(self, command, *args, **kwargs):
+        if command == "worktree":
+            worktree_path = args[1]
+            os.makedirs(worktree_path)
+            if self.checked_out_project is not None:
+                filename = os.path.basename(self.window.project_file_name())
+                with open(os.path.join(worktree_path, filename), "w", encoding="utf-8") as file:
+                    file.write(self.checked_out_project)
+            return ""
+        if command == "ls-files":
+            return "tracked\0" if self.tracked else ""
+        raise AssertionError("Unexpected git command: {} {}".format(command, args))
+
+
+class WorktreeCreationTestWindow:
+    def __init__(self, project_file, project_data):
+        self.project_file = project_file
+        self.data = project_data
+
+    def project_file_name(self):
+        return self.project_file
+
+    def project_data(self):
+        return self.data
 
 
 class WorktreesTestRepo(WorktreesMixin):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,60 @@
+import os
+
 from unittesting import DeferrableTestCase
 
+from GitSavvy.core import utils
 from GitSavvy.core.caches import (
     cached_until_focus_switch,
     until_focus_switch_cache,
 )
+from GitSavvy.tests.mockito import expect, mock, patch, unstub, verify, when
+
+
+class TestOpenWorktreeInNewWindow(DeferrableTestCase):
+    def tearDown(self):
+        unstub()
+
+    def test_opens_a_single_project_and_calls_back_with_the_new_window(self):
+        path = "/repo"
+        project_file = os.path.join(path, "repo.sublime-project")
+        source_window = mock()
+        project_window = mock()
+        callback = mock()
+
+        when(utils).glob(os.path.join(path, "*.sublime-project")).thenReturn([project_file])
+        when(utils.sublime).windows().thenReturn(
+            [source_window],
+            [source_window, project_window]
+        )
+        when(utils.sublime).active_window().thenReturn(source_window)
+        when(project_window).project_file_name().thenReturn(project_file)
+        expect(source_window).run_command("open_project_or_workspace", {
+            "file": project_file,
+            "new_window": True
+        }).thenReturn(None)
+        expect(callback).on_open(project_window).thenReturn(None)
+        patch(utils.runtime.on_worker, lambda fn: fn)
+
+        utils.open_worktree_in_new_window(path, then=callback.on_open)
+
+        verify(source_window).run_command("open_project_or_workspace", {
+            "file": project_file,
+            "new_window": True
+        })
+        verify(callback).on_open(project_window)
+
+    def test_falls_back_if_the_project_file_is_not_unique(self):
+        path = "/repo"
+        callback = mock()
+        when(utils).glob(os.path.join(path, "*.sublime-project")).thenReturn([
+            os.path.join(path, "one.sublime-project"),
+            os.path.join(path, "two.sublime-project")
+        ])
+        expect(utils).open_folder_in_new_window(path, then=callback).thenReturn(None)
+
+        utils.open_worktree_in_new_window(path, then=callback)
+
+        verify(utils).open_folder_in_new_window(path, then=callback)
 
 
 class Repo:


### PR DESCRIPTION
* Allow renaming worktree directories
* Copy the current project file around after creating and opening a new worktree. This is beta and under the setting "copy_active_project_file_to_new_worktrees"