### PR TITLE
Split app and project settings

### DIFF
--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -277,7 +277,12 @@
     "pedantic_commit_warning_length": 20,
 
     /*
-        Change this to `false` to suppress Git status in ST3 status bar.
+        When set to `true`, GitSavvy will show detailed Git status in the status
+        bar.
+
+        To avoid showing both GitSavvy's and Sublime Text's Git status, set
+        "show_git_status_in_status_bar" to `false` in Sublime Text's standard
+        preferences.
      */
     "git_status_in_status_bar": true,
 

--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -1,9 +1,8 @@
 {
-    /*
-        Change this to `false` if you don't wish to be prompted when
-        discarding files.
-     */
-    "prompt_before_destructive_action": true,
+    // Project settings
+    //
+    // These application defaults can be overridden in a project file under
+    // "settings": { "GitSavvy": { ... } }.
 
     /*
         Uncomment the setting below to explicitly set which git binary
@@ -29,6 +28,107 @@
     */
     "env": {
     },
+
+    /*
+        When entering a tag message, this will be used if the message is empty.
+        The replacement value "{tag_name}" is optional, but recommended.
+
+        If this is configured with a literal `v` before the placeholder, e.g.
+        "v{tag_name}", GitSavvy will avoid doubling it for tag names that
+        already start with `v`.
+     */
+    "default_tag_message": "Tag {tag_name}",
+
+    /*
+        Ask for a tag message to annotate the tag only if the tag looks like
+        a version, e.g. "v2.31.2" or "2022.11.23".  All other tags are considered
+        private and don't need to get annotated as we never push them.
+        Set to `false` if you always want to get asked for a tag message.
+     */
+    "only_ask_to_annotate_versions": true,
+
+    /*
+        Format used by the smart tagger for repositories that use calendar
+        versioning instead of semantic versioning.  Available fields are
+        {year}, {month}, {day}, {hour}, {minute}, and {second}; all numeric
+        fields are zero-padded.
+     */
+    "calendar_version_style": "{year}.{month}.{day}",
+
+    /*
+        The filename for extra customized info to be displayed after the default
+        COMMIT_HELP_TEXT, such as commit message rules/tips/conventions.
+        Place this file at the root of the repo, and it should be committed to the
+        repo as well.
+        The file name defaults to `.commit_help`.
+        If this file is not presented, the functionality is totally ignored.
+     */
+    "commit_help_extra_file": ".commit_help",
+
+    /*
+        For each command specified, always include the command line flags
+        indicated in the global_flags option AFTER the command.
+     */
+    "global_flags": {
+        // --no-columns is not supported in Git versions <1.7.11.  If Git is configured
+        //   to use columns globally, --no-columns should be added here.
+        // "branch": ["--no-columns"]
+        //
+        // or, configure a GPG key to sign commits with a given key
+        // "commit": ["-S", "--gpg-sign=<key-id>"]
+    },
+
+    /*
+        For each command specified, always include the command line flags
+        indicated in the global_flags option BEFORE the command.
+     */
+    "global_pre_flags": {
+        // for example, override settings via the "-c" option, e.g
+        // the following configures a gpg.program no-tty wrapper script
+        // "commit": ["-c", "gpg.program=./scripts/stgpg.sh"]
+        // and configure every commit to be signed with your key
+        // "commit": ["-c", "commit.gpgsign=true"]
+    },
+
+    /*
+        When set to `true`, GitSavvy will follow file renames when running git log/graph
+    */
+    "log_follow_rename": true,
+
+    /*
+        When set to `true`, GitSavvy will display git-flow integration commands.
+    */
+    "show_git_flow_commands": false,
+
+    /*
+        The default base for the rebase dashboard.
+    */
+    "rebase_default_base_ref": "",
+
+    /*
+        When set to `true`, rebase dashboard uses preserve-merges mode when opened.
+    */
+    "rebase_preserve_merges": false,
+
+    /*
+        This encoding will be used whenever Git's output cannot be correctly parsed
+        as UTF-8.  Modify this value if you regularly work with files and Git history
+        with a different text encoding.
+
+        Example:
+            "fallback_encoding": "gbk"
+     */
+    "fallback_encoding": "windows-1252",
+
+    //
+    // Application wide settings
+    //
+
+    /*
+        Change this to `false` if you don't wish to be prompted when
+        discarding files.
+     */
+    "prompt_before_destructive_action": true,
 
     /*
         Change this to `true` when doing dev work on GitSavvy.
@@ -182,67 +282,6 @@
     "git_status_in_status_bar": true,
 
     /*
-        When entering a tag message, this will be used if the message is empty.
-        The replacement value "{tag_name}" is optional, but recommended.
-
-        If this is configured with a literal `v` before the placeholder, e.g.
-        "v{tag_name}", GitSavvy will avoid doubling it for tag names that
-        already start with `v`.
-     */
-    "default_tag_message": "Tag {tag_name}",
-
-    /*
-        Ask for a tag message to annotate the tag only if the tag looks like
-        a version, e.g. "v2.31.2" or "2022.11.23".  All other tags are considered
-        private and don't need to get annotated as we never push them.
-        Set to `false` if you always want to get asked for a tag message.
-     */
-    "only_ask_to_annotate_versions": true,
-
-    /*
-        Format used by the smart tagger for repositories that use calendar
-        versioning instead of semantic versioning.  Available fields are
-        {year}, {month}, {day}, {hour}, {minute}, and {second}; all numeric
-        fields are zero-padded.
-     */
-    "calendar_version_style": "{year}.{month}.{day}",
-
-    /*
-        The filename for extra customized info to be displayed after the default
-        COMMIT_HELP_TEXT, such as commit message rules/tips/conventions.
-        Place this file at the root of the repo, and it should be committed to the
-        repo as well.
-        The file name defaults to `.commit_help`.
-        If this file is not presented, the functionality is totally ignored.
-     */
-    "commit_help_extra_file": ".commit_help",
-
-    /*
-        For each command specified, always include the command line flags
-        indicated in the global_flags option AFTER the command.
-     */
-    "global_flags": {
-        // --no-columns is not supported in Git versions <1.7.11.  If Git is configured
-        //   to use columns globally, --no-columns should be added here.
-        // "branch": ["--no-columns"]
-        //
-        // or, configure a GPG key to sign commits with a given key
-        // "commit": ["-S", "--gpg-sign=<key-id>"]
-    },
-
-    /*
-        For each command specified, always include the command line flags
-        indicated in the global_flags option BEFORE the command.
-     */
-    "global_pre_flags": {
-        // for example, override settings via the "-c" option, e.g
-        // the following configures a gpg.program no-tty wrapper script
-        // "commit": ["-c", "gpg.program=./scripts/stgpg.sh"]
-        // and configure every commit to be signed with your key
-        // "commit": ["-c", "commit.gpgsign=true"]
-    },
-
-    /*
         Sort branches by recency.
         Change this to `true` to sort branches by "committerdate".
         Change this to `false` to sort branches by their name.
@@ -283,11 +322,6 @@
     "show_full_commit_info": true,
 
     /*
-        When set to `true`, GitSavvy will follow file renames when running git log/graph
-    */
-    "log_follow_rename": true,
-
-    /*
         Set it to "file", "commit" or "all_commits" to specify the default detection
         method for the blame view.
     */
@@ -299,21 +333,6 @@
         the commit message view. Ignored when "commit_on_close" is true.
     */
     "prompt_on_abort_commit": true,
-
-    /*
-        When set to `true`, GitSavvy will display git-flow integration commands.
-    */
-    "show_git_flow_commands": false,
-
-    /*
-        The default base for the rebase dashboard.
-    */
-    "rebase_default_base_ref": "",
-
-    /*
-        When set to `true`, rebase dashboard uses preserve-merges mode when opened.
-    */
-    "rebase_preserve_merges": false,
 
     /*
         When set to `true`, GitSavvy will prompt for confirmation before actually
@@ -332,16 +351,6 @@
         The same is also true for amending commits.
      */
     "commit_on_close": false,
-
-    /*
-        This encoding will be used whenever Git's output cannot be correctly parsed
-        as UTF-8.  Modify this value if you regularly with files and Git history
-        with a different text encoding.
-
-        Example:
-            "fallback_encoding": "gbk"
-     */
-    "fallback_encoding": "windows-1252",
 
     /*
         This setting should only be set to true in the following conditions:

--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -299,8 +299,9 @@
     "max_items_in_tags_dashboard": null,
 
     /*
-        When set to `true`, GitSavvy will automatically display more info about the
-        current commit in a output panel.
+        When set to `true`, GitSavvy will show a preview in an output panel while
+        navigating commit lists, such as those shown by log, cherry-pick, revert,
+        reset, fixup, and checkout commands.
      */
     "log_show_more_commit_info": true,
 

--- a/common/commands/debug.py
+++ b/common/commands/debug.py
@@ -8,7 +8,7 @@ import sublime
 from sublime_plugin import WindowCommand
 
 from ..util import debug
-from ...core.settings import GitSavvySettings
+from ...core.settings import app_settings
 from ...core.view import replace_view_content
 
 
@@ -39,7 +39,7 @@ class gs_reload_modules_debug(WindowCommand):
         )
 
     def is_visible(self):
-        return GitSavvySettings().get("dev_mode")
+        return app_settings.get("dev_mode")
 
 
 class gs_start_logging(WindowCommand):

--- a/common/commands/view_manipulation.py
+++ b/common/commands/view_manipulation.py
@@ -16,9 +16,9 @@ class gs_handle_vintageous(TextCommand, GitCommand):
     """
 
     def run(self, edit):
-        if self.savvy_settings.get("vintageous_friendly"):
+        if self.app_settings.get("vintageous_friendly"):
             self.view.settings().set("git_savvy.vintageous_friendly", True)
-            if self.savvy_settings.get("vintageous_enter_insert_mode"):
+            if self.app_settings.get("vintageous_enter_insert_mode"):
                 self.view.settings().set("vintageous_reset_mode_when_switching_tabs", False)
                 # NeoVintageous renamed the command starting with v1.22.0.
                 # We call both commands for backwards compatibility.
@@ -34,5 +34,5 @@ class gs_handle_arrow_keys(TextCommand, GitCommand):
     """
 
     def run(self, edit):
-        if self.savvy_settings.get("arrow_keys_navigation"):
+        if self.app_settings.get("arrow_keys_navigation"):
             self.view.settings().set("git_savvy.arrow_keys_navigation", True)

--- a/common/util/actions.py
+++ b/common/util/actions.py
@@ -2,7 +2,7 @@ from functools import wraps
 
 import sublime
 
-from ...core.settings import GitSavvySettings
+from ...core.settings import app_settings
 
 from typing import Callable, Optional, TypeVar, TYPE_CHECKING
 T = TypeVar('T')
@@ -16,7 +16,7 @@ def destructive(description: str) -> "Callable[[Callable[P, T]], Callable[P, Opt
     def decorator(fn: "Callable[P, T]") -> "Callable[P, Optional[T]]":
         @wraps(fn)
         def wrapped_fn(*args: "P.args", **kwargs: "P.kwargs") -> Optional[T]:
-            if GitSavvySettings().get("prompt_before_destructive_action"):
+            if app_settings.get("prompt_before_destructive_action"):
                 message = (
                     "You are about to {desc}.  "
                     "This is a destructive action.  \n\n"

--- a/common/util/view.py
+++ b/common/util/view.py
@@ -2,7 +2,7 @@ from collections import ChainMap
 import bisect
 
 import sublime
-from ...core.settings import GitSavvySettings
+from ...core.settings import app_settings
 from ...core.view import place_view
 
 
@@ -221,7 +221,7 @@ def get_instance_after_pt(view, pt, pattern):
 def disable_other_plugins(view):
     # Disable key-bindings for Vitageous
     # https://github.com/guillermooo/Vintageous/wiki/Disabling
-    if GitSavvySettings().get("vintageous_friendly", False) is False:
+    if app_settings.get("vintageous_friendly", False) is False:
         view.settings().set("__vi_external_disable", False)
 
 

--- a/core/commands/blame.py
+++ b/core/commands/blame.py
@@ -467,7 +467,7 @@ class gs_blame_refresh(GsTextCommand):
 
         within_what = settings.get("git_savvy.blame_view.detect_move_or_copy_within")
         if not within_what:
-            within_what = self.savvy_settings.get("blame_detect_move_or_copy_within")
+            within_what = self.app_settings.get("blame_detect_move_or_copy_within")
 
         blame_format = blame_format_for_view(self.view)
         remember_blame_format(blame_format)

--- a/core/commands/checkout.py
+++ b/core/commands/checkout.py
@@ -170,7 +170,7 @@ class gs_checkout_current_file_at_commit(LogMixin, WindowCommand, GitCommand):
             super().run(file_path=self.file_path)
 
     def on_highlight(self, commit, file_path=None):
-        if not self.savvy_settings.get("log_show_more_commit_info", True):
+        if not self.app_settings.get("log_show_more_commit_info", True):
             return
         if commit:
             self.window.run_command('gs_show_file_diff', {

--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -142,9 +142,9 @@ class gs_commit(WindowCommand, GitCommand):
             settings.set("git_savvy.commit_view.automatically_switched_to_all", False)
             settings.set("git_savvy.diff_view.in_cached_mode", not include_unstaged)
             settings.set("git_savvy.commit_view.amend", amend)
-            commit_on_close = self.savvy_settings.get("commit_on_close")
+            commit_on_close = self.app_settings.get("commit_on_close")
             settings.set("git_savvy.commit_on_close", commit_on_close)
-            prompt_on_abort_commit = self.savvy_settings.get("prompt_on_abort_commit")
+            prompt_on_abort_commit = self.app_settings.get("prompt_on_abort_commit")
             settings.set("git_savvy.prompt_on_abort_commit", prompt_on_abort_commit)
             util.view.mark_as_lintable(view)
 
@@ -182,7 +182,7 @@ class gs_commit(WindowCommand, GitCommand):
 
         initial_text += "\n\n" + generate_help_text(view)
 
-        commit_help_extra_file = self.savvy_settings.get("commit_help_extra_file") or ".commit_help"
+        commit_help_extra_file = self.project_settings.get("commit_help_extra_file") or ".commit_help"
         commit_help_extra_path = self.to_full_path(commit_help_extra_file)
         if os.path.exists(commit_help_extra_path):
             with util.file.safe_open(commit_help_extra_path, "r", encoding="utf-8") as f:
@@ -227,12 +227,12 @@ class gs_prepare_commit_refresh_diff(TextCommand, GitCommand):
         automatically_switched_to_all = settings.get(
             "git_savvy.commit_view.automatically_switched_to_all")
         amend = settings.get("git_savvy.commit_view.amend")
-        show_commit_diff = self.savvy_settings.get("show_commit_diff")
+        show_commit_diff = self.app_settings.get("show_commit_diff")
         # for backward compatibility, check also if show_commit_diff is True
         show_patch = show_commit_diff is True or show_commit_diff == "full"
         show_stat = (
             show_commit_diff == "stat"
-            or (show_commit_diff == "full" and self.savvy_settings.get("show_diffstat"))
+            or (show_commit_diff == "full" and self.app_settings.get("show_diffstat"))
         )
 
         try:
@@ -468,14 +468,14 @@ class GsPedanticEnforceEventListener(EventListener, SettingsMixin):
         if 'make_commit' not in view.settings().get('syntax', ''):
             return
 
-        if not self.savvy_settings.get('pedantic_commit'):
+        if not self.app_settings.get('pedantic_commit'):
             return
 
-        subject_line_limit = self.savvy_settings.get('pedantic_commit_first_line_length')
-        body_line_limit = self.savvy_settings.get('pedantic_commit_message_line_length')
-        warning_length = self.savvy_settings.get('pedantic_commit_warning_length')
+        subject_line_limit = self.app_settings.get('pedantic_commit_first_line_length')
+        body_line_limit = self.app_settings.get('pedantic_commit_message_line_length')
+        warning_length = self.app_settings.get('pedantic_commit_warning_length')
 
-        if self.savvy_settings.get('pedantic_commit_ruler'):
+        if self.app_settings.get('pedantic_commit_ruler'):
             rulers = self.find_rulers(view, subject_line_limit, body_line_limit)
             view.settings().set("rulers", rulers)
 

--- a/core/commands/context_menu.py
+++ b/core/commands/context_menu.py
@@ -28,7 +28,7 @@ class CommandContext:
 
     @cached_property
     def enabled(self) -> bool:
-        return not self._cmd.savvy_settings.get("disable_context_menus")
+        return not self._cmd.app_settings.get("disable_context_menus")
 
     @cached_property
     def sel(self) -> List[sublime.Region]:

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -254,7 +254,7 @@ class gs_diff(WindowCommand, GitCommand):
                 title = (DIFF_CACHED_TITLE if in_cached_mode else DIFF_TITLE).format(
                     os.path.basename(file_path) if file_path else os.path.basename(repo_path)
                 )
-            show_diffstat = self.savvy_settings.get("show_diffstat", True)
+            show_diffstat = self.app_settings.get("show_diffstat", True)
             diff_view = util.view.create_scratch_view(self.window, "diff", {
                 "title": title,
                 "syntax": "Packages/GitSavvy/syntax/diff_view.sublime-syntax",

--- a/core/commands/flow.py
+++ b/core/commands/flow.py
@@ -27,7 +27,7 @@ class FlowMixin(GsWindowCommand):
             show_noop_panel(self.window, INIT_REQUIRED_MSG)
 
     def is_visible(self, **kwargs):
-        return self.savvy_settings.get("show_git_flow_commands") or False
+        return self.project_settings.get("show_git_flow_commands") or False
 
     def get_flow_settings(self):
         flow_ver = self.git("flow", "version")

--- a/core/commands/init.py
+++ b/core/commands/init.py
@@ -51,7 +51,7 @@ class gs_offer_init(WindowCommand, GitCommand):
     """
 
     def run(self):
-        if self.savvy_settings.get("disable_git_init_prompt"):
+        if self.app_settings.get("disable_git_init_prompt"):
             return
 
         view = self.window.active_view()

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -388,7 +388,7 @@ class gs_inline_diff_refresh(TextCommand, GitCommand):
         in_cached_mode = settings.get("git_savvy.inline_diff_view.in_cached_mode")
         base_commit = settings.get("git_savvy.inline_diff_view.base_commit")
         target_commit = settings.get("git_savvy.inline_diff_view.target_commit")
-        ignore_eol_ws = self.savvy_settings.get("inline_diff_ignore_eol_whitespaces", True)
+        ignore_eol_ws = self.app_settings.get("inline_diff_ignore_eol_whitespaces", True)
         if target_commit and not base_commit:
             target_commit = "{}^".format(target_commit)
 
@@ -468,7 +468,7 @@ class gs_inline_diff_refresh(TextCommand, GitCommand):
         navigate_to_first_hunk = (
             match_position is None
             and view.size() == 0  # t.i. only on the initial draw!
-            and self.savvy_settings.get("inline_diff_auto_scroll", True)
+            and self.app_settings.get("inline_diff_auto_scroll", True)
         )
 
         with reapply_possible_fold(view):
@@ -752,7 +752,7 @@ class gs_inline_diff_stage_or_reset_base(TextCommand, GitCommand):
 
         ignore_ws = (
             "--ignore-whitespace"
-            if self.savvy_settings.get("inline_diff_ignore_eol_whitespaces", True)
+            if self.app_settings.get("inline_diff_ignore_eol_whitespaces", True)
             else None
         )
         frozen_sel = [s for s in self.view.sel()]

--- a/core/commands/log.py
+++ b/core/commands/log.py
@@ -49,7 +49,7 @@ class LogMixin(GitCommand):
     def run_async(self, *, file_path=None, **kwargs):
         follow = kwargs.pop(
             "follow",
-            self.savvy_settings.get("log_follow_rename") if file_path else False
+            self.project_settings.get("log_follow_rename") if file_path else False
         )
         entries = self.log_generator(file_path=file_path, follow=follow, **kwargs)
         # `on_highlight` gets called on `on_done` as well with the same
@@ -96,7 +96,7 @@ class LogMixin(GitCommand):
     def on_highlight(self, commit, file_path=None):
         if not commit:
             return
-        if not self.savvy_settings.get("log_show_more_commit_info", True):
+        if not self.app_settings.get("log_show_more_commit_info", True):
             return
         window = self._current_window()
         if window:
@@ -300,7 +300,7 @@ class gs_log_action(PanelActionMixin, WindowCommand):
         assert self._file_path
         file_path = (
             self.filename_at_commit(self._file_path, self._commit_hash)
-            if self.savvy_settings.get("log_follow_rename") else
+            if self.project_settings.get("log_follow_rename") else
             self._file_path
         )
         self.checkout_ref(self._commit_hash, fpath=file_path)

--- a/core/commands/log_graph_main_actions.py
+++ b/core/commands/log_graph_main_actions.py
@@ -748,7 +748,7 @@ class gs_log_graph_action(WindowCommand, GitCommand):
     def checkout_file_at_commit(self, commit_hash: str, file_path: FullPath):
         file_path = (
             self.filename_at_commit(file_path, commit_hash)
-            if self.savvy_settings.get("log_follow_rename") else
+            if self.project_settings.get("log_follow_rename") else
             file_path
         )
         self.checkout_ref(commit_hash, fpath=file_path)

--- a/core/commands/log_graph_renderer.py
+++ b/core/commands/log_graph_renderer.py
@@ -964,7 +964,7 @@ class gs_log_graph_refresh(GsTextCommand):
 
             return args
 
-        follow = self.savvy_settings.get("log_follow_rename")
+        follow = self.project_settings.get("log_follow_rename")
         all_branches = settings.get("git_savvy.log_graph_view.all_branches")
         branches = settings.get("git_savvy.log_graph_view.branches")
         paths = settings.get("git_savvy.log_graph_view.paths", [])  # type: List[str]

--- a/core/commands/push.py
+++ b/core/commands/push.py
@@ -41,7 +41,7 @@ class PushMixin(GsWindowCommand):
         """
         Perform `git push remote branch`.
         """
-        if self.savvy_settings.get("confirm_force_push", True):
+        if self.app_settings.get("confirm_force_push", True):
             if force:
                 if not sublime.ok_cancel_dialog(CONFIRM_FORCE_PUSH.format("--force")):
                     return

--- a/core/commands/remote.py
+++ b/core/commands/remote.py
@@ -65,7 +65,7 @@ class gs_remote_add(GsWindowCommand):
             self.update_store({"last_remote_used_for_push": remote_name})
 
         util.view.refresh_gitsavvy_interfaces(self.window, refresh_status_bar=False)
-        if self.savvy_settings.get("fetch_new_remotes", True) or sublime.ok_cancel_dialog(
+        if self.app_settings.get("fetch_new_remotes", True) or sublime.ok_cancel_dialog(
             "Your remote was added successfully.  "
             "Would you like to fetch from this remote?"
         ):

--- a/core/commands/reset.py
+++ b/core/commands/reset.py
@@ -32,7 +32,7 @@ class ResetMixin(GsWindowCommand):
             return
         self._selected_hash = commit_hash
 
-        use_reset_mode = self.savvy_settings.get("use_reset_mode")
+        use_reset_mode = self.app_settings.get("use_reset_mode")
         last_reset_mode_used = \
             self.current_state().get("last_reset_mode_used", use_reset_mode)
         reset_modes = (

--- a/core/commands/show_commit.py
+++ b/core/commands/show_commit.py
@@ -84,7 +84,7 @@ class gs_show_commit(WindowCommand, GitCommand):
                 "git_savvy.show_commit_view.commit": commit_hash,
                 "git_savvy.show_commit_view.ignore_whitespace": False,
                 "git_savvy.show_commit_view.show_diffstat":
-                    self.savvy_settings.get("show_diffstat", True),
+                    self.app_settings.get("show_diffstat", True),
                 "result_file_regex": diff.FILE_RE,
                 "result_line_regex": diff.LINE_RE,
                 "result_base_dir": repo_path,

--- a/core/commands/show_commit_info.py
+++ b/core/commands/show_commit_info.py
@@ -95,8 +95,8 @@ class gs_show_commit_info(WindowCommand, GitCommand):
         settings.set("result_base_dir", self.repo_path)
 
         if commit_hash:
-            show_patch = self.savvy_settings.get("show_full_commit_info")
-            show_diffstat = self.savvy_settings.get("show_diffstat")
+            show_patch = self.app_settings.get("show_full_commit_info")
+            show_diffstat = self.app_settings.get("show_diffstat")
             text = (
                 self._read_commit_for_file(commit_hash, file_path, show_diffstat, show_patch, settings)
                 if file_path else

--- a/core/commands/show_file_at_commit.py
+++ b/core/commands/show_file_at_commit.py
@@ -774,8 +774,8 @@ class gs_show_file_at_commit_open_info_popup(GsTextCommand):
         # type: (...) -> None
         settings = self.view.settings()
         commit_hash = settings.get("git_savvy.show_file_at_commit_view.commit")
-        show_patch = self.savvy_settings.get("show_full_commit_info")
-        show_diffstat = self.savvy_settings.get("show_diffstat")
+        show_patch = self.app_settings.get("show_full_commit_info")
+        show_diffstat = self.app_settings.get("show_diffstat")
         text = self.read_commit(commit_hash, None, show_diffstat, show_patch)
 
         prelude = re.split(r"^diff", text, 1, re.M)[0].rstrip()

--- a/core/commands/status_bar.py
+++ b/core/commands/status_bar.py
@@ -43,7 +43,7 @@ class gs_draw_status_bar(TextCommand, GitCommand):
 
     def run(self, edit, repo_path=None):
         view = self.view
-        if not self.savvy_settings.get("git_status_in_status_bar"):
+        if not self.app_settings.get("git_status_in_status_bar"):
             view.erase_status(STATUSBAR_KEY)
             return
 

--- a/core/commands/tag.py
+++ b/core/commands/tag.py
@@ -134,7 +134,7 @@ def ask_for_tag_message():
         if should_ask_for_tag_message(cmd, tag_name):
             show_single_line_input_panel(
                 TAG_CREATE_MESSAGE_PROMPT,
-                default_tag_message(cmd.savvy_settings.get("default_tag_message"), tag_name),
+                default_tag_message(cmd.project_settings.get("default_tag_message"), tag_name),
                 done
             )
         else:
@@ -144,7 +144,7 @@ def ask_for_tag_message():
 
 def should_ask_for_tag_message(cmd: GsCommand, tag_name: str) -> bool:
     return (
-        not cmd.savvy_settings.get("only_ask_to_annotate_versions")
+        not cmd.project_settings.get("only_ask_to_annotate_versions")
         or is_version_tag(tag_name)
     )
 
@@ -304,7 +304,7 @@ class gs_smart_tag(GsWindowCommand):
         ]
 
     def get_calendar_version_style(self) -> str:
-        style = self.savvy_settings.get("calendar_version_style")
+        style = self.project_settings.get("calendar_version_style")
         if not calendar_version_style_is_valid(style):
             print(
                 f"calendar_version_style is invalid. "

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -350,7 +350,7 @@ class _GitCommand(SettingsMixin):
         command_str = util.debug.pretty_git_command(command[1:])
 
         if show_panel is None:
-            show_panel = git_cmd in self.savvy_settings.get("show_panel_for")
+            show_panel = git_cmd in self.app_settings.get("show_panel_for")
 
         log = None
         if show_panel:
@@ -375,7 +375,7 @@ class _GitCommand(SettingsMixin):
             window.extract_variables(),
             os.environ
         )
-        savvy_env = self.savvy_settings.get("env") or {}
+        savvy_env = self.project_settings.get("env") or {}
         savvy_env_expanded = {
             k: sublime.expand_variables(v, vars_for_replace)
             for k, v in savvy_env.items()
@@ -554,7 +554,7 @@ class _GitCommand(SettingsMixin):
         return [
             'utf-8',
             locale.getpreferredencoding(),
-            self.savvy_settings.get("fallback_encoding")
+            self.project_settings.get("fallback_encoding")
         ]
 
     def strict_decode(self, input):
@@ -602,7 +602,7 @@ class _GitCommand(SettingsMixin):
         global binary_not_found_message_displayed, git_too_old_message_displayed
         global git_binaries
 
-        git_path_setting = self.savvy_settings.get("git_path")
+        git_path_setting = self.project_settings.get("git_path")
         git_path = (
             (
                 git_path_setting.get(sublime.platform())
@@ -859,8 +859,8 @@ class _GitCommand(SettingsMixin):
         Transforms the Git command arguments with flags indicated in the
         global GitSavvy settings.
         """
-        global_pre_flags = self.savvy_settings.get("global_pre_flags", {}).get(git_cmd, [])
-        global_flags = self.savvy_settings.get("global_flags", {}).get(git_cmd, [])
+        global_pre_flags = self.project_settings.get("global_pre_flags", {}).get(git_cmd, [])
+        global_flags = self.project_settings.get("global_flags", {}).get(git_cmd, [])
         return global_pre_flags + [git_cmd] + global_flags + args
 
 

--- a/core/git_mixins/stash.py
+++ b/core/git_mixins/stash.py
@@ -34,7 +34,7 @@ class StashMixin(mixin_base):
 
     def show_stash(self, id):
         # type: (StashId) -> str
-        show_diffstat = self.savvy_settings.get("show_diffstat", True)
+        show_diffstat = self.app_settings.get("show_diffstat", True)
         stash_name = "stash@{{{}}}".format(id)
         return self.git("stash", "show", "--no-color", "--stat" if show_diffstat else None, "-p", stash_name)
 

--- a/core/git_mixins/worktrees.py
+++ b/core/git_mixins/worktrees.py
@@ -103,7 +103,7 @@ class WorktreesMixin(mixin_base):
         #       computation.  Change when needed.
         project = (
             self._project_for_new_worktree()
-            if self.savvy_settings.get("copy_active_project_file_to_new_worktrees", True)
+            if self.app_settings.get("copy_active_project_file_to_new_worktrees", True)
             else None
         )
         if not worktree_path:

--- a/core/interfaces/__init__.py
+++ b/core/interfaces/__init__.py
@@ -32,7 +32,7 @@ class gs_tab_cycle(TextCommand, GitCommand):
                 self.view.close()
 
     def get_next(self, source, reverse=False):
-        tab_order = self.savvy_settings.get("tab_order")
+        tab_order = self.app_settings.get("tab_order")
 
         try:
             idx = tab_order.index(source)

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -184,9 +184,9 @@ class BranchInterface(ui.ReactiveInterface, GitCommand):
 
         self.update_state({
             'git_root': self.short_repo_path,
-            'sort_by_recent': self.savvy_settings.get("sort_by_recent_in_branch_dashboard"),
+            'sort_by_recent': self.app_settings.get("sort_by_recent_in_branch_dashboard"),
             'group_by_distance_to_head':
-                self.savvy_settings.get("group_by_distance_to_head_in_branch_dashboard"),
+                self.app_settings.get("group_by_distance_to_head_in_branch_dashboard"),
             'show_help': not self.view.settings().get("git_savvy.help_hidden"),
         })
 

--- a/core/interfaces/rebase.py
+++ b/core/interfaces/rebase.py
@@ -245,7 +245,7 @@ class RebaseInterface(ui.Interface, NearestBranchMixin, GitCommand):
                 skip_commit_key='k' if not vintageous_friendly else 'K')
 
     def preserve_merges(self):
-        default = self.savvy_settings.get("rebase_preserve_merges")
+        default = self.project_settings.get("rebase_preserve_merges")
         return not self.in_rebase_apply() and \
             (self.in_rebase_merge() or
              self.view.settings().get("git_savvy.rebase.preserve_merges", default))
@@ -332,7 +332,7 @@ class RebaseInterface(ui.Interface, NearestBranchMixin, GitCommand):
         base_ref = self.view.settings().get("git_savvy.rebase.base_ref")
 
         if not base_ref or reset_ref:
-            base_ref = self.savvy_settings.get("rebase_default_base_ref")
+            base_ref = self.project_settings.get("rebase_default_base_ref")
 
             if not base_ref:
                 # use remote tracking branch as a sane default
@@ -1003,7 +1003,7 @@ class gs_rebase_toggle_preserve_mode(RebaseInterfaceCommand):
     def run(self, edit):
         preserve = self.view.settings().get("git_savvy.rebase.preserve_merges", False)
         self.view.settings().set("git_savvy.rebase.preserve_merges", not preserve)
-        self.savvy_settings.set("rebase_preserve_merges", not preserve)
+        self.app_settings.set("rebase_preserve_merges", not preserve)
         util.view.refresh_gitsavvy(self.view)
 
 

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -180,7 +180,7 @@ class TagsInterface(ui.ReactiveInterface, GitCommand):
 
         self.update_state({
             'git_root': self.short_repo_path,
-            'max_items': self.savvy_settings.get("max_items_in_tags_dashboard", None),
+            'max_items': self.app_settings.get("max_items_in_tags_dashboard", None),
             'show_help': not self.view.settings().get("git_savvy.help_hidden"),
         })
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from functools import lru_cache
 import os
+from typing import Any
 
 import sublime
 import sublime_plugin
@@ -11,65 +12,125 @@ from GitSavvy.core.fns import maybe
 
 __all__ = (
     "ProjectFileChanges",
+    "ProjectSettings",
+    "app_settings",
 )
 
-from typing import Any, Dict
 
+class _AppSettings:
+    def __init__(self) -> None:
+        self._settings = settings = sublime.load_settings("GitSavvy.sublime-settings")
+        self._cache: dict[str, Any] = {}
+        settings.clear_on_change(__name__)
+        settings.add_on_change(__name__, self._on_update)
 
-class GitSavvySettings:
-    def __init__(self, window=None):
-        # type: (sublime.Window) -> None
-        self._window = window or sublime.active_window()
-        self._global_settings = get_global_settings()
-
-    def get(self, key, default=None):
+    def get(self, name: str, default: Any = None) -> Any:
         try:
-            return get_project_settings(self._window)[key]
+            return self._cache[name]
         except KeyError:
-            return self._global_settings.get(key, default)
+            current_value: Any = self._settings.get(name, default)
+            self._cache[name] = current_value
+            return current_value
 
-    def set(self, key, value):
-        self._global_settings.set(key, value)
+    def set(self, name: str, value: Any) -> None:
+        self._settings.set(name, value)  # implicitly calls `_on_update` to clear cache
+
+    def has(self, name: str) -> bool:
+        return self._settings.has(name)
+
+    def _on_update(self) -> None:
+        self._cache.clear()
 
 
-CHANGE_COUNT = 0
+app_settings = _AppSettings()
+
+
+class ProjectSettings:
+    _instances: dict[sublime.WindowId, ProjectSettings] = {}
+    _window: sublime.Window
+    _change_count: int
+    _settings: dict[str, Any]
+
+    def __new__(cls, window: sublime.Window) -> ProjectSettings:
+        window_id = window.id()
+        instance = cls._instances.get(window_id)
+        if instance is None:
+            instance = super().__new__(cls)
+            instance._window = window
+            instance._change_count = -1
+            instance._settings = {}
+            cls._instances[window_id] = instance
+        return instance
+
+    def __init__(self, window: sublime.Window) -> None:
+        pass
+
+    def get(self, key: str, default: Any = None) -> Any:
+        if self._change_count != PROJECT_FILE_CHANGE_COUNT:
+            self._reload()
+
+        try:
+            return self._settings[key]
+        except KeyError:
+            return app_settings.get(key, default)
+
+    @classmethod
+    def forget_window(cls, window_id: sublime.WindowId) -> None:
+        cls._instances.pop(window_id, None)
+
+    def _reload(self) -> None:
+        project_data = self._window.project_data() or {}
+        self._settings = project_data.get("settings", {}).get("GitSavvy", {}) or {}
+        self._change_count = PROJECT_FILE_CHANGE_COUNT
+
+
+class SettingsMixin:
+    _project_settings: ProjectSettings | None = None
+
+    @property
+    def app_settings(self) -> _AppSettings:
+        return app_settings
+
+    @property
+    def project_settings(self) -> ProjectSettings:
+        if self._project_settings is None:
+            self._project_settings = ProjectSettings(self.some_window())
+        return self._project_settings
+
+    def default_project_root(self) -> str:
+        default_root = self.app_settings.get("users_home") or "~"
+        if os.name == "nt" and default_root == "~":
+            default_root = R"~\Desktop"
+        return os.path.expanduser(default_root)
+
+    def some_window(self) -> sublime.Window:
+        return (
+            maybe(lambda: self.window)  # type: ignore[attr-defined]
+            or maybe(lambda: self.view.window())  # type: ignore[attr-defined]
+            or sublime.active_window()
+        )
+
+
+PROJECT_FILE_CHANGE_COUNT = 0
 
 
 class ProjectFileChanges(sublime_plugin.EventListener):
-    def on_post_save(self, view):
-        # type: (sublime.View) -> None
-        global CHANGE_COUNT
+    def on_post_save(self, view: sublime.View) -> None:
+        global PROJECT_FILE_CHANGE_COUNT
         file_path = view.file_name()
         if file_path and file_path.endswith(".sublime-project"):
-            CHANGE_COUNT += 1
+            PROJECT_FILE_CHANGE_COUNT += 1
 
-
-def get_project_settings(window):
-    # type: (sublime.Window) -> Dict
-    global CHANGE_COUNT
-    return _get_project_settings(window.id(), CHANGE_COUNT)
-
-
-@lru_cache(maxsize=16)
-def _get_project_settings(wid, _counter):
-    # type: (sublime.WindowId, int) -> Dict
-    window = sublime.Window(wid)
-    project_data = window.project_data()
-    if not project_data:
-        return {}
-    return project_data.get("settings", {}).get("GitSavvy", {})
-
-
-@lru_cache(maxsize=1)
-def get_global_settings():
-    return GlobalSettings("GitSavvy.sublime-settings")
+    def on_pre_close_window(self, window: sublime.Window) -> None:
+        window_id = window.id()
+        sublime.set_timeout(lambda: ProjectSettings.forget_window(window_id))
 
 
 def color_value(namespace: str, key: str) -> str:
-    app_settings = get_global_settings().get("colors", {})
+    colors = app_settings.get("colors", {})
     default_settings = read_default_settings()["colors"]
     try:
-        return app_settings[namespace][key]
+        return colors[namespace][key]
     except KeyError:
         return default_settings[namespace][key]
 
@@ -78,49 +139,3 @@ def color_value(namespace: str, key: str) -> str:
 def read_default_settings() -> dict[str, Any]:
     path = "Packages/GitSavvy/GitSavvy.sublime-settings"
     return sublime.decode_value(sublime.load_resource(path))
-
-
-class GlobalSettings:
-    def __init__(self, name):
-        self._settings = s = sublime.load_settings(name)
-        s.clear_on_change(name)
-        s.add_on_change(name, self._on_update)
-        self._cache = {}
-
-    def get(self, name, default=None):
-        try:
-            return self._cache[name]
-        except KeyError:
-            self._cache[name] = current_value = self._settings.get(name, default)  # type: ignore[var-annotated]
-            return current_value
-
-    def set(self, name, value):
-        self._settings.set(name, value)  # implicitly calls `_on_update` to clear cache
-
-    def _on_update(self):
-        self._cache.clear()
-
-
-class SettingsMixin:
-    _savvy_settings = None
-
-    @property
-    def savvy_settings(self):
-        if not self._savvy_settings:
-            window = self.some_window()
-            self._savvy_settings = GitSavvySettings(window)
-        return self._savvy_settings
-
-    def some_window(self):
-        # type: () -> sublime.Window
-        return (
-            maybe(lambda: self.window)  # type: ignore[attr-defined]
-            or maybe(lambda: self.view.window())  # type: ignore[attr-defined]
-            or sublime.active_window()
-        )
-
-    def default_project_root(self) -> str:
-        default_root = self.savvy_settings.get("users_home") or "~"
-        if os.name == "nt" and default_root == "~":
-            default_root = R"~\Desktop"
-        return os.path.expanduser(default_root)

--- a/git_savvy.py
+++ b/git_savvy.py
@@ -78,6 +78,7 @@ with reloader():
     from .common.ui import *
     from .common.global_events import *
     from .core.commands import *
+    from .core.settings import _AppSettings, app_settings
     from .core.settings import *
     from .core.interfaces import *
     from .core.runtime import *
@@ -86,7 +87,7 @@ with reloader():
     from .gitlab.commands import *
 
 
-UNUSED_GLOBAL_SETTINGS = (
+UNUSED_APP_SETTINGS = (
     "graph_show_more_commit_info",
     "hide_help_menu",
     "show_remotes_in_branch_dashboard",
@@ -122,14 +123,13 @@ def prepare_gitsavvy() -> None:
 
     sublime.set_timeout_async(prepare_views)
 
-    savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
-    warn_about_unused_global_settings(savvy_settings)
-    if savvy_settings.get("load_additional_codecs"):
+    warn_about_unused_app_settings(app_settings)
+    if app_settings.get("load_additional_codecs"):
         sublime.set_timeout_async(reload_codecs)
 
 
-def warn_about_unused_global_settings(settings: sublime.Settings) -> None:
-    for key in UNUSED_GLOBAL_SETTINGS:
+def warn_about_unused_app_settings(settings: _AppSettings) -> None:
+    for key in UNUSED_APP_SETTINGS:
         if settings.has(key):
             print(
                 f'GitSavvy: The "{key}" setting is no longer used. '
@@ -139,8 +139,7 @@ def warn_about_unused_global_settings(settings: sublime.Settings) -> None:
 
 
 def reload_codecs() -> None:
-    savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
-    fallback_encoding = savvy_settings.get("fallback_encoding")
+    fallback_encoding = app_settings.get("fallback_encoding")
     try:
         import imp, codecs, encodings
         imp.reload(encodings)

--- a/github/commands/add_fork_as_remote.py
+++ b/github/commands/add_fork_as_remote.py
@@ -40,7 +40,7 @@ class gs_github_add_fork_as_remote(git_mixins.GithubRemotesMixin, GsWindowComman
         show_paginated_panel(
             forks_,
             self.on_select_fork,
-            limit=self.savvy_settings.get("github_per_page_max", 100),
+            limit=self.app_settings.get("github_per_page_max", 100),
             format_item=lambda fork: (fork["full_name"], fork),
             status_message="Getting forks...")
 

--- a/github/commands/commit.py
+++ b/github/commands/commit.py
@@ -68,7 +68,7 @@ class gs_github_show_issues(git_mixins.GithubRemotesMixin, GsTextCommand):
             issues,
             self.on_done,
             format_item=self.format_item,
-            limit=self.savvy_settings.get("github_per_page_max", 100),
+            limit=self.app_settings.get("github_per_page_max", 100),
             status_message="Getting issues..."
         )
         if pp.is_empty():
@@ -113,7 +113,7 @@ class gs_github_show_contributors(git_mixins.GithubRemotesMixin, GsTextCommand):
             contributors,
             self.on_done,
             format_item=self.format_item,
-            limit=self.savvy_settings.get("github_per_page_max", 100),
+            limit=self.app_settings.get("github_per_page_max", 100),
             status_message="Getting contributors..."
         )
         if pp.is_empty():

--- a/github/commands/create_fork.py
+++ b/github/commands/create_fork.py
@@ -23,7 +23,7 @@ class gs_github_create_fork(GsWindowCommand, git_mixins.GithubRemotesMixin):
         base_remote = github.parse_remote(base_remote_url)
 
         if default_branch_only is None:
-            default_branch_only = self.savvy_settings.get("sparse_fork", True)
+            default_branch_only = self.app_settings.get("sparse_fork", True)
         self.window.status_message(START_CREATE_MESSAGE.format(repo=base_remote.url))
         result = github.create_fork(base_remote, default_branch_only=default_branch_only)
         util.debug.add_to_log({"github: fork result": result})

--- a/github/commands/create_repo.py
+++ b/github/commands/create_repo.py
@@ -32,7 +32,7 @@ def ask_for_repo_name(cmd: GsCommand, args: Args, done: Kont) -> None:
 
 def get_github_user_token(cmd: GsCommand, args: Args, done: Kont) -> None:
     fqdn = "github.com"
-    token = cmd.savvy_settings.get("api_tokens", {}).get(fqdn) or os.environ.get("GITHUB_TOKEN")
+    token = cmd.app_settings.get("api_tokens", {}).get(fqdn) or os.environ.get("GITHUB_TOKEN")
     if not token:
         cmd.window.status_message(
             f"Abort, no API token found in settings for {fqdn} or env var GITHUB_TOKEN."

--- a/github/commands/pull_request.py
+++ b/github/commands/pull_request.py
@@ -56,7 +56,7 @@ class gs_github_pull_request(GsWindowCommand, git_mixins.GithubRemotesMixin):
         pp = show_paginated_panel(
             self.pull_requests,
             self.on_select_pr,
-            limit=self.savvy_settings.get("github_per_page_max", 100),
+            limit=self.app_settings.get("github_per_page_max", 100),
             format_item=self.format_item,
             status_message="Getting pull requests..."
         )

--- a/github/github.py
+++ b/github/github.py
@@ -12,7 +12,7 @@ from webbrowser import open as open_in_browser
 
 from ..common import interwebs
 from ..core.exceptions import FailedGithubRequest
-from ..core.settings import GitSavvySettings
+from ..core.settings import app_settings
 from ..core.utils import STARTUPINFO
 
 
@@ -76,7 +76,7 @@ def parse_remote(remote_url: str) -> GitHubRepo:
         raise ValueError("Invalid github url: {}".format(url))
 
     fqdn, owner, repo = match.groups()
-    token = GitSavvySettings().get("api_tokens", {}).get(fqdn) or os.environ.get("GITHUB_TOKEN")
+    token = app_settings.get("api_tokens", {}).get(fqdn) or os.environ.get("GITHUB_TOKEN")
     return GitHubRepo(url, fqdn, owner, repo, token)
 
 

--- a/gitlab/commands/merge_request.py
+++ b/gitlab/commands/merge_request.py
@@ -38,7 +38,7 @@ class gs_gitlab_merge_request(GsWindowCommand, git_mixins.GitLabRemotesMixin):
         pp = show_paginated_panel(
             self.merge_requests,
             self.on_select_mr,
-            limit=self.savvy_settings.get("gitlab_per_page_max", 100),
+            limit=self.app_settings.get("gitlab_per_page_max", 100),
             format_item=self.format_item,
             status_message="Getting merge requests..."
         )

--- a/gitlab/gitlab.py
+++ b/gitlab/gitlab.py
@@ -10,7 +10,7 @@ from webbrowser import open as open_in_browser
 
 from ..common import interwebs, util
 from ..core.exceptions import FailedGitLabRequest
-from ..core.settings import GitSavvySettings
+from ..core.settings import app_settings
 
 
 GITLAB_PER_PAGE_MAX = 100
@@ -73,7 +73,7 @@ def parse_remote(remote):
         return None
 
     fqdn, owner, repo = match.groups()
-    token = GitSavvySettings().get("api_tokens", {}).get(fqdn) or os.environ.get("GITLAB_TOKEN")
+    token = app_settings.get("api_tokens", {}).get(fqdn) or os.environ.get("GITLAB_TOKEN")
     return GitLabRepo(url, fqdn, owner, repo, token)
 
 

--- a/tests/test_app_state.py
+++ b/tests/test_app_state.py
@@ -146,7 +146,7 @@ class TestAppState(DeferrableTestCase):
         self.assertIs(app_state.get(ui.HIDE_HELP_MENU_KEY), True)
 
 
-class TestUnusedGlobalSettingsWarning(DeferrableTestCase):
+class TestUnusedAppSettingsWarning(DeferrableTestCase):
     def tearDown(self):
         unstub()
 
@@ -158,7 +158,7 @@ class TestUnusedGlobalSettingsWarning(DeferrableTestCase):
         })
         when(builtins).print(...)
 
-        git_savvy.warn_about_unused_global_settings(settings)
+        git_savvy.warn_about_unused_app_settings(settings)
 
         verify(builtins).print(
             'GitSavvy: The "hide_help_menu" setting is no longer used. '

--- a/tests/test_git_mixins.py
+++ b/tests/test_git_mixins.py
@@ -495,12 +495,16 @@ class WorktreeCreationTestRepo(WorktreesMixin):
         copy_project=True
     ):
         self._repo_path = repo_path
-        self._savvy_settings = {
+        self._app_settings = {
             "copy_active_project_file_to_new_worktrees": copy_project
         }
         self.window = WorktreeCreationTestWindow(project_file, project_data)
         self.tracked = tracked
         self.checked_out_project = checked_out_project
+
+    @property
+    def app_settings(self):
+        return self._app_settings
 
     @property
     def repo_path(self):

--- a/tests/test_graph_view.py
+++ b/tests/test_graph_view.py
@@ -15,7 +15,7 @@ from GitSavvy.core.commands.log_graph import (
 from GitSavvy.core.commands.log_graph_renderer import gs_log_graph_refresh
 from GitSavvy.core.commands.show_commit_info import gs_show_commit_info
 from GitSavvy.core.git_mixins.status import WorkingDirState
-from GitSavvy.core.settings import GitSavvySettings
+from GitSavvy.core.settings import app_settings
 
 
 RUNNING_ON_LINUX = os.environ.get('RUNNER_OS') == 'Linux'
@@ -142,11 +142,10 @@ class TestGraphViewInteractionWithCommitInfoPanel(DeferrableTestCase):
         view.set_scratch(True)
         view.close()
 
-    def set_global_setting(self, key, value):
-        settings = GitSavvySettings()
-        original_value = settings.get(key)
-        settings.set(key, value)
-        self.addCleanup(settings.set, key, original_value)
+    def set_app_setting(self, key, value):
+        original_value = app_settings.get(key)
+        app_settings.set(key, value)
+        self.addCleanup(app_settings.set, key, original_value)
 
     def set_app_state(self, key, value, default):
         original_value = app_state.get(key, default)
@@ -183,7 +182,7 @@ class TestGraphViewInteractionWithCommitInfoPanel(DeferrableTestCase):
             show_commit_info_setting,
             default=True
         )
-        self.set_global_setting('git_status_in_status_bar', False)
+        self.set_app_setting('git_status_in_status_bar', False)
         self.register_commit_info({
             'fec0aca': COMMIT_1,
             'f461ea1': COMMIT_2

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,7 +1,13 @@
 from unittesting import DeferrableTestCase
 
 from GitSavvy.core import settings
-from GitSavvy.core.settings import color_value, read_default_settings
+from GitSavvy.core.settings import (
+    ProjectFileChanges,
+    ProjectSettings,
+    app_settings,
+    color_value,
+    read_default_settings,
+)
 from GitSavvy.tests.mockito import unstub, when
 
 
@@ -15,9 +21,43 @@ class TestReadDefaultSettings(DeferrableTestCase):
         )
 
 
+class TestProjectSettings(DeferrableTestCase):
+    def tearDown(self) -> None:
+        unstub()
+
+    def test_returns_one_instance_per_window(self) -> None:
+        window = Window({})
+
+        self.assertIs(ProjectSettings(window), ProjectSettings(window))
+        self.assertIsNot(ProjectSettings(window), ProjectSettings(Window({})))
+
+    def test_prefers_project_value(self) -> None:
+        window = Window({"settings": {"GitSavvy": {"git_path": "project-git"}}})
+
+        self.assertEqual(ProjectSettings(window).get("git_path"), "project-git")
+
+    def test_falls_back_to_app_value(self) -> None:
+        window = Window({})
+        when(app_settings).get("git_path", None).thenReturn("app-git")
+
+        self.assertEqual(ProjectSettings(window).get("git_path"), "app-git")
+
+    def test_forgets_instance_after_window_closes(self) -> None:
+        window = Window({})
+        project_settings = ProjectSettings(window)
+        queued = []
+        when(settings.sublime).set_timeout(...).thenAnswer(queued.append)
+
+        ProjectFileChanges().on_pre_close_window(window)
+
+        self.assertIs(ProjectSettings(window), project_settings)
+        queued.pop()()
+        self.assertIsNot(ProjectSettings(window), project_settings)
+
+
 class TestColorValue(DeferrableTestCase):
     def setUp(self) -> None:
-        app_settings = {
+        app_colors = {
             "log_graph": {
                 "commit_dot_background": "#eee",
                 "commit_dot_foreground": "",
@@ -31,7 +71,7 @@ class TestColorValue(DeferrableTestCase):
             }
         }
 
-        when(settings).get_global_settings().thenReturn({"colors": app_settings})
+        when(app_settings).get("colors", {}).thenReturn(app_colors)
         when(settings).read_default_settings().thenReturn({"colors": default_settings})
 
     def tearDown(self) -> None:
@@ -54,3 +94,18 @@ class TestColorValue(DeferrableTestCase):
             color_value("log_graph", "commit_dot_foreground"),
             ""
         )
+
+
+class Window:
+    next_id = 1
+
+    def __init__(self, project_data: dict) -> None:
+        self._project_data = project_data
+        self._id = self.next_id
+        Window.next_id += 1
+
+    def id(self) -> int:
+        return self._id
+
+    def project_data(self) -> dict:
+        return self._project_data

--- a/tests/test_theme_generator.py
+++ b/tests/test_theme_generator.py
@@ -27,10 +27,10 @@ class TestThemeGenerator(DeferrableTestCase):
             "color_scheme": "Packages/Example/Example.sublime-color-scheme"
         })
         syntax_settings = WatchableSettings({})
-        savvy_settings = WatchableSettings({"colors": {}})
+        app_settings = WatchableSettings({"colors": {}})
         settings = {
             "Preferences.sublime-settings": preferences,
-            "GitSavvy.sublime-settings": savvy_settings,
+            "GitSavvy.sublime-settings": app_settings,
             "graph.sublime-settings": syntax_settings,
         }
         queued = []


### PR DESCRIPTION
We need to be honest here, we read a lot of the settings through the project/view settings.  But (a) that didn't make sense, (b) it required a Window which we didn't pass around everywhere (so we just used `active_window()` which is only good enough until it breaks).

Split settings like a Sublime Texter into global app settings and project settings.  For this our shipped settings, the file contents have been reordered.

A refactoring for better sleep.